### PR TITLE
fix for permissions problem for runas ~op

### DIFF
--- a/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
@@ -63,7 +63,7 @@ public class Meta {
                             new InvocationHandler() {
 
                                 public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                                    if (method.getName().equals("isOp")) {
+                                    if (method.getName().equals("isOp") || method.getName().equals("isPermissionSet") || method.getName().equals("hasPermission")) {
                                         return true;
                                     } else {
                                         return method.invoke(p, args);


### PR DESCRIPTION
Fixes problem with running several commands that require some permission.

mvn test passed

packaged it and is running it on my own server

runas can now use /permissions from permissionsbukkit, and /reload from essentials
