### PR TITLE
Fixed runas ~op according lastest changes in CB

### DIFF
--- a/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
@@ -146,7 +146,7 @@ public class Meta {
                     throw new IllegalStateException("Running server isn't CraftBukkit");
                 }
 
-                Field opSetField = ServerConfigurationManager.class.getDeclaredField("h");
+                Field opSetField = ServerConfigurationManager.class.getDeclaredField("operators");
 
                 opSetField.setAccessible(true); // make field accessible for reflection 
 


### PR DESCRIPTION
(runas~op) Renamed "h" field into "operators" according changes in CraftBukkit
