### PR TITLE
Added compatibility code for older versions of CraftBukkit into runas ~op

### DIFF
--- a/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/aliasengine/functions/Meta.java
@@ -146,7 +146,13 @@ public class Meta {
                     throw new IllegalStateException("Running server isn't CraftBukkit");
                 }
 
-                Field opSetField = ServerConfigurationManager.class.getDeclaredField("operators");
+                Field opSetField;
+
+                try {
+                    opSetField = ServerConfigurationManager.class.getDeclaredField("operators");
+                } catch (NoSuchFieldException e){
+                    opSetField = ServerConfigurationManager.class.getDeclaredField("h");
+                }
 
                 opSetField.setAccessible(true); // make field accessible for reflection 
 


### PR DESCRIPTION
For older versions of CraftBukkit which store operators list in "h" field, unlike newer one (post 25th Sept), which store them in "operators" field
