### PR TITLE
Lots of vehicle/riding related things, and some things that go boom

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -236,6 +236,10 @@ public class BukkitConvertor extends AbstractConvertor {
 			return new BukkitMCSheep((Sheep) be);
 		}
 		
+		if (be instanceof Pig) {
+			return new BukkitMCPig((Pig) be);
+		}
+		
     	if(be instanceof Ageable){
     		return new BukkitMCAgeable(be);
     	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPig.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPig.java
@@ -1,0 +1,26 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import org.bukkit.entity.Pig;
+
+import com.laytonsmith.abstraction.entities.MCPig;
+
+/**
+ * 
+ * @author jb_aero
+ */
+public class BukkitMCPig extends BukkitMCAgeable implements MCPig {
+
+	Pig p;
+	public BukkitMCPig(Pig be) {
+		super(be);
+		p = be;
+	}
+
+	public boolean isSaddled() {
+		return p.hasSaddle();
+	}
+
+	public void setSaddled(boolean saddled) {
+		p.setSaddle(saddled);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitEntityEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitEntityEvents.java
@@ -2,6 +2,7 @@
 package com.laytonsmith.abstraction.bukkit.events;
 
 import com.laytonsmith.abstraction.*;
+import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
 import com.laytonsmith.abstraction.bukkit.BukkitMCEntity;
 import com.laytonsmith.abstraction.bukkit.BukkitMCItem;
@@ -10,6 +11,7 @@ import com.laytonsmith.abstraction.bukkit.BukkitMCLivingEntity;
 import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.BukkitMCPlayer;
 import com.laytonsmith.abstraction.bukkit.BukkitMCProjectile;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
 import com.laytonsmith.abstraction.enums.MCDamageCause;
 import com.laytonsmith.abstraction.enums.MCEntityType;
 import com.laytonsmith.abstraction.enums.MCMobs;
@@ -23,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -30,6 +33,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
@@ -45,6 +49,52 @@ import org.bukkit.inventory.ItemStack;
  */
 public class BukkitEntityEvents {
 	
+	public static class BukkitMCEntityExplodeEvent implements MCEntityExplodeEvent {
+
+		EntityExplodeEvent e;
+		public BukkitMCEntityExplodeEvent(EntityExplodeEvent event) {
+			e = event;
+		}
+		
+		public Object _GetObject() {
+			return e;
+		}
+
+		public MCEntity getEntity() {
+			if (e.getEntity() != null) {
+				return BukkitConvertor.BukkitGetCorrectEntity(e.getEntity());
+			}
+			return null;
+		}
+
+		public List<MCBlock> getBlocks() {
+			List<MCBlock> ret = new ArrayList<MCBlock>();
+			for (Block b : e.blockList()) {
+				ret.add(new BukkitMCBlock(b));
+			}
+			return ret;
+		}
+		
+		public void setBlocks(List<MCBlock> blocks) {
+			e.blockList().clear();
+			for (MCBlock b : blocks) {
+				e.blockList().add(((BukkitMCBlock) b).__Block());
+			}
+		}
+
+		public MCLocation getLocation() {
+			return new BukkitMCLocation(e.getLocation());
+		}
+
+		public float getYield() {
+			return e.getYield();
+		}
+
+		public void setYield(float power) {
+			e.setYield(power);
+		}
+	}
+
 	@abstraction(type = Implementation.Type.BUKKIT)
 	public static class BukkitMCProjectileHitEvent implements MCProjectileHitEvent {
 		

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
@@ -1,0 +1,142 @@
+package com.laytonsmith.abstraction.bukkit.events;
+
+import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
+import org.bukkit.event.vehicle.VehicleCollisionEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
+import org.bukkit.event.vehicle.VehicleEvent;
+import org.bukkit.event.vehicle.VehicleExitEvent;
+
+import com.laytonsmith.abstraction.Implementation;
+import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCVehicle;
+import com.laytonsmith.abstraction.blocks.MCBlock;
+import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
+import com.laytonsmith.abstraction.enums.MCCollisionType;
+import com.laytonsmith.abstraction.events.MCVehicleBlockCollideEvent;
+import com.laytonsmith.abstraction.events.MCVehicleEnitityCollideEvent;
+import com.laytonsmith.abstraction.events.MCVehicleEnterExitEvent;
+import com.laytonsmith.abstraction.events.MCVehicleEvent;
+import com.laytonsmith.annotations.abstraction;
+
+/**
+ * 
+ * @author jb_aero
+ */
+public class BukkitVehicleEvents {
+	
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCVehicleEntityCollideEvent extends BukkitMCVehicleEvent
+			implements MCVehicleEnitityCollideEvent {
+
+		VehicleEntityCollisionEvent vec;
+		public BukkitMCVehicleEntityCollideEvent(VehicleCollisionEvent event) {
+			super(event);
+			vec = (VehicleEntityCollisionEvent) event;
+		}
+		
+		public MCEntity getEntity() {
+			if (vec.getEntity() == null) {
+				return null;
+			}
+			return BukkitConvertor.BukkitGetCorrectEntity(vec.getEntity());
+		}
+
+		public boolean isCollisionCancelled() {
+			return vec.isCollisionCancelled();
+		}
+
+		public boolean isPickupCancelled() {
+			return vec.isPickupCancelled();
+		}
+
+		public void setCollisionCancelled(boolean cancel) {
+			vec.setCollisionCancelled(cancel);
+		}
+
+		public void setPickupCancelled(boolean cancel) {
+			vec.setPickupCancelled(cancel);
+		}
+
+		@Override
+		public MCCollisionType getCollisionType() {
+			return MCCollisionType.ENTITY;
+		}
+	}
+	
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCVehicleBlockCollideEvent extends BukkitMCVehicleEvent
+			implements MCVehicleBlockCollideEvent {
+
+		VehicleBlockCollisionEvent vbc;
+		public BukkitMCVehicleBlockCollideEvent(VehicleCollisionEvent event) {
+			super(event);
+			vbc = (VehicleBlockCollisionEvent) event;
+		}
+		
+		public MCBlock getBlock() {
+			return new BukkitMCBlock(vbc.getBlock());
+		}
+
+		@Override
+		public MCCollisionType getCollisionType() {
+			return MCCollisionType.BLOCK;
+		}
+	}
+	
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCVehicleEnterEvent extends BukkitMCVehicleEvent
+			implements MCVehicleEnterExitEvent {
+
+		VehicleEnterEvent vee;
+		public BukkitMCVehicleEnterEvent(VehicleEnterEvent event) {
+			super(event);
+			vee = event;
+		}
+		
+		public MCEntity getEntity() {
+			if (vee.getEntered() == null) {
+				return null;
+			}
+			return BukkitConvertor.BukkitGetCorrectEntity(vee.getEntered());
+		}
+	}
+	
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCVehicleExitEvent extends BukkitMCVehicleEvent
+			implements MCVehicleEnterExitEvent {
+
+		VehicleExitEvent vee;
+		public BukkitMCVehicleExitEvent(VehicleExitEvent event) {
+			super(event);
+			vee = event;
+		}
+		
+		public MCEntity getEntity() {
+			if (vee.getExited() == null) {
+				return null;
+			}
+			return BukkitConvertor.BukkitGetCorrectEntity(vee.getExited());
+		}
+	}
+	
+	public static class BukkitMCVehicleEvent implements MCVehicleEvent {
+
+		VehicleEvent ve;
+		public BukkitMCVehicleEvent(VehicleEvent event) {
+			ve = event;
+		}
+		
+		public MCVehicle getVehicle() {
+			if (ve.getVehicle() instanceof org.bukkit.entity.Vehicle) {
+				return (MCVehicle) BukkitConvertor.BukkitGetCorrectEntity(ve.getVehicle());
+			}
+			return null;
+		}
+
+		public Object _GetObject() {
+			return ve;
+		}
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitEntityListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitEntityListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -108,5 +109,12 @@ public class BukkitEntityListener implements Listener{
 		BukkitEntityEvents.BukkitMCEntityEnterPortalEvent pe = new BukkitEntityEvents.BukkitMCEntityEnterPortalEvent(event);
 		EventUtils.TriggerExternal(pe);
 		EventUtils.TriggerListener(Driver.ENTITY_ENTER_PORTAL, "entity_enter_portal", pe);
+	}
+	
+	@EventHandler(priority= EventPriority.LOWEST)
+	public void onExplode(EntityExplodeEvent event) {
+		BukkitEntityEvents.BukkitMCEntityExplodeEvent ee = new BukkitEntityEvents.BukkitMCEntityExplodeEvent(event);
+		EventUtils.TriggerExternal(ee);
+		EventUtils.TriggerListener(Driver.ENTITY_EXPLODE, "entity_explode", ee);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitVehicleListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitVehicleListener.java
@@ -2,7 +2,21 @@
 
 package com.laytonsmith.abstraction.bukkit.events.drivers;
 
+import org.bukkit.entity.Pig;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
+import org.bukkit.event.vehicle.VehicleExitEvent;
+
+import com.laytonsmith.abstraction.bukkit.events.BukkitVehicleEvents.BukkitMCVehicleBlockCollideEvent;
+import com.laytonsmith.abstraction.bukkit.events.BukkitVehicleEvents.BukkitMCVehicleEnterEvent;
+import com.laytonsmith.abstraction.bukkit.events.BukkitVehicleEvents.BukkitMCVehicleEntityCollideEvent;
+import com.laytonsmith.abstraction.bukkit.events.BukkitVehicleEvents.BukkitMCVehicleExitEvent;
+import com.laytonsmith.core.events.Driver;
+import com.laytonsmith.core.events.EventUtils;
 
 /**
  *
@@ -10,4 +24,36 @@ import org.bukkit.event.Listener;
  */
 public class BukkitVehicleListener implements Listener{
     
+	@EventHandler(priority= EventPriority.LOWEST)
+	public void onEnter(VehicleEnterEvent event) {
+		BukkitMCVehicleEnterEvent vee = new BukkitMCVehicleEnterEvent(event);
+		EventUtils.TriggerExternal(vee);
+		EventUtils.TriggerListener(Driver.VEHICLE_ENTER, "vehicle_enter", vee);
+	}
+	
+	//@EventHandler(priority= EventPriority.LOWEST)
+	public void onExit(VehicleExitEvent event) {
+		BukkitMCVehicleExitEvent vee = new BukkitMCVehicleExitEvent(event);
+		EventUtils.TriggerExternal(vee);
+		EventUtils.TriggerListener(Driver.VEHICLE_LEAVE, "vehicle_leave", vee);
+	}
+	
+	@EventHandler(priority= EventPriority.LOWEST)
+	public void onBlockCollide(VehicleBlockCollisionEvent event) {
+		if (event.getVehicle() instanceof Pig && !((Pig) event.getVehicle()).hasSaddle()) {
+			return;
+		}
+		BukkitMCVehicleBlockCollideEvent vbc = new BukkitMCVehicleBlockCollideEvent(event);
+		EventUtils.TriggerExternal(vbc);
+		EventUtils.TriggerListener(Driver.VEHICLE_COLLIDE, "vehicle_collide", vbc);
+	}
+
+	@EventHandler(priority= EventPriority.LOWEST)
+	public void onEntityCollide(VehicleEntityCollisionEvent event) {
+		if (event.getVehicle().getPassenger() != event.getEntity()) {
+			BukkitMCVehicleEntityCollideEvent vec = new BukkitMCVehicleEntityCollideEvent(event);
+			EventUtils.TriggerExternal(vec);
+			EventUtils.TriggerListener(Driver.VEHICLE_COLLIDE, "vehicle_collide", vec);
+		}
+	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCPig.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCPig.java
@@ -1,0 +1,9 @@
+package com.laytonsmith.abstraction.entities;
+
+import com.laytonsmith.abstraction.MCAgeable;
+import com.laytonsmith.abstraction.MCVehicle;
+
+public interface MCPig extends MCAgeable, MCVehicle {
+	public boolean isSaddled();
+	public void setSaddled(boolean saddled);
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCCollisionType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCCollisionType.java
@@ -1,0 +1,6 @@
+package com.laytonsmith.abstraction.enums;
+
+public enum MCCollisionType {
+	BLOCK,
+	ENTITY
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCEntityExplodeEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCEntityExplodeEvent.java
@@ -1,0 +1,23 @@
+package com.laytonsmith.abstraction.events;
+
+import java.util.List;
+
+import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCLocation;
+import com.laytonsmith.abstraction.blocks.MCBlock;
+import com.laytonsmith.core.events.BindableEvent;
+
+public interface MCEntityExplodeEvent extends BindableEvent {
+
+	public MCEntity getEntity();
+	
+	public List<MCBlock> getBlocks();
+	
+	public void setBlocks(List<MCBlock> blocks);
+	
+	public MCLocation getLocation();
+	
+	public float getYield();
+	
+	public void setYield(float power);
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleBlockCollideEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleBlockCollideEvent.java
@@ -1,0 +1,7 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.blocks.MCBlock;
+
+public interface MCVehicleBlockCollideEvent extends MCVehicleCollideEvent {
+	public MCBlock getBlock();
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleCollideEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleCollideEvent.java
@@ -1,0 +1,7 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.enums.MCCollisionType;
+
+public interface MCVehicleCollideEvent extends MCVehicleEvent {
+	public MCCollisionType getCollisionType();
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEnitityCollideEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEnitityCollideEvent.java
@@ -1,0 +1,11 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCEntity;
+
+public interface MCVehicleEnitityCollideEvent extends MCVehicleCollideEvent {
+	public MCEntity getEntity();
+	public boolean isCollisionCancelled();
+	public boolean isPickupCancelled();
+	public void setCollisionCancelled(boolean cancel);
+	public void setPickupCancelled(boolean cancel);
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEnterExitEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEnterExitEvent.java
@@ -1,0 +1,7 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCEntity;
+
+public interface MCVehicleEnterExitEvent extends MCVehicleEvent {
+	public MCEntity getEntity();
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEvent.java
@@ -1,0 +1,8 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCVehicle;
+import com.laytonsmith.core.events.BindableEvent;
+
+public interface MCVehicleEvent extends BindableEvent {
+	public MCVehicle getVehicle();
+}

--- a/src/main/java/com/laytonsmith/core/events/Driver.java
+++ b/src/main/java/com/laytonsmith/core/events/Driver.java
@@ -30,6 +30,7 @@ public enum Driver {
     ENTITY_DAMAGE_PLAYER, 
 	ENTITY_DAMAGE,
 	ENTITY_DEATH,
+	ENTITY_EXPLODE,
 	CREATURE_SPAWN,
 	PLAYER_MOVE,  
 	ITEM_PICKUP,
@@ -44,6 +45,9 @@ public enum Driver {
 	SERVER_PING,
 	ENTITY_ENTER_PORTAL,
 	PLUGIN_MESSAGE_RECEIVED,
+	VEHICLE_ENTER,
+	VEHICLE_LEAVE,
+	VEHICLE_COLLIDE,
 	/**
 	 * Used by events fired from the extension system.
 	 */

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -88,8 +88,16 @@ public class InventoryEvents {
 				map.put("rawslot", new CInt(e.getRawSlot(), Target.UNKNOWN));
 				map.put("slottype", new CString(e.getSlotType().name(), Target.UNKNOWN));
 				map.put("slotitem", ObjectGenerator.GetGenerator().item(e.getCurrentItem(), Target.UNKNOWN));
-				map.put("inventorytype", new CString(e.getInventory().getType().name(), Target.UNKNOWN));
-				map.put("inventorysize", new CInt(e.getInventory().getSize(), Target.UNKNOWN));
+				
+				CArray items = CArray.GetAssociativeArray(Target.UNKNOWN);
+				MCInventory inv = e.getInventory();
+				for (int i = 0; i < inv.getSize(); i++) {
+					Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), Target.UNKNOWN);
+					items.set(i, c, Target.UNKNOWN);
+				}
+				map.put("inventory", items);
+				map.put("inventorytype", new CString(inv.getType().name(), Target.UNKNOWN));
+				map.put("inventorysize", new CInt(inv.getSize(), Target.UNKNOWN));
 
 				return map;
 			} else {

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -1659,7 +1659,7 @@ public class PlayerEvents {
 		}
 	
 		public String docs() {
-			return "{state: <macro> Can be one of" + StringUtils.Join(MCFishingState.values(), ", ", ", or ")
+			return "{state: <macro> Can be one of " + StringUtils.Join(MCFishingState.values(), ", ", ", or ")
 					+ " | player: <macro> The player who is fishing}"
 					+ " Fires when a player casts or reels a fishing rod {player | state | chance | xp"
 					+ " | hook: the fishhook entity | caught: the id of the snared entity, can be a fish item}"

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -1,0 +1,263 @@
+package com.laytonsmith.core.events.drivers;
+
+import java.util.Map;
+
+import com.laytonsmith.PureUtilities.StringUtils;
+import com.laytonsmith.PureUtilities.Version;
+import com.laytonsmith.abstraction.enums.MCCollisionType;
+import com.laytonsmith.abstraction.events.MCVehicleBlockCollideEvent;
+import com.laytonsmith.abstraction.events.MCVehicleCollideEvent;
+import com.laytonsmith.abstraction.events.MCVehicleEnitityCollideEvent;
+import com.laytonsmith.abstraction.events.MCVehicleEnterExitEvent;
+import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.CHVersion;
+import com.laytonsmith.core.ObjectGenerator;
+import com.laytonsmith.core.Static;
+import com.laytonsmith.core.constructs.CArray;
+import com.laytonsmith.core.constructs.CBoolean;
+import com.laytonsmith.core.constructs.CInt;
+import com.laytonsmith.core.constructs.CNull;
+import com.laytonsmith.core.constructs.CString;
+import com.laytonsmith.core.constructs.Construct;
+import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.events.AbstractEvent;
+import com.laytonsmith.core.events.BindableEvent;
+import com.laytonsmith.core.events.Driver;
+import com.laytonsmith.core.events.Prefilters;
+import com.laytonsmith.core.events.Prefilters.PrefilterType;
+import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.core.exceptions.EventException;
+import com.laytonsmith.core.exceptions.PrefilterNonMatchException;
+
+/**
+ * 
+ * @author jb_aero
+ */
+public class VehicleEvents {
+
+	@api
+	public static class vehicle_enter extends AbstractEvent {
+
+		public String getName() {
+			return "vehicle_enter";
+		}
+
+		public String docs() {
+			return "{vehicletype: <macro> the entitytype of the vehicle | passengertype: <macro>"
+					+ " the enitytype of the passenger} Fires when an entity enters a vehicle."
+					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID}"
+					+ " {}"
+					+ " {}";
+		}
+
+		public boolean matches(Map<String, Construct> prefilter, BindableEvent event) throws PrefilterNonMatchException {
+			if (event instanceof MCVehicleEnterExitEvent) {
+				MCVehicleEnterExitEvent e = (MCVehicleEnterExitEvent) event;
+				Prefilters.match(prefilter, "vehicletype", e.getVehicle().getType().name(), PrefilterType.MACRO);
+				Prefilters.match(prefilter, "passengertype", e.getEntity().getType().name(), PrefilterType.MACRO);
+				return true;
+			}
+			return false;
+		}
+
+		public BindableEvent convert(CArray manualObject) {
+			throw new ConfigRuntimeException("Unsupported Operation", Target.UNKNOWN);
+		}
+
+		public Map<String, Construct> evaluate(BindableEvent event) throws EventException {
+			if (event instanceof MCVehicleEnterExitEvent) {
+				MCVehicleEnterExitEvent e = (MCVehicleEnterExitEvent) event;
+				Target t = Target.UNKNOWN;
+				Map<String, Construct> ret = evaluate_helper(e);
+				ret.put("vehicletype", new CString(e.getVehicle().getType().name(), t));
+				ret.put("passengertype", new CString(e.getEntity().getType().name(), t));
+				ret.put("vehicle", new CInt(e.getVehicle().getEntityId(), t));
+				ret.put("passenger", new CInt(e.getEntity().getEntityId(), t));
+				return ret;
+			} else {
+				throw new EventException("Could not convert to MCVehicleEnterExitEvent");
+			}
+		}
+
+		public Driver driver() {
+			return Driver.VEHICLE_ENTER;
+		}
+
+		public boolean modifyEvent(String key, Construct value, BindableEvent event) {
+			return false;
+		}
+
+		public Version since() {
+			return CHVersion.V3_3_1;
+		}
+	}
+	
+	//@api
+	public static class vehicle_leave extends AbstractEvent {
+
+		public String getName() {
+			return "vehicle_leave";
+		}
+
+		public String docs() {
+			return "{vehicletype: <macro> the entitytype of the vehicle | passengertype: <macro>"
+					+ " the enitytype of the passenger} Fires when an entity leaves a vehicle."
+					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID}"
+					+ " {}"
+					+ " {}";
+		}
+
+		public boolean matches(Map<String, Construct> prefilter, BindableEvent event) throws PrefilterNonMatchException {
+			if (event instanceof MCVehicleEnterExitEvent) {
+				MCVehicleEnterExitEvent e = (MCVehicleEnterExitEvent) event;
+				Prefilters.match(prefilter, "vehicletype", e.getVehicle().getType().name(), PrefilterType.MACRO);
+				Prefilters.match(prefilter, "passengertype", e.getEntity().getType().name(), PrefilterType.MACRO);
+				return true;
+			}
+			return false;
+		}
+
+		public BindableEvent convert(CArray manualObject) {
+			throw new ConfigRuntimeException("Unsupported Operation", Target.UNKNOWN);
+		}
+
+		public Map<String, Construct> evaluate(BindableEvent event) throws EventException {
+			if (event instanceof MCVehicleEnterExitEvent) {
+				MCVehicleEnterExitEvent e = (MCVehicleEnterExitEvent) event;
+				Target t = Target.UNKNOWN;
+				Map<String, Construct> ret = evaluate_helper(e);
+				ret.put("vehicletype", new CString(e.getVehicle().getType().name(), t));
+				ret.put("passengertype", new CString(e.getEntity().getType().name(), t));
+				ret.put("vehicle", new CInt(e.getVehicle().getEntityId(), t));
+				ret.put("passenger", new CInt(e.getEntity().getEntityId(), t));
+				return ret;
+			} else {
+				throw new EventException("Could not convert to MCVehicleEnterExitEvent");
+			}
+		}
+
+		public Driver driver() {
+			return Driver.VEHICLE_LEAVE;
+		}
+
+		public boolean modifyEvent(String key, Construct value, BindableEvent event) {
+			return false;
+		}
+
+		public Version since() {
+			return CHVersion.V3_3_1;
+		}
+	}
+	
+	@api
+	public static class vehicle_collide extends AbstractEvent {
+
+		public String getName() {
+			return "vehicle_collide";
+		}
+
+		public String docs() {
+			return "{type: <macro> The entitytype of the vehicle | collisiontype: <macro> One of "
+					+ StringUtils.Join(MCCollisionType.values(), ", ", ", or ", " or ")
+					+ " | hittype: <macro> Matches an entitytype in an enitity collision"
+					+ " | hittype: <item match> Matches a block in a block collision}"
+					+ " Fires when a vehicle runs into something. If it ran into a block,"
+					+ " event data will contain block info. If it ran into an entity,"
+					+ " event data will contain info and options relevant to hitting an entity."
+					+ " {type | id: The entityID of the vehicle | entity: the entityID of the entity that was hit"
+					+ " | block: the location of the block that was hit | collisiontype | collide | pickup}"
+					+ " {collide: whether the vehicle hits the entity or passes through it | pickup: whether or not the"
+					+ " vehicle pick up the entity | both fields can only be modified for entity collisions}"
+					+ " {}";
+		}
+
+		public boolean matches(Map<String, Construct> prefilter, BindableEvent e) throws PrefilterNonMatchException {
+			if (e instanceof MCVehicleCollideEvent) {
+				MCVehicleCollideEvent event = (MCVehicleCollideEvent) e;
+				Prefilters.match(prefilter, "type", event.getVehicle().getType().name(), PrefilterType.MACRO);
+				Prefilters.match(prefilter, "collisiontype", event.getCollisionType().name(), PrefilterType.MACRO);
+				switch (event.getCollisionType()) {
+					case BLOCK:
+						Prefilters.match(prefilter, "hittype", Static.ParseItemNotation(((MCVehicleBlockCollideEvent) event)
+								.getBlock()), PrefilterType.ITEM_MATCH);
+						break;
+					case ENTITY:
+						Prefilters.match(prefilter, "hittype", ((MCVehicleEnitityCollideEvent) event)
+								.getEntity().getType().name(), PrefilterType.MACRO);
+						break;
+						default:
+							throw new ConfigRuntimeException("Greetings from the future! If you are seeing this message,"
+									+ " Minecraft has reached the point where vehicles can hit things that are neither"
+									+ " a block nor an entity.", Target.UNKNOWN);
+				}
+				return true;
+			}
+			return false;
+		}
+
+		public BindableEvent convert(CArray manualObject) {
+			throw new ConfigRuntimeException("Unsupported Operation", Target.UNKNOWN);
+		}
+
+		public Map<String, Construct> evaluate(BindableEvent event) throws EventException {
+			if (event instanceof MCVehicleCollideEvent) {
+				MCVehicleCollideEvent e = (MCVehicleCollideEvent) event;
+				Target t = Target.UNKNOWN;
+				Map<String, Construct> ret = evaluate_helper(e);
+				ret.put("type", new CString(e.getVehicle().getType().name(), t));
+				ret.put("id", new CInt(e.getVehicle().getEntityId(), t));
+				ret.put("collisiontype", new CString(e.getCollisionType().name(), t));
+				Construct block = new CNull(t);
+				Construct entity = new CNull(t);
+				boolean collide = true;
+				boolean pickup = false;
+				switch (e.getCollisionType()) {
+					case BLOCK:
+						block = ObjectGenerator.GetGenerator().location(
+								((MCVehicleBlockCollideEvent) e).getBlock().getLocation());
+						break;
+					case ENTITY:
+						MCVehicleEnitityCollideEvent vec = (MCVehicleEnitityCollideEvent) e;
+						entity = new CInt(vec.getEntity().getEntityId(), t);
+						collide = !vec.isCollisionCancelled();
+						pickup = !vec.isPickupCancelled();
+						break;
+						default:
+							throw new ConfigRuntimeException("Greetings from the future! If you are seeing this message,"
+									+ " Minecraft has reached the point where vehicles can hit things that are neither"
+									+ " a block nor an entity.", t);
+				}
+				ret.put("block", block);
+				ret.put("entity", entity);
+				ret.put("pickup", new CBoolean(pickup, t));
+				ret.put("collide", new CBoolean(collide, t));
+				return ret;
+			} else {
+				throw new EventException("The event could not be converted to MCVehicleCollideEvent.");
+			}
+		}
+
+		public Driver driver() {
+			return Driver.VEHICLE_COLLIDE;
+		}
+
+		public boolean modifyEvent(String key, Construct value, BindableEvent event) {
+			if (event instanceof MCVehicleEnitityCollideEvent) {
+				MCVehicleEnitityCollideEvent e = (MCVehicleEnitityCollideEvent) event;
+				if (key.equals("collide")) {
+					e.setCollisionCancelled(!Static.getBoolean(value));
+					return true;
+				}
+				if (key.equals("pickup")) {
+					e.setPickupCancelled(!Static.getBoolean(value));
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public Version since() {
+			return CHVersion.V3_3_1;
+		}
+	}
+}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -8,8 +8,12 @@ import com.laytonsmith.abstraction.enums.MCEntityType;
 import com.laytonsmith.abstraction.enums.MCEquipmentSlot;
 import com.laytonsmith.abstraction.enums.MCProjectileType;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.CHVersion;
+import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.ObjectGenerator;
+import com.laytonsmith.core.Optimizable;
+import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.*;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
@@ -18,8 +22,10 @@ import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Exceptions.ExceptionType;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -1100,6 +1106,89 @@ public class EntityManagement {
 					+ StringUtils.Join(spawnable, ", ", " or ", ", or ") 
 					+ ". Falling_blocks will be sand by default, and dropped_items will be stone,"
 					+ " as these entities already have their own functions for spawning.";
+		}
+	}
+
+	@api
+	public static class set_entity_rider extends EntitySetterFunction {
+	
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			MCEntity horse, rider;
+			boolean success;
+			if (args[0] instanceof CNull) {
+				horse = null;
+			} else {
+				horse = Static.getEntity(Static.getInt32(args[0], t), t);
+			}
+			if (args[1] instanceof CNull) {
+				rider = null;
+			} else {
+				rider = Static.getEntity(Static.getInt32(args[1], t), t);
+			}
+			if ((horse == null && rider == null) || horse == rider) {
+				throw new Exceptions.FormatException("Horse and rider cannot be the same entity", t);
+			} else if (horse == null) {
+				success = rider.leaveVehicle();
+			} else if (rider == null) {
+				success = horse.eject();
+			} else {
+				success = horse.setPassenger(rider);
+			}
+			return new CBoolean(success, t);
+		}
+	
+		public String getName() {
+			return "set_entity_rider";
+		}
+	
+		public String docs() {
+			return "boolean {horse, rider} Sets the way two entities are stacked. Horse and rider are entity ids."
+					+ " If rider is null, horse will eject its current rider, if it has one. If horse is null,"
+					+ " rider will leave whatever it is riding. If horse and rider are both valid entities,"
+					+ " rider will ride horse. The function returns the success of whatever operation is done."
+					+ " If horse and rider are both null, or otherwise the same, a FormatException is thrown.";
+		}
+	}
+	
+	@api
+	public static class get_entity_rider extends EntityGetterFunction {
+
+		public Construct exec(Target t, Environment environment,
+				Construct... args) throws ConfigRuntimeException {
+			MCEntity ent = Static.getEntity(Static.getInt32(args[0], t), t);
+			if (ent.getPassenger() instanceof MCEntity) {
+				return new CInt(ent.getPassenger().getEntityId(), t);
+			}
+			return null;
+		}
+
+		public String getName() {
+			return "get_entity_rider";
+		}
+
+		public String docs() {
+			return "mixed {entityID} Returns the ID of the given entity's rider, or null if it doesn't have one.";
+		}
+	}
+	
+	@api
+	public static class get_entity_vehicle extends EntityGetterFunction {
+
+		public Construct exec(Target t, Environment environment,
+				Construct... args) throws ConfigRuntimeException {
+			MCEntity ent = Static.getEntity(Static.getInt32(args[0], t), t);
+			if (ent.isInsideVehicle()) {
+				return new CInt(ent.getVehicle().getEntityId(), t);
+			}
+			return new CNull(t);
+		}
+
+		public String getName() {
+			return "get_entity_vehicle";
+		}
+
+		public String docs() {
+			return "mixed {entityID} Returns the ID of the given entity's vehicle, or null if it doesn't have one.";
 		}
 	}
 }

--- a/src/main/java/com/laytonsmith/core/functions/Sandbox.java
+++ b/src/main/java/com/laytonsmith/core/functions/Sandbox.java
@@ -462,46 +462,4 @@ public class Sandbox {
 		}
 		
 	}
-	
-	@api(environments={CommandHelperEnvironment.class})
-	public static class set_entity_rider extends AbstractFunction{
-
-		public ExceptionType[] thrown() {
-			return new ExceptionType[]{ExceptionType.CastException, ExceptionType.BadEntityException};
-		}
-
-		public boolean isRestricted() {
-			return true;
-		}
-
-		public Boolean runAsync() {
-			return false;
-		}
-
-		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
-			MCEntity horse = Static.getEntity(Static.getInt32(args[0], t), t);
-			MCEntity rider = Static.getEntity(Static.getInt32(args[1], t), t);
-			horse.setPassenger(rider);
-			return new CVoid(t);
-		}
-
-		public String getName() {
-			return "set_entity_rider";
-		}
-
-		public Integer[] numArgs() {
-			return new Integer[]{2};
-		}
-
-		public String docs() {
-			return "void {horse, rider} Sets the rider of an entity. horse and rider are entity ids.";
-		}
-
-		public CHVersion since() {
-			return CHVersion.V3_3_1;
-		}
-		
-	}
-
-    
 }

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -547,7 +547,7 @@ public class Scoreboards {
 		}
 
 		public Integer[] numArgs() {
-			return new Integer[]{2};
+			return new Integer[]{2, 3};
 		}
 
 		public String docs() {


### PR DESCRIPTION
Adds 3 new events: entity_explode, vehicle_enter, and vehicle_collide. Vehicle_collide includes filters to prevent it from firing when a vehicle collides with the rider, as this isn't Garry's Mod, so we don't care about that, also to prevent it from firing for unsaddled pigs, as in that state they are no more a vehicle than any other mob. Vehicle_leave is not included because Bukkit doesn't fire it, so it would only cause confusion and silly bug reports.

Adds 3 new functions: get_entity_rider, get_entity_vehicle, and set_entity_stacking. The last of those is a more functional replacement for set_entity_rider, which has been moved out of sandbox and deprecated.

Fixes a spacing error in the docs for player_fish event.
Fixes set_objective_display not accepting enough args.
Adds the contents array to inventory_click event.
