### PR TITLE
New functions and events, fixes, changes in sk_* functions

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCTravelAgent.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCTravelAgent.java
@@ -1,0 +1,21 @@
+package com.laytonsmith.abstraction;
+
+/**
+ *
+ * @author MariuszT
+ */
+public interface MCTravelAgent extends AbstractionObject {
+
+	public boolean createPortal(MCLocation location);
+	public MCLocation findOrCreate(MCLocation location);
+	public MCLocation findPortal(MCLocation location);
+
+	public boolean getCanCreatePortal();
+	public void setCanCreatePortal(boolean create);
+
+	public int getCreationRadius();
+	public MCTravelAgent setCreationRadius(int radius);
+
+	public int getSearchRadius();
+	public MCTravelAgent setSearchRadius(int radius);
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -244,6 +244,14 @@ public class BukkitConvertor extends AbstractConvertor {
     		return new BukkitMCAgeable(be);
     	}
     	
+    	if(be instanceof Boat) {
+			return new BukkitMCBoat((Boat)be);
+    	}
+
+    	if(be instanceof Minecart) {
+    		return new BukkitMCMinecart((Minecart)be);
+    	}
+
     	if(be instanceof Vehicle){
     		return new BukkitMCVehicle(be);
     	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTravelAgent.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTravelAgent.java
@@ -1,0 +1,62 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.AbstractionObject;
+import com.laytonsmith.abstraction.MCLocation;
+import com.laytonsmith.abstraction.MCTravelAgent;
+import org.bukkit.TravelAgent;
+
+/**
+ *
+ * @author MariuszT
+ */
+public class BukkitMCTravelAgent implements MCTravelAgent {
+
+    TravelAgent a;
+    public BukkitMCTravelAgent(TravelAgent a) {
+        this.a = a;
+    }
+	
+	public BukkitMCTravelAgent(AbstractionObject o) {
+		a = (TravelAgent)o;
+	}
+
+	public boolean createPortal(MCLocation location) {
+		return a.createPortal(((BukkitMCLocation)location).asLocation());
+	}
+
+	public MCLocation findOrCreate(MCLocation location) {
+		return new BukkitMCLocation(a.findOrCreate(((BukkitMCLocation)location).asLocation()));
+	}
+
+	public MCLocation findPortal(MCLocation location) {
+		return new BukkitMCLocation(a.findPortal(((BukkitMCLocation)location).asLocation()));
+	}
+
+	public boolean getCanCreatePortal() {
+		return a.getCanCreatePortal();
+	}
+
+	public void setCanCreatePortal(boolean create) {
+		a.setCanCreatePortal(create);
+	}
+
+	public int getCreationRadius() {
+		return a.getCreationRadius();
+	}
+
+	public MCTravelAgent setCreationRadius(int radius) {
+		return new BukkitMCTravelAgent(a.setCreationRadius(radius));
+	}
+
+	public int getSearchRadius() {
+		return a.getSearchRadius();
+	}
+
+	public MCTravelAgent setSearchRadius(int radius) {
+		return new BukkitMCTravelAgent(a.setSearchRadius(radius));
+	}
+
+	public Object getHandle() {
+		return a;
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCBoat.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCBoat.java
@@ -1,0 +1,47 @@
+package com.laytonsmith.abstraction.bukkit.entities;
+
+import com.laytonsmith.abstraction.bukkit.BukkitMCVehicle;
+import com.laytonsmith.abstraction.entities.MCBoat;
+import org.bukkit.entity.Boat;
+
+public class BukkitMCBoat extends BukkitMCVehicle
+		implements MCBoat {
+
+	Boat b;
+	public BukkitMCBoat(Boat e) {
+		super(e);
+		this.b = e;
+	}
+
+	public double getMaxSpeed() {
+		return b.getMaxSpeed();
+	}
+
+	public void setMaxSpeed(double speed) {
+		b.setMaxSpeed(speed);
+	}
+
+	public double getOccupiedDeclaration() {
+		return b.getOccupiedDeceleration();
+	}
+
+	public void setOccupiedDeclaration(double rate) {
+		b.setOccupiedDeceleration(rate);
+	}
+
+	public double getUnoccupiedDeclaration() {
+		return b.getOccupiedDeceleration();
+	}
+
+	public void setUnoccupiedDeclaration(double rate) {
+		b.setUnoccupiedDeceleration(rate);
+	}
+
+	public boolean getWorkOnLand() {
+		return b.getWorkOnLand();
+	}
+
+	public void setWorkOnLand(boolean workOnLand) {
+		b.setWorkOnLand(workOnLand);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCMinecart.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCMinecart.java
@@ -1,0 +1,39 @@
+package com.laytonsmith.abstraction.bukkit.entities;
+
+import com.laytonsmith.abstraction.bukkit.BukkitMCVehicle;
+import com.laytonsmith.abstraction.entities.MCMinecart;
+import org.bukkit.entity.Minecart;
+
+public class BukkitMCMinecart extends BukkitMCVehicle
+		implements MCMinecart {
+
+	Minecart m;
+	public BukkitMCMinecart(Minecart e) {
+		super(e);
+		this.m = e;
+	}
+
+	public void setDamage(int damage) {
+		m.setDamage(damage);
+	}
+
+	public int getDamage() {
+		return m.getDamage();
+	}
+
+	public double getMaxSpeed() {
+		return m.getMaxSpeed();
+	}
+
+	public void setMaxSpeed(double speed) {
+		m.setMaxSpeed(speed);
+	}
+
+	public boolean isSlowWhenEmpty() {
+		return m.isSlowWhenEmpty();
+	}
+
+	public void setSlowWhenEmpty(boolean slow) {
+		m.setSlowWhenEmpty(slow);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
@@ -8,18 +8,30 @@ import com.laytonsmith.abstraction.bukkit.BukkitMCHumanEntity;
 import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
 import com.laytonsmith.abstraction.bukkit.BukkitMCInventoryView;
 import com.laytonsmith.abstraction.bukkit.BukkitMCItemStack;
+import com.laytonsmith.abstraction.enums.MCDragType;
+import com.laytonsmith.abstraction.enums.MCResult;
 import com.laytonsmith.abstraction.enums.MCSlotType;
 import com.laytonsmith.abstraction.events.MCInventoryClickEvent;
 import com.laytonsmith.abstraction.events.MCInventoryCloseEvent;
+import com.laytonsmith.abstraction.events.MCInventoryDragEvent;
 import com.laytonsmith.abstraction.events.MCInventoryEvent;
+import com.laytonsmith.abstraction.events.MCInventoryInteractEvent;
 import com.laytonsmith.abstraction.events.MCInventoryOpenEvent;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.Event.Result;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  *
@@ -56,6 +68,36 @@ public class BukkitInventoryEvents {
 		}
 	}
 
+	public static class BukkitMCInventoryInteractEvent extends BukkitMCInventoryEvent
+	implements MCInventoryInteractEvent {
+		InventoryInteractEvent iie;
+
+		public BukkitMCInventoryInteractEvent(InventoryInteractEvent e) {
+			super(e);
+			iie = e;
+		}
+
+		public MCHumanEntity getWhoClicked() {
+			return new BukkitMCHumanEntity(iie.getWhoClicked());
+		}
+
+		public void setResult(MCResult newResult) {
+			iie.setResult(Result.valueOf(newResult.name()));
+		}
+
+		public MCResult getResult() {
+			return MCResult.valueOf(iie.getResult().name());
+		}
+
+		public boolean isCanceled() {
+			return iie.isCancelled();
+		}
+
+        public void setCancelled(boolean cancelled) {
+            iie.setCancelled(cancelled);
+        }
+	}
+
 	public static class BukkitMCInventoryOpenEvent extends BukkitMCInventoryEvent
 	implements MCInventoryOpenEvent {
 		InventoryOpenEvent ioe;
@@ -84,7 +126,7 @@ public class BukkitInventoryEvents {
 		}
 	}
 
-	public static class BukkitMCInventoryClickEvent extends BukkitMCInventoryEvent
+	public static class BukkitMCInventoryClickEvent extends BukkitMCInventoryInteractEvent
 	implements MCInventoryClickEvent {
 
 		InventoryClickEvent ic;
@@ -113,10 +155,6 @@ public class BukkitInventoryEvents {
 			return MCSlotType.valueOf(ic.getSlotType().name());
 		}
 
-		public MCHumanEntity getWhoClicked() {
-			return new BukkitMCHumanEntity(ic.getWhoClicked());
-		}
-
 		public boolean isLeftClick() {
 			return ic.isLeftClick();
 		}
@@ -140,9 +178,63 @@ public class BukkitInventoryEvents {
 		public void setCursor(MCItemStack cursor) {
 			ic.setCursor(((BukkitMCItemStack) cursor).asItemStack());
 		}
+	}
 
-        public void setCancelled(boolean cancelled) {
-            ic.setCancelled(cancelled);
-        }
+	public static class BukkitMCInventoryDragEvent extends BukkitMCInventoryInteractEvent
+	implements MCInventoryDragEvent {
+
+		InventoryDragEvent id;
+		public BukkitMCInventoryDragEvent(InventoryDragEvent e) {
+			super(e);
+			this.id = e;
+		}
+
+		public Map<Integer, MCItemStack> getNewItems() {
+			Map<Integer, MCItemStack> ret = new HashMap<Integer, MCItemStack>();
+
+			for (Map.Entry<Integer, ItemStack> ni : id.getNewItems().entrySet()) {
+				Integer key = ni.getKey();
+				ItemStack value = ni.getValue();
+				ret.put(key, new BukkitMCItemStack(value));
+			}
+			
+			return ret;
+		}
+
+		public Set<Integer> getRawSlots() {
+			Set<Integer> ret = new HashSet<Integer>();
+
+			for (Integer rs : id.getRawSlots()) {
+				ret.add(rs);
+			}
+			
+			return ret;
+		}
+
+		public Set<Integer> getInventorySlots() {
+			Set<Integer> ret = new HashSet<Integer>();
+
+			for (Integer is : id.getInventorySlots()) {
+				ret.add(is);
+			}
+
+			return ret;
+		}
+
+		public MCItemStack getCursor() {
+			return new BukkitMCItemStack(id.getCursor());
+		}
+
+		public void setCursor(MCItemStack newCursor) {
+			id.setCursor(((BukkitMCItemStack) newCursor).asItemStack());
+		}
+
+		public MCItemStack getOldCursor() {
+			return new BukkitMCItemStack(id.getOldCursor());
+		}
+
+		public MCDragType getType() {
+			return MCDragType.valueOf(id.getType().name());
+		}
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
@@ -5,11 +5,11 @@ package com.laytonsmith.abstraction.bukkit.events;
 import com.laytonsmith.abstraction.*;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCBlockFace;
-import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
 import com.laytonsmith.abstraction.bukkit.BukkitMCEntity;
 import com.laytonsmith.abstraction.bukkit.BukkitMCItemStack;
 import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.BukkitMCPlayer;
+import com.laytonsmith.abstraction.bukkit.BukkitMCTravelAgent;
 import com.laytonsmith.abstraction.bukkit.BukkitMCWorld;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFishHook;
@@ -17,8 +17,10 @@ import com.laytonsmith.abstraction.bukkit.events.BukkitEntityEvents.BukkitMCEnti
 import com.laytonsmith.abstraction.entities.MCFishHook;
 import com.laytonsmith.abstraction.enums.MCAction;
 import com.laytonsmith.abstraction.enums.MCFishingState;
+import com.laytonsmith.abstraction.enums.MCTeleportCause;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCAction;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCFishingState;
+import com.laytonsmith.abstraction.enums.bukkit.BukkitMCTeleportCause;
 import com.laytonsmith.abstraction.events.*;
 import com.laytonsmith.annotations.abstraction;
 import java.util.ArrayList;
@@ -27,12 +29,14 @@ import java.util.HashSet;
 import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.TravelAgent;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerPreLoginEvent.Result;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -141,6 +145,7 @@ public class BukkitPlayerEvents {
 
     }
 
+	@abstraction(type=Implementation.Type.BUKKIT)
 	public static class BukkitMCPlayerTeleportEvent implements MCPlayerTeleportEvent {
 		PlayerTeleportEvent e;
 
@@ -160,8 +165,12 @@ public class BukkitPlayerEvents {
 			return new BukkitMCLocation(e.getTo());
 		}
 
-		public String getCause() {
-			return e.getCause().name();
+		public MCTeleportCause getCause() {
+			return BukkitMCTeleportCause.getConvertor().getAbstractedEnum(e.getCause());
+		}
+
+		public void setFrom(MCLocation oldloc) {
+			e.setFrom(((BukkitMCLocation) oldloc)._Location());
 		}
 
 		public void setTo(MCLocation newloc) {
@@ -188,6 +197,41 @@ public class BukkitPlayerEvents {
 
 		public boolean isCancelled() {
 			return e.isCancelled();
+		}
+	}
+
+	@abstraction(type=Implementation.Type.BUKKIT)
+	public static class BukkitMCPlayerPortalEvent extends BukkitMCPlayerTeleportEvent
+			implements MCPlayerPortalEvent {
+
+		PlayerPortalEvent p;
+		public BukkitMCPlayerPortalEvent(PlayerPortalEvent event) {
+			super(event);
+			p = event;
+		}
+
+		public void useTravelAgent(boolean useTravelAgent) {
+			p.useTravelAgent(useTravelAgent);
+		}
+
+		public boolean useTravelAgent() {
+			return p.useTravelAgent();
+		}
+
+		public MCTravelAgent getPortalTravelAgent() {
+			return new BukkitMCTravelAgent(p.getPortalTravelAgent());
+		}
+
+		public void setPortalTravelAgent(MCTravelAgent travelAgent) {
+			p.setPortalTravelAgent((TravelAgent) travelAgent.getHandle());
+		}
+
+		@Override
+		public MCLocation getTo() {
+			if (e.getTo() == null) {
+				return null;
+			}
+			return new BukkitMCLocation(e.getTo());
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
@@ -3,6 +3,7 @@ package com.laytonsmith.abstraction.bukkit.events.drivers;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCInventoryClickEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCInventoryCloseEvent;
+import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCInventoryDragEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCInventoryOpenEvent;
 import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
@@ -11,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 
 /**
@@ -24,6 +26,13 @@ public class BukkitInventoryListener implements Listener{
 		BukkitMCInventoryClickEvent ice = new BukkitInventoryEvents.BukkitMCInventoryClickEvent(event);
 		EventUtils.TriggerExternal(ice);
 		EventUtils.TriggerListener(Driver.INVENTORY_CLICK, "inventory_click", ice);
+	}
+
+	@EventHandler(priority=EventPriority.LOWEST)
+	public void onInvDrag(InventoryDragEvent event) {
+		BukkitMCInventoryDragEvent ide = new BukkitInventoryEvents.BukkitMCInventoryDragEvent(event);
+		EventUtils.TriggerExternal(ide);
+		EventUtils.TriggerListener(Driver.INVENTORY_DRAG, "inventory_drag", ide);
 	}
 	
 	@EventHandler(priority=EventPriority.LOWEST)

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
@@ -207,6 +207,14 @@ public class BukkitPlayerListener implements Listener {
 		EventUtils.TriggerListener(Driver.PLAYER_TELEPORT, "player_teleport", pte);
 	}
 	
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPortalEnter(PlayerPortalEvent event) {
+		BukkitPlayerEvents.BukkitMCPlayerPortalEvent pe = new BukkitPlayerEvents.BukkitMCPlayerPortalEvent(event);
+		EventUtils.TriggerExternal(pe);
+		EventUtils.TriggerListener(Driver.PLAYER_PORTAL_TRAVEL, "player_portal_travel", pe);
+	}
+
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onConsume(PlayerItemConsumeEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerItemConsumeEvent pic = 

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCBoat.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCBoat.java
@@ -1,0 +1,14 @@
+package com.laytonsmith.abstraction.entities;
+
+import com.laytonsmith.abstraction.MCVehicle;
+
+public interface MCBoat extends MCVehicle {
+	public double getMaxSpeed();
+	public void setMaxSpeed(double speed);
+	public double getOccupiedDeclaration();
+	public void setOccupiedDeclaration(double rate);
+	public double getUnoccupiedDeclaration();
+	public void setUnoccupiedDeclaration(double rate);
+	public boolean getWorkOnLand();
+	public void setWorkOnLand(boolean workOnLand);
+}

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCMinecart.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCMinecart.java
@@ -1,0 +1,12 @@
+package com.laytonsmith.abstraction.entities;
+
+import com.laytonsmith.abstraction.MCVehicle;
+
+public interface MCMinecart extends MCVehicle {
+	public void setDamage(int damage);
+	public int getDamage();
+	public double getMaxSpeed();
+	public void setMaxSpeed(double speed);
+	public boolean isSlowWhenEmpty();
+	public void setSlowWhenEmpty(boolean slow);
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCDragType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCDragType.java
@@ -1,0 +1,10 @@
+package com.laytonsmith.abstraction.enums;
+
+/**
+ *
+ * @author MariuszT
+ */
+public enum MCDragType {
+	SINGLE,
+	EVEN;
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCResult.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCResult.java
@@ -1,0 +1,10 @@
+package com.laytonsmith.abstraction.enums;
+
+/**
+ *
+ * @author MariuszT
+ */
+public enum MCResult {
+	DENY,
+	DEFAULT;
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCDragType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCDragType.java
@@ -1,0 +1,28 @@
+
+package com.laytonsmith.abstraction.enums.bukkit;
+
+import com.laytonsmith.abstraction.Implementation;
+import com.laytonsmith.abstraction.enums.EnumConvertor;
+import com.laytonsmith.abstraction.enums.MCDragType;
+import com.laytonsmith.annotations.abstractionenum;
+import org.bukkit.event.inventory.DragType;
+
+/**
+ *
+ * @author MariuszT
+ */
+@abstractionenum(
+		implementation = Implementation.Type.BUKKIT,
+forAbstractEnum = MCDragType.class,
+forConcreteEnum = DragType.class)
+public class BukkitMCDragType extends EnumConvertor<MCDragType, DragType> {
+
+	private static com.laytonsmith.abstraction.enums.bukkit.BukkitMCDragType instance;
+
+	public static com.laytonsmith.abstraction.enums.bukkit.BukkitMCDragType getConvertor() {
+		if (instance == null) {
+			instance = new com.laytonsmith.abstraction.enums.bukkit.BukkitMCDragType();
+		}
+		return instance;
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCResult.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCResult.java
@@ -1,0 +1,28 @@
+
+package com.laytonsmith.abstraction.enums.bukkit;
+
+import com.laytonsmith.abstraction.Implementation;
+import com.laytonsmith.abstraction.enums.EnumConvertor;
+import com.laytonsmith.abstraction.enums.MCResult;
+import com.laytonsmith.annotations.abstractionenum;
+import org.bukkit.event.Event.Result;
+
+/**
+ *
+ * @author MariuszT
+ */
+@abstractionenum(
+		implementation = Implementation.Type.BUKKIT,
+forAbstractEnum = MCResult.class,
+forConcreteEnum = Result.class)
+public class BukkitMCResult extends EnumConvertor<MCResult, Result> {
+
+	private static com.laytonsmith.abstraction.enums.bukkit.BukkitMCResult instance;
+
+	public static com.laytonsmith.abstraction.enums.bukkit.BukkitMCResult getConvertor() {
+		if (instance == null) {
+			instance = new com.laytonsmith.abstraction.enums.bukkit.BukkitMCResult();
+		}
+		return instance;
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCTeleportCause.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCTeleportCause.java
@@ -1,4 +1,3 @@
-
 package com.laytonsmith.abstraction.enums.bukkit;
 
 import com.laytonsmith.abstraction.Implementation;

--- a/src/main/java/com/laytonsmith/abstraction/events/MCInventoryDragEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCInventoryDragEvent.java
@@ -1,0 +1,20 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.enums.MCDragType;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ * @author import
+ */
+public interface MCInventoryDragEvent extends MCInventoryInteractEvent {
+	public Map<Integer, MCItemStack> getNewItems();
+	public Set<Integer> getRawSlots();
+	public Set<Integer> getInventorySlots();
+	public MCItemStack getCursor();
+	public void setCursor(MCItemStack newCursor);
+	public MCItemStack getOldCursor();
+	public MCDragType getType();
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCInventoryInteractEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCInventoryInteractEvent.java
@@ -1,0 +1,16 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCHumanEntity;
+import com.laytonsmith.abstraction.enums.MCResult;
+
+/**
+ *
+ * @author import
+ */
+public interface MCInventoryInteractEvent extends MCInventoryEvent {
+	public MCHumanEntity getWhoClicked();
+	public void setResult(MCResult newResult);
+	public MCResult getResult();
+	public boolean isCanceled();
+	public void setCancelled(boolean toCancel);
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPlayerPortalEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPlayerPortalEvent.java
@@ -1,0 +1,10 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCTravelAgent;
+
+public interface MCPlayerPortalEvent extends MCPlayerTeleportEvent {
+	public void useTravelAgent(boolean useTravelAgent);
+	public boolean useTravelAgent();
+	public MCTravelAgent getPortalTravelAgent();
+	public void setPortalTravelAgent(MCTravelAgent travelAgent);
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPlayerTeleportEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPlayerTeleportEvent.java
@@ -1,16 +1,14 @@
 package com.laytonsmith.abstraction.events;
 
 import com.laytonsmith.abstraction.MCLocation;
+import com.laytonsmith.abstraction.enums.MCTeleportCause;
 
 /**
  *
  * @author layton
  */
-public interface MCPlayerTeleportEvent extends MCPlayerEvent{
-    public MCLocation getFrom();
-	public MCLocation getTo();
-	public String getCause();
+public interface MCPlayerTeleportEvent extends MCPlayerMoveEvent {
+	public MCTeleportCause getCause();
+    public void setFrom(MCLocation oldloc);
     public void setTo(MCLocation newloc);
-	public void setCancelled(boolean state);
-	public boolean isCancelled();
 }

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -557,14 +557,14 @@ public final class Static {
      */
     public static MCItemStack ParseItemNotation(String functionName, String notation, int qty, Target t) {
         int type = 0;
-        byte data = 0;
+        short data = 0;
         MCItemStack is = null;
         if (notation.matches("\\d*:\\d*")) {
             String[] sData = notation.split(":");
             try {
                 type = (int) Integer.parseInt(sData[0]);
                 if (sData.length > 1) {
-                    data = (byte) Integer.parseInt(sData[1]);
+                    data = (short) Integer.parseInt(sData[1]);
                 }
             } catch (NumberFormatException e) {
                 throw new ConfigRuntimeException("Item value passed to " + functionName + " is invalid: " + notation, ExceptionType.FormatException, t);

--- a/src/main/java/com/laytonsmith/core/events/Driver.java
+++ b/src/main/java/com/laytonsmith/core/events/Driver.java
@@ -37,6 +37,7 @@ public enum Driver {
 	ITEM_DROP,
 	ITEM_SPAWN,
 	INVENTORY_CLICK,
+	INVENTORY_DRAG,
 	INVENTORY_OPEN,
 	INVENTORY_CLOSE,
 	PLAYER_CONSUME,
@@ -49,6 +50,7 @@ public enum Driver {
 	VEHICLE_ENTER,
 	VEHICLE_LEAVE,
 	VEHICLE_COLLIDE,
+	PLAYER_PORTAL_TRAVEL,
 	/**
 	 * Used by events fired from the extension system.
 	 */

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -4,7 +4,9 @@ import java.util.Map;
 
 import com.laytonsmith.PureUtilities.StringUtils;
 import com.laytonsmith.PureUtilities.Version;
+import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.enums.MCCollisionType;
+import com.laytonsmith.abstraction.enums.MCEntityType;
 import com.laytonsmith.abstraction.events.MCVehicleBlockCollideEvent;
 import com.laytonsmith.abstraction.events.MCVehicleCollideEvent;
 import com.laytonsmith.abstraction.events.MCVehicleEnitityCollideEvent;
@@ -45,7 +47,8 @@ public class VehicleEvents {
 		public String docs() {
 			return "{vehicletype: <macro> the entitytype of the vehicle | passengertype: <macro>"
 					+ " the enitytype of the passenger} Fires when an entity enters a vehicle."
-					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID}"
+					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID"
+					+ " | player: player name if passenger is a player, null otherwise}"
 					+ " {}"
 					+ " {}";
 		}
@@ -73,6 +76,11 @@ public class VehicleEvents {
 				ret.put("passengertype", new CString(e.getEntity().getType().name(), t));
 				ret.put("vehicle", new CInt(e.getVehicle().getEntityId(), t));
 				ret.put("passenger", new CInt(e.getEntity().getEntityId(), t));
+				if (e.getEntity().getType() == MCEntityType.PLAYER) {
+					ret.put("player", new CString(((MCPlayer)e.getEntity()).getName(), t));
+				} else {
+					ret.put("player", new CNull(t));
+				}
 				return ret;
 			} else {
 				throw new EventException("Could not convert to MCVehicleEnterExitEvent");
@@ -102,7 +110,8 @@ public class VehicleEvents {
 		public String docs() {
 			return "{vehicletype: <macro> the entitytype of the vehicle | passengertype: <macro>"
 					+ " the enitytype of the passenger} Fires when an entity leaves a vehicle."
-					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID}"
+					+ " {vehicletype | passengertype | vehicle: entityID | passenger: entityID"
+					+ " | player: player name if passenger is a player, null otherwise}"
 					+ " {}"
 					+ " {}";
 		}
@@ -130,6 +139,11 @@ public class VehicleEvents {
 				ret.put("passengertype", new CString(e.getEntity().getType().name(), t));
 				ret.put("vehicle", new CInt(e.getVehicle().getEntityId(), t));
 				ret.put("passenger", new CInt(e.getEntity().getEntityId(), t));
+				if (e.getEntity().getType() == MCEntityType.PLAYER) {
+					ret.put("player", new CString(((MCPlayer)e.getEntity()).getName(), t));
+				} else {
+					ret.put("player", new CNull(t));
+				}
 				return ret;
 			} else {
 				throw new EventException("Could not convert to MCVehicleEnterExitEvent");

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -3,6 +3,8 @@ package com.laytonsmith.core.functions;
 import com.laytonsmith.PureUtilities.StringUtils;
 import com.laytonsmith.abstraction.*;
 import com.laytonsmith.abstraction.blocks.MCBlockFace;
+import com.laytonsmith.abstraction.entities.MCBoat;
+import com.laytonsmith.abstraction.entities.MCMinecart;
 import com.laytonsmith.abstraction.enums.MCEntityEffect;
 import com.laytonsmith.abstraction.enums.MCEntityType;
 import com.laytonsmith.abstraction.enums.MCEquipmentSlot;
@@ -27,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.bukkit.Material;
 
 /**
  *
@@ -1182,6 +1185,75 @@ public class EntityManagement {
 
 		public String docs() {
 			return "mixed {entityID} Returns the ID of the given entity's vehicle, or null if it doesn't have one.";
+		}
+	}
+
+	@api
+	public static class get_entity_max_speed extends EntityGetterFunction {
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.BadEntityException, ExceptionType.BadEntityTypeException};
+		}
+
+		public Construct exec(Target t, Environment environment,
+				Construct... args) throws ConfigRuntimeException {
+
+			MCEntity e = Static.getEntity(Static.getInt32(args[0], t), t);
+
+			if (e instanceof MCBoat) {
+				return new CDouble(((MCBoat) e).getMaxSpeed(), t);
+			} else if(e instanceof MCMinecart) {
+				return new CDouble(((MCMinecart) e).getMaxSpeed(), t);
+			}
+
+			throw new ConfigRuntimeException("Given entity must be a boat or minecart.",
+					ExceptionType.BadEntityTypeException, t);
+		}
+
+		public String getName() {
+			return "get_entity_max_speed";
+		}
+
+		public String docs() {
+			return "double {entityID} Returns a max speed for given entity. Make sure that the entity is a boat"
+					+ " or minecart.";
+		}
+	}
+
+	@api
+	public static class set_entity_max_speed extends EntitySetterFunction {
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.BadEntityException, ExceptionType.BadEntityTypeException};
+		}
+
+		public Construct exec(Target t, Environment environment,
+				Construct... args) throws ConfigRuntimeException {
+
+			MCEntity e = Static.getEntity(Static.getInt32(args[0], t), t);
+			CDouble speed = new CDouble(args[1].val(), t);
+
+			if (e instanceof MCBoat) {
+				((MCBoat) e).setMaxSpeed(speed.getDouble());
+			} else if(e instanceof MCMinecart) {
+				((MCMinecart) e).setMaxSpeed(speed.getDouble());
+			} else {
+				throw new ConfigRuntimeException("Given entity must be a boat or minecart.",
+						ExceptionType.BadEntityTypeException, t);
+			}
+
+			return new CVoid(t);
+		}
+
+		public String getName() {
+			return "set_entity_max_speed";
+		}
+
+		public String docs() {
+			return "void {entityID} Sets a max speed for given entity. Make sure that the entity is a boat"
+					+ " or minecart.";
 		}
 	}
 }

--- a/src/main/java/com/laytonsmith/core/functions/Exceptions.java
+++ b/src/main/java/com/laytonsmith/core/functions/Exceptions.java
@@ -196,7 +196,10 @@ public class Exceptions {
 		 * Thrown if an entity is looked up by id, but doesn't exist.
 		 */
 		BadEntityException("Thrown if an entity is looked up by id, but doesn't exist.", CHVersion.V3_3_1),
-		
+		/**
+		 * Thrown if an entity has the wrong type than expected.
+		 */
+		BadEntityTypeException("Thrown if an entity has the wrong type.", CHVersion.V3_3_1),
 		/**
 		 * Thrown if a field was read only, but a write operation was attempted.
 		 */

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -1012,9 +1012,8 @@ public class PlayerManagement {
 					}
 				} else if (args.length == 1) {
 					//if it's a number, we are setting F. Otherwise, it's a getter for the MCPlayer specified.
-					try {
-						Integer.parseInt(args[0].val());
-					} catch (NumberFormatException e) {
+
+					if (!(args[0] instanceof CInt)) {
 						MCPlayer p2 = Static.GetPlayer(args[0], t);
 						l = p2.getLocation();
 					}
@@ -3429,7 +3428,7 @@ public class PlayerManagement {
 		}
 
 		public String docs() {
-			return "mixed {[player]} Returns name of vehicle which player is in or null if player is outside the vehicle";
+			return "mixed {[player]} Returns ID of vehicle which player is in or null if player is outside the vehicle";
 			}
 
 		public ExceptionType[] thrown() {


### PR DESCRIPTION
Fixed durability, pfacing and sk_region_addmember, add support to sk_\* functions for **global** region, add player_portal_travel and inventory_drag events, add player info to vehicle_enter event, add player info to vehicle_enter event, add sk_region_rename, get_entity_max_speed and set_entity_max_speed

Durability can be greater than 127 so we need short type instead of byte.
Pfacing bad works if a player had the only number as a nickname.
