### PR TITLE
edited play_sound function to use paths if the sound name doesn't match any of Bukkit's sound names.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
@@ -118,6 +118,8 @@ public interface MCPlayer extends MCCommandSender, MCHumanEntity,
 	public void playNote(MCLocation loc, MCInstrument instrument, MCNote note);
 	
 	public void playSound(MCLocation l, MCSound sound, float volume, float pitch);
+	
+	public void playSoundPath(MCLocation l, String sound, float volume, float pitch);
 
 	public int getHunger();
 

--- a/src/main/java/com/laytonsmith/abstraction/MCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCWorld.java
@@ -56,6 +56,8 @@ public interface MCWorld extends AbstractionObject{
     public void playEffect(MCLocation l, MCEffect mCEffect, int e, int data);
 
 	public void playSound(MCLocation l, MCSound sound, float volume, float pitch);
+	
+	public void playSoundPath(MCLocation l, String sound, float volume, float pitch);
 
     public MCItem dropItemNaturally(MCLocation l, MCItemStack is);
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPlayer.java
@@ -433,6 +433,10 @@ public class BukkitMCPlayer extends BukkitMCHumanEntity implements MCPlayer, MCC
 		p.playSound(((BukkitMCLocation) l).asLocation(), 
 				BukkitMCSound.getConvertor().getConcreteEnum(sound), volume, pitch);
 	}
+	
+	public void playSoundPath(MCLocation l, String sound, float volume, float pitch) {
+		p.playSound(((BukkitMCLocation)l).asLocation(), sound, volume, pitch);
+	}
 
 	public int getHunger() {
 		return p.getFoodLevel();

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
@@ -41,8 +41,10 @@ import com.laytonsmith.abstraction.enums.bukkit.BukkitMCWorldType;
 import com.laytonsmith.core.constructs.*;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Exceptions.ExceptionType;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -206,6 +208,11 @@ public class BukkitMCWorld implements MCWorld {
 	public void playSound(MCLocation l, MCSound sound, float volume, float pitch) {
 		w.playSound(((BukkitMCLocation) l).asLocation(), 
 				BukkitMCSound.getConvertor().getConcreteEnum(sound), volume, pitch);
+	}
+	
+	public void playSoundPath(MCLocation l, String sound, float volume, float pitch) {
+		for(Player p: w.getPlayers())
+			p.playSound(((BukkitMCLocation)l).asLocation(), sound, volume, pitch);
 	}
 
     public MCItem dropItemNaturally(MCLocation l, MCItemStack is) {

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -10,8 +10,6 @@ import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCSign;
-import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
-import com.laytonsmith.abstraction.bukkit.BukkitMCPlayer;
 import com.laytonsmith.abstraction.enums.MCBiomeType;
 import com.laytonsmith.abstraction.enums.MCInstrument;
 import com.laytonsmith.abstraction.enums.MCSound;
@@ -908,15 +906,14 @@ public class Environment {
 				
 				for (MCPlayer p : players) {
 					if(usingPath) {
-						((BukkitMCPlayer)p)._Player().playSound(((BukkitMCLocation)loc).asLocation(), path, volume, pitch);
+						p.playSoundPath(loc, path, volume, pitch);
 					} else {
 						p.playSound(loc, sound, volume, pitch);
 					}
 				}
 			} else {
 				if(usingPath) {
-					for(MCPlayer p: loc.getWorld().getPlayers())
-						((BukkitMCPlayer)p)._Player().playSound(((BukkitMCLocation)loc).asLocation(), path, volume, pitch);
+					loc.getWorld().playSoundPath(loc, path, volume, pitch);
 				} else {
 					loc.getWorld().playSound(loc, sound, volume, pitch);
 				}


### PR DESCRIPTION
this is something VergilPrime wanted because of his custom resource pack addiction.

the main thing is that if does use paths it uses Bukkit's deprecated playSound function for it.
sorry if this pull looks ridiculous. i don't even know if i'm merging to the right branch or not.
sorry about those useless whitespace changes too.

(it also isn't tested, sorry)
