### PR TITLE
Added URL tracking for ClassMirror classes.

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassDiscovery.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassDiscovery.java
@@ -6,8 +6,8 @@ import com.laytonsmith.PureUtilities.ClassLoading.ClassMirror.FieldMirror;
 import com.laytonsmith.PureUtilities.ClassLoading.ClassMirror.MethodMirror;
 import com.laytonsmith.PureUtilities.Common.ClassUtils;
 import com.laytonsmith.PureUtilities.Common.FileUtil;
-import com.laytonsmith.PureUtilities.ProgressIterator;
 import com.laytonsmith.PureUtilities.Common.StringUtils;
+import com.laytonsmith.PureUtilities.ProgressIterator;
 import com.laytonsmith.PureUtilities.ZipIterator;
 import java.io.File;
 import java.io.IOException;
@@ -296,7 +296,7 @@ public class ClassDiscovery {
 						try {
 							stream = FileUtil.readAsStream(new File(rootLocationFile,
 									f.getAbsolutePath().replaceFirst(Pattern.quote(new File(root).getAbsolutePath() + File.separator), "")));
-							ClassMirror cm = new ClassMirror(stream);
+							ClassMirror cm = new ClassMirror(stream, new URL(url));
 							mirrors.add(cm);
 						} catch (IOException ex) {
 							Logger.getLogger(ClassDiscovery.class.getName()).log(Level.SEVERE, null, ex);
@@ -328,7 +328,7 @@ public class ClassDiscovery {
 						public void handle(String filename, InputStream in) {
 							if (!filename.matches(".*\\$(?:\\d)*\\.class") && filename.endsWith(".class")) {
 								try {
-									ClassMirror cm = new ClassMirror(in);
+									ClassMirror cm = new ClassMirror(in, rootLocationFile.toURI().toURL());
 									mirrors.add(cm);
 								} catch (IOException ex) {
 									Logger.getLogger(ClassDiscovery.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassDiscoveryURLCache.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassDiscoveryURLCache.java
@@ -2,6 +2,7 @@
 package com.laytonsmith.PureUtilities.ClassLoading;
 
 import com.laytonsmith.PureUtilities.ClassLoading.ClassMirror.ClassMirror;
+import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
 import com.laytonsmith.PureUtilities.ProgressIterator;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,7 +48,9 @@ public class ClassDiscoveryURLCache {
 		//we would get stuck in an infinite loop.
 		discovery.setClassDiscoveryCache(null);
 		discovery.addDiscoveryLocation(url);
+		
 		for(ClassMirror m : discovery.getKnownClasses(url)){
+			ReflectionUtils.set(ClassMirror.class, m, "originalURL", url);
 			list.add(m);
 		}
 	}
@@ -60,6 +63,7 @@ public class ClassDiscoveryURLCache {
 	 * @param url
 	 * @param descriptor
 	 * @throws IOException 
+	 * @throws java.lang.ClassNotFoundException 
 	 */
 	public ClassDiscoveryURLCache(URL url, InputStream descriptor) throws IOException, ClassNotFoundException{
 		List<ClassMirror<?>> _list;
@@ -75,6 +79,11 @@ public class ClassDiscoveryURLCache {
 			}
 		}
 		ois.close();
+
+		for (ClassMirror m : _list) {
+			ReflectionUtils.set(ClassMirror.class, m, "originalURL", url);
+		}
+		
 		this.list = _list;
 	}
 	

--- a/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassMirror/ClassMirror.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassMirror/ClassMirror.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,16 +43,24 @@ public class ClassMirror<T> implements Serializable {
 	 * the wrapped return.
 	 */
 	private final Class underlyingClass;
+        
+	/**
+	 * The original URL that houses this class.
+	**/
+	private final URL originalURL;
 	
 	/**
 	 * Creates a ClassMirror object for a given input stream representing
 	 * a class file.
 	 * @param is
+	 * @param container
 	 * @throws IOException 
 	 */
-	public ClassMirror(InputStream is) throws IOException {
+	public ClassMirror(InputStream is, URL container) throws IOException {
 		reader = new org.objectweb.asm.ClassReader(is);
 		underlyingClass = null;
+		originalURL = container;
+		
 		parse();
 	}
 	
@@ -62,7 +71,7 @@ public class ClassMirror<T> implements Serializable {
 	 * @throws IOException 
 	 */
 	public ClassMirror(File file) throws FileNotFoundException, IOException {
-		this(new FileInputStream(file));
+		this(new FileInputStream(file), file.toURI().toURL());
 	}
 	
 	/**
@@ -85,6 +94,14 @@ public class ClassMirror<T> implements Serializable {
 		reader.accept(info, org.objectweb.asm.ClassReader.SKIP_CODE 
 				| org.objectweb.asm.ClassReader.SKIP_DEBUG 
 				| org.objectweb.asm.ClassReader.SKIP_FRAMES);
+	}
+        
+	/**
+	 * Return the container that houses this class.
+	 * @return 
+	 */
+	public URL getContainer() {
+		return originalURL;
 	}
 	
 	/**

--- a/src/main/java/com/laytonsmith/core/Main.java
+++ b/src/main/java/com/laytonsmith/core/Main.java
@@ -5,9 +5,9 @@ import com.laytonsmith.PureUtilities.ArgumentSuite;
 import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscovery;
 import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscoveryCache;
 import com.laytonsmith.PureUtilities.Common.FileUtil;
-import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.PureUtilities.Common.Misc;
 import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
+import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.PureUtilities.ZipReader;
 import com.laytonsmith.abstraction.Implementation;
 import com.laytonsmith.annotations.api;
@@ -17,7 +17,11 @@ import com.laytonsmith.core.functions.FunctionBase;
 import com.laytonsmith.core.functions.FunctionList;
 import com.laytonsmith.persistence.PersistenceNetwork;
 import com.laytonsmith.persistence.io.ConnectionMixinFactory;
-import com.laytonsmith.tools.*;
+import com.laytonsmith.tools.ExampleLocalPackageInstaller;
+import com.laytonsmith.tools.Interpreter;
+import com.laytonsmith.tools.MSLPMaker;
+import com.laytonsmith.tools.Manager;
+import com.laytonsmith.tools.SyntaxHighlighters;
 import com.laytonsmith.tools.docgen.DocGen;
 import com.laytonsmith.tools.docgen.DocGenExportTool;
 import com.laytonsmith.tools.docgen.DocGenUI;
@@ -297,6 +301,7 @@ public class Main {
 						}, " // "));
 				System.exit(0);
 			} else if (mode == syntaxMode) {
+				// TODO: Maybe load extensions here?
 				List<String> syntax = parsedArgs.getStringListArgument();
 				String type = (syntax.size() >= 1 ? syntax.get(0) : null);
 				String theme = (syntax.size() >= 2 ? syntax.get(1) : null);


### PR DESCRIPTION
Tested with jars with jarInfo.ser, as well as ones without. Also correctly works for running from source (returns the /classes/ directory)
