### PR TITLE
Don't fail on non-Bukkit entity.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -1,5 +1,4 @@
 
-
 package com.laytonsmith.abstraction.bukkit;
 
 import com.laytonsmith.PureUtilities.DaemonManager;
@@ -481,15 +480,18 @@ public class BukkitConvertor extends AbstractConvertor {
             return new BukkitMCLivingEntity(((LivingEntity)be));
         }
         
-        throw new Error("While trying to find the correct entity type for " + be.getClass().getName() + ", was unable"
-                + " to find the appropriate implementation. Please alert the developers of this stack trace.");
+        throw new Error("Entity not known to Bukkit.");
     }
 
 	@Override
     public MCEntity GetCorrectEntity(MCEntity e) {
 
         Entity be = ((BukkitMCEntity)e).asEntity();
-        return BukkitConvertor.BukkitGetCorrectEntity(be);
+        try {
+        	return BukkitConvertor.BukkitGetCorrectEntity(be);
+        } catch (Error err) {
+        	return e;
+        }
     }
 
 	@Override


### PR DESCRIPTION
Previously, any modded entity that was non-living, non-hanging, and non-vehicular was incompatible with most entity functions and events. However just because Bukkit doesn't know about them doesn't mean they are invalid. All the previous handling was doing was being a nuisance to modded servers.
