### PR TITLE
Update for latest changes to projectiles.

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -13,14 +13,14 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.compile.on.save>none</netbeans.compile.on.save>
+        <netbeans.compile.on.save>all</netbeans.compile.on.save>
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
         <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>4</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
         <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>120</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
         <com-junichi11-netbeans-changelf.use-project>true</com-junichi11-netbeans-changelf.use-project>
         <com-junichi11-netbeans-changelf.enable>true</com-junichi11-netbeans-changelf.enable>
@@ -34,5 +34,6 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>
+		<netbeans.hint.licensePath>LICENSE.txt</netbeans.hint.licensePath>
     </properties>
 </project-shared-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
 		</contributor>
 	</contributors>
 	<issueManagement>
-		<system>sk89q's Redmine</system>
-		<url>http://redmine.sk89q.com/projects/commandhelper/</url>
+		<system>sk89q's Youtrack</system>
+		<url>http://youtrack.sk89q.com/issues/CMDHELPER</url>
 	</issueManagement>
 	<ciManagement>
 		<system>TeamCity</system>
@@ -177,7 +177,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.7.2-R0.1-SNAPSHOT</version>
+			<version>1.7.2-R0.3-SNAPSHOT</version>
 		</dependency>
         
 		<!-- CraftBukkit Dependency for experimental features

--- a/src/main/java/com/laytonsmith/abstraction/MCEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCEntity.java
@@ -13,63 +13,6 @@ import java.util.UUID;
  * @author layton
  */
 public interface MCEntity extends MCMetadatable {
-	public static class Velocity {
-		public double magnitude;
-		public double x;
-		public double y;
-		public double z;
-
-		public Velocity(double x, double y, double z){
-			this(Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2) + Math.pow(z, 2)), x, y, z);
-		}
-		public Velocity(double magnitude, double x, double y, double z) {
-			this.magnitude = magnitude;
-			this.x = x;
-			this.y = y;
-			this.z = z;
-		}
-
-		public Velocity add(Velocity vec) {
-			this.x += vec.x;
-			this.y += vec.y;
-			this.z += vec.z;
-			return this;
-		}
-
-		public Velocity multiply(Velocity vec) {
-			this.x *= vec.x;
-			this.y *= vec.y;
-			this.z *= vec.z;
-			return this;
-		}
-
-		public Velocity multiply(double m) {
-			this.x *= m;
-			this.y *= m;
-			this.z *= m;
-			return this;
-		}
-
-		public Velocity normalize() {
-			double length = length();
-
-			this.x /= length;
-			this.y /= length;
-			this.z /= length;
-			return this;
-		}
-
-		public Velocity subtract(Velocity vec) {
-			this.x -= vec.x;
-			this.y -= vec.y;
-			this.z -= vec.z;
-			return this;
-		}
-
-		public double length() {
-			return Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2) + Math.pow(this.z, 2));
-		}
-	}
 
 	public boolean eject();
 

--- a/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
@@ -2,7 +2,6 @@
 package com.laytonsmith.abstraction;
 
 import com.laytonsmith.abstraction.blocks.MCBlock;
-import com.laytonsmith.abstraction.enums.MCProjectileType;
 import com.laytonsmith.core.constructs.Target;
 import java.util.HashSet;
 import java.util.List;
@@ -11,7 +10,7 @@ import java.util.List;
  *
  * @author layton
  */
-public interface MCLivingEntity extends MCEntity {
+public interface MCLivingEntity extends MCEntity, MCProjectileSource {
 
 	public void addEffect(int potionID, int strength, int seconds, boolean ambient, Target t);
 	public boolean removeEffect(int potionID);
@@ -47,7 +46,6 @@ public interface MCLivingEntity extends MCEntity {
     public int getRemainingAir();
 	public boolean isCustomNameVisible();
 	public boolean isLeashed();
-    public MCProjectile launchProjectile(MCProjectileType projectile);
 	public void resetMaxHealth();
 	public void setCanPickupItems(boolean pickup);
 	public void setRemoveWhenFarAway(boolean remove);

--- a/src/main/java/com/laytonsmith/abstraction/MCLocation.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLocation.java
@@ -1,7 +1,7 @@
 
 package com.laytonsmith.abstraction;
 
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 
 /**

--- a/src/main/java/com/laytonsmith/abstraction/MCProjectile.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCProjectile.java
@@ -7,7 +7,7 @@ package com.laytonsmith.abstraction;
  */
 public interface MCProjectile extends MCEntity, MCMetadatable {
 	public boolean doesBounce();
-	public MCLivingEntity getShooter();
+	public MCProjectileSource getShooter();
 	public void setBounce(boolean doesBounce);
-	public void setShooter(MCLivingEntity shooter);
+	public void setShooter(MCProjectileSource shooter);
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCProjectileSource.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCProjectileSource.java
@@ -1,0 +1,14 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.Velocity;
+import com.laytonsmith.abstraction.enums.MCProjectileType;
+
+/**
+ *
+ * @author jb_aero
+ */
+public interface MCProjectileSource extends AbstractionObject {
+	
+	public MCProjectile launchProjectile(MCProjectileType projectile);
+	public MCProjectile launchProjectile(MCProjectileType projectile, Velocity init);
+}

--- a/src/main/java/com/laytonsmith/abstraction/Velocity.java
+++ b/src/main/java/com/laytonsmith/abstraction/Velocity.java
@@ -1,0 +1,63 @@
+package com.laytonsmith.abstraction;
+
+/**
+ *
+ * @author layton
+ */
+public class Velocity {
+	public double magnitude;
+	public double x;
+	public double y;
+	public double z;
+
+	public Velocity(double x, double y, double z) {
+		this(Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2) + Math.pow(z, 2)), x, y, z);
+	}
+
+	public Velocity(double magnitude, double x, double y, double z) {
+		this.magnitude = magnitude;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public Velocity add(Velocity vec) {
+		this.x += vec.x;
+		this.y += vec.y;
+		this.z += vec.z;
+		return this;
+	}
+
+	public Velocity multiply(Velocity vec) {
+		this.x *= vec.x;
+		this.y *= vec.y;
+		this.z *= vec.z;
+		return this;
+	}
+
+	public Velocity multiply(double m) {
+		this.x *= m;
+		this.y *= m;
+		this.z *= m;
+		return this;
+	}
+
+	public Velocity normalize() {
+		double length = length();
+		this.x /= length;
+		this.y /= length;
+		this.z /= length;
+		return this;
+	}
+
+	public Velocity subtract(Velocity vec) {
+		this.x -= vec.x;
+		this.y -= vec.y;
+		this.z -= vec.z;
+		return this;
+	}
+
+	public double length() {
+		return Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2) + Math.pow(this.z, 2));
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCBlockProjectileSource.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCBlockProjectileSource.java
@@ -1,0 +1,12 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCProjectileSource;
+
+/**
+ *
+ * @author jb_aero
+ */
+public interface MCBlockProjectileSource extends MCProjectileSource {
+	
+	public MCBlock getBlock();
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -32,6 +32,7 @@ import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEnderDragon;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEnderDragonPart;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEnderSignal;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEnderman;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEntityProjectileSource;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFirework;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFishHook;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCHorse;
@@ -62,7 +63,10 @@ import com.laytonsmith.abstraction.enums.MCRecipeType;
 import com.laytonsmith.abstraction.enums.MCTone;
 import com.laytonsmith.annotations.convert;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
+import com.laytonsmith.core.CHLog;
+import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.Static;
+import com.laytonsmith.core.constructs.Target;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -139,6 +143,7 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.material.MaterialData;
+import org.bukkit.projectiles.ProjectileSource;
 
 /**
  *
@@ -480,17 +485,28 @@ public class BukkitConvertor extends AbstractConvertor {
         if(be instanceof LivingEntity){
             return new BukkitMCLivingEntity(((LivingEntity)be));
         }
-        
-        throw new Error("While trying to find the correct entity type for " + be.getClass().getName() + ", was unable"
-                + " to find the appropriate implementation. Please alert the developers of this stack trace.");
-    }
+		
+		if (be instanceof ProjectileSource) {
+			return new BukkitMCEntityProjectileSource(be);
+		}
+		
+		throw new IllegalArgumentException("While trying to find the correct entity type for " + be.getClass().getName()
+				+ ", was unable to find the appropriate implementation. If the named entity is not provided by mods,"
+				+ " please alert the developers of this stack trace. This is not necessarily an error,"
+				+ " we just don't have any special handling for this entity yet, and will treat it generically.");
+	}
 
 	@Override
-    public MCEntity GetCorrectEntity(MCEntity e) {
+	public MCEntity GetCorrectEntity(MCEntity e) {
 
-        Entity be = ((BukkitMCEntity)e).asEntity();
-        return BukkitConvertor.BukkitGetCorrectEntity(be);
-    }
+		Entity be = ((BukkitMCEntity)e).asEntity();
+		try {
+			return BukkitConvertor.BukkitGetCorrectEntity(be);
+		} catch (IllegalArgumentException iae) {
+			CHLog.GetLogger().Log(CHLog.Tags.RUNTIME, LogLevel.INFO, iae.getMessage(), Target.UNKNOWN);
+			return e;
+		}
+	}
 
 	@Override
 	public MCItemMeta GetCorrectMeta(MCItemMeta im) {

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireball.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireball.java
@@ -1,6 +1,7 @@
 package com.laytonsmith.abstraction.bukkit;
 
 import com.laytonsmith.abstraction.MCFireball;
+import com.laytonsmith.abstraction.Velocity;
 import org.bukkit.entity.Fireball;
 import org.bukkit.util.Vector;
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLivingEntity.java
@@ -6,10 +6,9 @@ import com.laytonsmith.abstraction.MCEntityEquipment;
 import com.laytonsmith.abstraction.MCLivingEntity;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
-import com.laytonsmith.abstraction.MCProjectile;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
-import com.laytonsmith.abstraction.enums.MCProjectileType;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEntityProjectileSource;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -22,10 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Creature;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -35,7 +31,7 @@ import org.bukkit.util.BlockIterator;
  *
  * @author layton
  */
-public class BukkitMCLivingEntity extends BukkitMCEntity implements MCLivingEntity {
+public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource implements MCLivingEntity {
 
 	LivingEntity le;
 
@@ -276,21 +272,6 @@ public class BukkitMCLivingEntity extends BukkitMCEntity implements MCLivingEnti
 			effects.add(e);
 		}
 		return effects;
-	}
-
-	@Override
-	public MCProjectile launchProjectile(MCProjectileType projectile) {
-		EntityType et = EntityType.valueOf(projectile.name());
-		Class<? extends Entity> c = et.getEntityClass();
-		Projectile proj = le.launchProjectile(c.asSubclass(Projectile.class));
-
-		MCEntity e = BukkitConvertor.BukkitGetCorrectEntity(proj);
-
-		if (e instanceof MCProjectile) {
-			return (MCProjectile) e;
-		} else {
-			return null;
-		}
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLocation.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLocation.java
@@ -2,7 +2,7 @@ package com.laytonsmith.abstraction.bukkit;
 
 import com.laytonsmith.abstraction.AbstractionObject;
 import com.laytonsmith.abstraction.MCChunk;
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.blocks.MCBlock;

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCProjectile.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCProjectile.java
@@ -3,7 +3,12 @@ package com.laytonsmith.abstraction.bukkit;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCLivingEntity;
 import com.laytonsmith.abstraction.MCProjectile;
+import com.laytonsmith.abstraction.MCProjectileSource;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlockProjectileSource;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
+import org.bukkit.projectiles.BlockProjectileSource;
+import org.bukkit.projectiles.ProjectileSource;
 
 public class BukkitMCProjectile extends BukkitMCEntity implements MCProjectile {
 	
@@ -19,11 +24,18 @@ public class BukkitMCProjectile extends BukkitMCEntity implements MCProjectile {
 	}
 
 	@Override
-	public MCLivingEntity getShooter() {
-		MCEntity e = BukkitConvertor.BukkitGetCorrectEntity(proj.getShooter());
+	public MCProjectileSource getShooter() {
+		ProjectileSource source = proj.getShooter();
 		
-		if (e instanceof MCLivingEntity) {
-			return (MCLivingEntity)e;
+		if (source instanceof BlockProjectileSource) {
+			return new BukkitMCBlockProjectileSource((BlockProjectileSource) source);
+		}
+		
+		if (source instanceof Entity) {
+			MCEntity e = BukkitConvertor.BukkitGetCorrectEntity((Entity) source);
+			if (e instanceof MCProjectileSource) {
+				return (MCProjectileSource) e;
+			}
 		}
 		
 		return null;
@@ -35,11 +47,11 @@ public class BukkitMCProjectile extends BukkitMCEntity implements MCProjectile {
 	}
 
 	@Override
-	public void setShooter(MCLivingEntity shooter) {
-		proj.setShooter(((BukkitMCLivingEntity)shooter).asLivingEntity());
+	public void setShooter(MCProjectileSource shooter) {
+		proj.setShooter((ProjectileSource) shooter.getHandle());
 	}
 
-    public Projectile asProjectile() {
-        return proj;
-    }
+	public Projectile asProjectile() {
+		return proj;
+	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBlockProjectileSource.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBlockProjectileSource.java
@@ -1,0 +1,67 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCProjectile;
+import com.laytonsmith.abstraction.Velocity;
+import com.laytonsmith.abstraction.blocks.MCBlock;
+import com.laytonsmith.abstraction.blocks.MCBlockProjectileSource;
+import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
+import com.laytonsmith.abstraction.enums.MCProjectileType;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Projectile;
+import org.bukkit.projectiles.BlockProjectileSource;
+import org.bukkit.util.Vector;
+
+/**
+ *
+ * @author jb_aero
+ */
+public class BukkitMCBlockProjectileSource implements MCBlockProjectileSource {
+
+	BlockProjectileSource bps;
+	public BukkitMCBlockProjectileSource(BlockProjectileSource source) {
+		bps = source;
+	}
+	
+	@Override
+	public MCProjectile launchProjectile(MCProjectileType projectile) {
+		EntityType et = EntityType.valueOf(projectile.name());
+		Class<? extends Entity> c = et.getEntityClass();
+		Projectile proj = bps.launchProjectile(c.asSubclass(Projectile.class));
+
+		MCEntity e = BukkitConvertor.BukkitGetCorrectEntity(proj);
+
+		if (e instanceof MCProjectile) {
+			return (MCProjectile) e;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public MCProjectile launchProjectile(MCProjectileType projectile, Velocity init) {
+		EntityType et = EntityType.valueOf(projectile.name());
+		Class<? extends Entity> c = et.getEntityClass();
+		Vector vector = new Vector(init.x, init.y, init.z);
+		Projectile proj = bps.launchProjectile(c.asSubclass(Projectile.class), vector);
+
+		MCEntity e = BukkitConvertor.BukkitGetCorrectEntity(proj);
+
+		if (e instanceof MCProjectile) {
+			return (MCProjectile) e;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public MCBlock getBlock() {
+		return new BukkitMCBlock(bps.getBlock());
+	}
+
+	@Override
+	public Object getHandle() {
+		return bps;
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntityProjectileSource.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntityProjectileSource.java
@@ -1,0 +1,63 @@
+package com.laytonsmith.abstraction.bukkit.entities;
+
+import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCProjectile;
+import com.laytonsmith.abstraction.MCProjectileSource;
+import com.laytonsmith.abstraction.Velocity;
+import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
+import com.laytonsmith.abstraction.bukkit.BukkitMCEntity;
+import com.laytonsmith.abstraction.enums.MCProjectileType;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Projectile;
+import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.util.Vector;
+
+/**
+ * Workaround class to accommodate for the likelihood of non-living entities that can shoot stuff.
+ * Why did I bother doing this? Because such things already exist.
+ * 
+ * @author jb_aero
+ */
+public class BukkitMCEntityProjectileSource extends BukkitMCEntity implements MCProjectileSource {
+
+	ProjectileSource eps;
+	public BukkitMCEntityProjectileSource(Entity source) {
+		super(source);
+		if (!(source instanceof ProjectileSource)) {
+			throw new IllegalArgumentException("Tried to construct BukkitMCEntityProjectileSource from invalid source.");
+		}
+		eps = (ProjectileSource) source;
+	}
+	
+	@Override
+	public MCProjectile launchProjectile(MCProjectileType projectile) {
+		EntityType et = EntityType.valueOf(projectile.name());
+		Class<? extends Entity> c = et.getEntityClass();
+		Projectile proj = eps.launchProjectile(c.asSubclass(Projectile.class));
+
+		MCEntity mcproj = BukkitConvertor.BukkitGetCorrectEntity(proj);
+
+		if (mcproj instanceof MCProjectile) {
+			return (MCProjectile) mcproj;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public MCProjectile launchProjectile(MCProjectileType projectile, Velocity init) {
+		EntityType et = EntityType.valueOf(projectile.name());
+		Class<? extends Entity> c = et.getEntityClass();
+		Vector vector = new Vector(init.x, init.y, init.z);
+		Projectile proj = eps.launchProjectile(c.asSubclass(Projectile.class), vector);
+
+		MCEntity mcproj = BukkitConvertor.BukkitGetCorrectEntity(proj);
+
+		if (mcproj instanceof MCProjectile) {
+			return (MCProjectile) mcproj;
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
@@ -3,7 +3,7 @@
 package com.laytonsmith.abstraction.bukkit.events;
 
 import com.laytonsmith.abstraction.*;
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCBlockState;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
@@ -290,7 +290,7 @@ public class BukkitBlockEvents {
 		}
 
 		@Override
-		public void setVelocity(MCEntity.Velocity vel) {
+		public void setVelocity(Velocity vel) {
 			Vector v = new Vector(vel.x, vel.y, vel.z);
 			bde.setVelocity(v);
 		}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockDispenseEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockDispenseEvent.java
@@ -1,6 +1,6 @@
 package com.laytonsmith.abstraction.events;
 
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.MCItemStack;
 
 /**

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -20,6 +20,7 @@ import com.laytonsmith.abstraction.MCShapelessRecipe;
 import com.laytonsmith.abstraction.MCSkullMeta;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.enums.MCRecipeType;
 import com.laytonsmith.core.constructs.CArray;
@@ -638,7 +639,7 @@ public class ObjectGenerator {
 		}
 	}
 	
-	public CArray velocity(MCEntity.Velocity v, Target t) {
+	public CArray velocity(Velocity v, Target t) {
 		double x,y,z,mag;
 		x = y = z = mag = 0;
 		if (v != null) {
@@ -655,7 +656,7 @@ public class ObjectGenerator {
 		return ret;
 	}
 
-	public MCEntity.Velocity velocity(Construct c, Target t) {
+	public Velocity velocity(Construct c, Target t) {
 		CArray va;
 		double x, y, z, mag;
 		x = y = z = mag = 0;
@@ -685,7 +686,7 @@ public class ObjectGenerator {
 					x = Static.getDouble(va.get(0), t);
 				}
 			}
-			return new MCEntity.Velocity(mag, x, y, z);
+			return new Velocity(mag, x, y, z);
 		} else {
 			throw new Exceptions.FormatException("Expected an array but recieved " + c, t);
 		}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -7,7 +7,7 @@ import com.laytonsmith.abstraction.MCBlockCommandSender;
 import com.laytonsmith.abstraction.MCChunk;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCEntity;
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.MCEntityEquipment;
 import com.laytonsmith.abstraction.MCExperienceOrb;
 import com.laytonsmith.abstraction.MCFireball;
@@ -21,11 +21,13 @@ import com.laytonsmith.abstraction.MCMaterialData;
 import com.laytonsmith.abstraction.MCPainting;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCProjectile;
+import com.laytonsmith.abstraction.MCProjectileSource;
 import com.laytonsmith.abstraction.MCTNT;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCBlockFace;
+import com.laytonsmith.abstraction.blocks.MCBlockProjectileSource;
 import com.laytonsmith.abstraction.blocks.MCFallingBlock;
 import com.laytonsmith.abstraction.entities.MCBoat;
 import com.laytonsmith.abstraction.entities.MCCreeper;
@@ -2814,7 +2816,9 @@ public class EntityManagement {
 
 		@Override
 		public String docs() {
-			return "int {entityID} Returns the shooter of the given projectile, can be null.";
+			return "mixed {entityID} Returns the shooter of the given projectile, can be null."
+					+ " If the shooter is an entity, that entity's ID will be return, but if it is a block,"
+					+ " that block's location will be returned.";
 		}
 
 		@Override
@@ -2823,10 +2827,12 @@ public class EntityManagement {
 			MCEntity entity = Static.getEntity(id, t);
 			
 			if (entity instanceof MCProjectile) {
-				MCLivingEntity shooter = ((MCProjectile) entity).getShooter();
+				MCProjectileSource shooter = ((MCProjectile) entity).getShooter();
 				
-				if (shooter != null) {
-					return new CInt(shooter.getEntityId(), t);
+				if (shooter instanceof MCBlockProjectileSource) {
+					return ObjectGenerator.GetGenerator().location(((MCBlockProjectileSource) shooter).getBlock().getLocation());
+				} else if (shooter instanceof MCEntity) {
+					return new CInt(((MCEntity) shooter).getEntityId(), t);
 				} else {
 					return new CNull(t);
 				}
@@ -2857,9 +2863,15 @@ public class EntityManagement {
 			if (entity instanceof MCProjectile) {
 				if (args[1] instanceof CNull) {
 					((MCProjectile) entity).setShooter(null);
+				} else if (args[1] instanceof CInt) {
+  					int id2 = Static.getInt32(args[1], t);
+  					((MCProjectile) entity).setShooter(Static.getLivingEntity(id2, t));
+				} else if (args[1] instanceof CArray) {
+					throw new ConfigRuntimeException("Setting a block as a shooter is not yet supported",
+							ExceptionType.FormatException, t);
 				} else {
-					int id2 = Static.getInt32(args[1], t);
-					((MCProjectile) entity).setShooter(Static.getLivingEntity(id2, t));
+					throw new ConfigRuntimeException("Unable to determine intended shooter from arg 2.",
+							ExceptionType.FormatException, t);
 				}
 			} else {
 				throw new ConfigRuntimeException("The given entity is not a projectile.", ExceptionType.BadEntityException, t);

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -3466,7 +3466,7 @@ public class PlayerManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 			CArray vector = CArray.GetAssociativeArray(t);
-			MCPlayer.Velocity velocity = p.getVelocity();
+			Velocity velocity = p.getVelocity();
 			vector.set("magnitude", new CDouble(velocity.magnitude, t), t);
 			vector.set("x", new CDouble(velocity.x, t), t);
 			vector.set("y", new CDouble(velocity.y, t), t);
@@ -3537,7 +3537,7 @@ public class PlayerManagement {
 				default:
 					throw new RuntimeException();
 			}
-			MCEntity.Velocity v = new MCEntity.Velocity(x, y, z);
+			Velocity v = new Velocity(x, y, z);
 			if (v.magnitude > 10) {
 				CHLog.GetLogger().Log(CHLog.Tags.GENERAL, LogLevel.WARNING,
 						"The call to " + getName() + " has been cancelled, because the magnitude was greater than 10."

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -3,7 +3,7 @@ package com.laytonsmith.core.functions;
 import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.abstraction.MCCommandSender;
-import com.laytonsmith.abstraction.MCEntity.Velocity;
+import com.laytonsmith.abstraction.Velocity;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;


### PR DESCRIPTION
Recent additions to Bukkit included distinction of ProjectileSource,
which can be an entity or a dispenser (or through modding, other
blocks). The previous behavior was CH treated projectile sources as
either an entity or null. This commit accommodates the new handling.
