### PR TITLE
Update descriptions for /reloadaliases flags

### DIFF
--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -282,7 +282,7 @@ public class AliasCore {
 		reloadOptions = ArgumentParser.GetParser().addFlag("whitelist", "Sets the list of arguments to be a whitelist, that is,"
 				+ " only the specified modules get reloaded, the rest will be skipped. Without this option, the specified modules"
 				+ " don't get reloaded.")
-				.addFlag('g', "globals", "Specifies that globals memory (values stored with export/import) should be preserved")
+				.addFlag('g', "globals", "Specifies that globals memory (values stored with export/import) should be preserved.")
 				.addFlag('t', "tasks", "Specifies that tasks registered with set_interval/set_timeout should be preserved.")
 				.addFlag('e', "execution-queue", "Specifies that tasks registered in execution queues should be preserved.")
 				.addFlag('r', "persistence-config", "Specifies that the persistence config file should not be reloaded.")


### PR DESCRIPTION
Descriptions for some /reloadaliases flags are inconsistent with actual usage.

For example, "-r: Specifies that the persistence config file should be reloaded." however, -r prevents the persistence config file from being reloaded unless --whitelist is specified.

This contrasts with other flags whose descriptions are correct, i.e. "-s: Specifies that the scripts should not be reloaded."

Updated descriptions to be correct and consistent with actual usage and each other.
