### PR TITLE
Refactored sk_region_create so that it works as described.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/WorldEdit.java
+++ b/src/main/java/com/laytonsmith/core/functions/WorldEdit.java
@@ -974,19 +974,18 @@ public class WorldEdit {
 			if ("__global__".equalsIgnoreCase(region)) {
 				newRegion = new GlobalProtectedRegion(region);
 			} else {
+				if (verticies.size() == 2) {
+					newRegion = new ProtectedCuboidRegion(region, verticies.get(0), verticies.get(1));
+				} else {
 
-				List<BlockVector> pointsCuboid = new ArrayList<>();
-				List<BlockVector2D> pointsPoly = new ArrayList<>();
-				int minY = 0;
-				int maxY = 0;
+					List<BlockVector2D> pointsPoly = new ArrayList<>();
+					int minY = 0;
+					int maxY = 0;
 
-				for (int i = 0; i < verticies.size(); i++) {
+					for (int i = 0; i < verticies.size(); i++) {
 
-					BlockVector vector = verticies.get(i);
+						BlockVector vector = verticies.get(i);
 
-					if (verticies.size() == 2) {
-						pointsCuboid.add(vector);
-					} else {
 						int x = vector.getBlockX();
 						int y = vector.getBlockY();
 						int z = vector.getBlockZ();
@@ -1003,11 +1002,6 @@ public class WorldEdit {
 							}
 						}
 					}
-				}
-
-				if (verticies.size() == 2) {
-					newRegion = new ProtectedCuboidRegion(region, pointsCuboid.get(0), pointsCuboid.get(1));
-				} else {
 					newRegion = new ProtectedPolygonalRegion(region, pointsPoly, minY, maxY);
 				}
 


### PR DESCRIPTION
The function was giving me an error when I gave it arrays without a world (even though the original code ignores any world in the location arrays anyway).

The problem was with "MCLocation point = ObjectGenerator.GetGenerator().location(arg.get(i, t), null, t);" (old line 924). If no world was included in arg.get(i, t) then an error is thrown. I've fixed that problem by copying the useful code from the location generator and avoiding the world == null error. New lines 893 - 911.

I've also taken the opportunity to refactor the entire function so that now it can get the world from the location arrays too. It will go in the priority of: Defined world at arg[0] > defined world in LocationArrays > CommandSender's world > error thrown.

I've also directed the function to use the abstraction layer instead of accessing bukkit directly.

Netbeans suggested the use of "ProtectionDatabaseException" on line 1017.
