### PR TITLE
Add ItemArray conversion for the string name.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/Convertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/Convertor.java
@@ -37,15 +37,23 @@ public interface Convertor {
 
     public MCServer GetServer();
 
-    public MCItemStack GetItemStack(int type, int qty);
+	public MCItemStack GetItemStack(int type, int qty);
+
+	public MCItemStack GetItemStack(int type, int data, int qty);
+
+	public MCItemStack GetItemStack(MCMaterial type, int qty);
+
+	public MCItemStack GetItemStack(MCMaterial type, int data, int qty);
+
+	public MCItemStack GetItemStack(String type, int qty);
+
+	public MCItemStack GetItemStack(String type, int data, int qty);
 
     public void Startup(CommandHelperPlugin chp);
 
     public int LookupItemId(String materialName);
 
     public String LookupMaterialName(int id);
-
-    public MCItemStack GetItemStack(int type, int data, int qty);
 
 	public MCMaterial getMaterial(int id);
 

--- a/src/main/java/com/laytonsmith/abstraction/StaticLayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/StaticLayer.java
@@ -60,13 +60,29 @@ public final class StaticLayer {
         return GetLocation(w, x, y, z, 0, 0);
     }
 
-    public static MCItemStack GetItemStack(int type, int qty) {
-        return convertor.GetItemStack(type, qty);
-    }
-    
-    public static MCItemStack GetItemStack(int type, int data, int qty){
-        return convertor.GetItemStack(type, data, qty);
-    }
+	public static MCItemStack GetItemStack(int type, int qty) {
+		return convertor.GetItemStack(type, qty);
+	}
+
+	public static MCItemStack GetItemStack(int type, int data, int qty){
+		return convertor.GetItemStack(type, data, qty);
+	}
+
+	public static MCItemStack GetItemStack(String type, int qty) {
+		return convertor.GetItemStack(type, qty);
+	}
+
+	public static MCItemStack GetItemStack(String type, int data, int qty){
+		return convertor.GetItemStack(type, data, qty);
+	}
+
+	public static MCItemStack GetItemStack(MCMaterial type, int qty) {
+		return convertor.GetItemStack(type, qty);
+	}
+
+	public static MCItemStack GetItemStack(MCMaterial type, int data, int qty){
+		return convertor.GetItemStack(type, data, qty);
+	}
     
     public static MCServer GetServer(){
         return convertor.GetServer();

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCMaterial.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCMaterial.java
@@ -2,13 +2,14 @@
 
 package com.laytonsmith.abstraction.blocks;
 
+import com.laytonsmith.abstraction.AbstractionObject;
 import com.laytonsmith.abstraction.MCMaterialData;
 
 /**
  *
  * 
  */
-public interface MCMaterial {
+public interface MCMaterial extends AbstractionObject {
     short getMaxDurability();
 
     public int getType();

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -226,7 +226,33 @@ public class BukkitConvertor extends AbstractConvertor {
 
 	@Override
 	public MCItemStack GetItemStack(int type, int data, int qty) {
-		return new BukkitMCItemStack(new ItemStack(type, qty, (short) 0, (byte) data));
+		return new BukkitMCItemStack(new ItemStack(type, qty, (short) data));
+	}
+
+	@Override
+	public MCItemStack GetItemStack(MCMaterial type, int qty) {
+		return new BukkitMCItemStack(new ItemStack(((BukkitMCMaterial) type).getHandle(), qty));
+	}
+
+	@Override
+	public MCItemStack GetItemStack(MCMaterial type, int data, int qty) {
+		return new BukkitMCItemStack(new ItemStack(((BukkitMCMaterial) type).getHandle(), qty, (short) data));
+	}
+
+	public MCItemStack GetItemStack(String type, int qty) {
+		Material mat = Material.matchMaterial(type);
+		if (mat == null) {
+			return null;
+		}
+		return new BukkitMCItemStack(new ItemStack(mat, qty));
+	}
+
+	public MCItemStack GetItemStack(String type, int data, int qty) {
+		Material mat = Material.matchMaterial(type);
+		if (mat == null) {
+			return null;
+		}
+		return new BukkitMCItemStack(new ItemStack(mat, qty, (short) data));
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCMaterial.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCMaterial.java
@@ -88,4 +88,9 @@ public class BukkitMCMaterial implements MCMaterial {
 	public boolean isTransparent() {
 		return m.isTransparent();
 	}
+
+	@Override
+	public Material getHandle() {
+		return m;
+	}
 }

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -109,7 +109,7 @@ public class StaticTest {
     /**
      * Tests the boilerplate functions in a Function. While all functions should conform to
      * at least this, it is useful to also use the more strict TestBoilerplate function.
-     * @param f
+     * @param ff
      */
     public static void TestBoilerplate(FunctionBase ff, String name) throws Exception {
         if(!(ff instanceof Function)){
@@ -618,7 +618,7 @@ public class StaticTest {
     }
 
     @convert(type=Implementation.Type.TEST)
-    public static class TestConvertor extends AbstractConvertor{
+    public static class TestConvertor extends AbstractConvertor {
 
         private static MCServer fakeServer;
 		private RunnableQueue queue = new RunnableQueue("TestConvertorRunnableQueue");
@@ -651,12 +651,6 @@ public class StaticTest {
         }
 
 		@Override
-        public MCItemStack GetItemStack(int type, int qty) {
-            Convertor c = new BukkitConvertor();
-            return c.GetItemStack(type, qty);
-        }
-
-		@Override
         public void Startup(CommandHelperPlugin chp) {
             //Nothing.
         }
@@ -672,10 +666,40 @@ public class StaticTest {
         }
 
 		@Override
-        public MCItemStack GetItemStack(int type, int data, int qty) {
-            Convertor c = new BukkitConvertor();
-            return c.GetItemStack(type, data, qty);
-        }
+		public MCItemStack GetItemStack(int type, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, qty);
+		}
+
+		@Override
+		public MCItemStack GetItemStack(int type, int data, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, data, qty);
+		}
+
+		@Override
+		public MCItemStack GetItemStack(MCMaterial type, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, qty);
+		}
+
+		@Override
+		public MCItemStack GetItemStack(MCMaterial type, int data, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, data, qty);
+		}
+
+		@Override
+		public MCItemStack GetItemStack(String type, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, qty);
+		}
+
+		@Override
+		public MCItemStack GetItemStack(String type, int data, int qty) {
+			Convertor c = new BukkitConvertor();
+			return c.GetItemStack(type, data, qty);
+		}
 
 		@Override
         public int SetFutureRunnable(DaemonManager dm, long ms, Runnable r) {


### PR DESCRIPTION
Since numerical item ids are deprecated, we should allow users to start using the name of the item as supported by the server implementation they are using. This commit allows ObjectGenerator to interpret a new field "name", containing the string ID of the item, and if it is present the old integer "type" will be ignored. ObjectGenerator will also write the "name" to any new item arrays it creates, but will continue to fill in "type" for compatibility.
