### PR TITLE
Allow disabling of potion particles

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
@@ -75,11 +75,21 @@ public interface MCLivingEntity extends MCEntity, MCProjectileSource {
 		private int strength;
 		private int secondsRemaining;
 		private boolean ambient;
+		private boolean particles;
 		public MCEffect(int potionID, int strength, int secondsRemaining, boolean ambient){
 			this.potionID = potionID;
 			this.strength = strength;
 			this.secondsRemaining = secondsRemaining;
 			this.ambient = ambient;
+			this.particles = true;
+		}
+
+		public MCEffect(int potionID, int strength, int secondsRemaining, boolean ambient, boolean particles){
+			this.potionID = potionID;
+			this.strength = strength;
+			this.secondsRemaining = secondsRemaining;
+			this.ambient = ambient;
+			this.particles = particles;
 		}
 
 		public int getPotionID() {
@@ -97,6 +107,8 @@ public interface MCLivingEntity extends MCEntity, MCProjectileSource {
 		public boolean isAmbient() {
 			return ambient;
 		}
+
+		public boolean hasParticles() { return particles; }
 
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
@@ -13,6 +13,7 @@ import java.util.List;
 public interface MCLivingEntity extends MCEntity, MCProjectileSource {
 
 	public void addEffect(int potionID, int strength, int seconds, boolean ambient, Target t);
+	public void addEffect(int potionID, int strength, int seconds, boolean ambient, boolean particles, Target t);
 	public boolean removeEffect(int potionID);
 	/**
 	 * Returns the maximum effect id, inclusive.

--- a/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
@@ -108,7 +108,9 @@ public interface MCLivingEntity extends MCEntity, MCProjectileSource {
 			return ambient;
 		}
 
-		public boolean hasParticles() { return particles; }
+		public boolean hasParticles() {
+			return particles;
+		}
 
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
@@ -221,6 +221,16 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 		}
 	}
 
+	/**
+	 * This calls the 5-param constructor for PotionEffect to disable particles entirely
+	 * @param potionID - ID of the potion
+	 * @param strength - potion strength
+	 * @param seconds - duration of the potion in seconds
+	 * @param ambient - make particles less noticable
+	 * @param particles - enable or disable particles entirely
+	 * @param t - target
+	 */
+	@Override
 	public void addEffect(int potionID, int strength, int seconds, boolean ambient, boolean particles, Target t) {
 		PotionEffect pe = new PotionEffect(PotionEffectType.getById(potionID), (int)Static.msToTicks(seconds * 1000),
 				strength, ambient, particles);

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
@@ -216,31 +216,22 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 				le.addPotionEffect(pe, true);
 			}
 		} catch(NullPointerException e){
-			//
 			Logger.getLogger(BukkitMCLivingEntity.class.getName()).log(Level.SEVERE,
 					"Bukkit appears to have derped. This is a problem with Bukkit, not CommandHelper. The effect should have still been applied.", e);
 		}
-//        EntityPlayer ep = ((CraftPlayer) p).getHandle();
-//        MobEffect me = new MobEffect(potionID, seconds * 20, strength);
-//        //ep.addEffect(me);
-//        //ep.b(me);
-//
-//        Class epc = EntityLiving.class;
-//        try {
-//            Method meth = epc.getDeclaredMethod("b", net.minecraft.server.MobEffect.class);
-//            //ep.d(new MobEffect(effect, seconds * 20, strength));
-//            //Call it reflectively, because it's deobfuscated in newer versions of CB
-//            meth.invoke(ep, me);
-//        } catch (Exception e) {
-//            try {
-//                //Look for the addEffect version
-//                Method meth = epc.getDeclaredMethod("addEffect", MobEffect.class);
-//                //ep.addEffect(me);
-//                meth.invoke(ep, me);
-//            } catch (Exception ex) {
-//                Logger.getLogger(BukkitMCPlayer.class.getName()).log(Level.SEVERE, null, ex);
-//            }
-//        }
+	}
+
+	public void addEffect(int potionID, int strength, int seconds, boolean ambient, boolean particles, Target t) {
+		PotionEffect pe = new PotionEffect(PotionEffectType.getById(potionID), (int)Static.msToTicks(seconds * 1000),
+				strength, ambient, particles);
+		try{
+			if(le != null){
+				le.addPotionEffect(pe, true);
+			}
+		} catch(NullPointerException e){
+			Logger.getLogger(BukkitMCLivingEntity.class.getName()).log(Level.SEVERE,
+					"Bukkit appears to have derped. This is a problem with Bukkit, not CommandHelper. The effect should have still been applied.", e);
+		}
 	}
 	
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
@@ -263,7 +263,7 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 		List<MCEffect> effects = new ArrayList<MCEffect>();
 		for(PotionEffect pe : le.getActivePotionEffects()){
 			MCEffect e = new MCEffect(pe.getType().getId(), pe.getAmplifier(), 
-					(int)(Static.ticksToMs(pe.getDuration()) / 1000), pe.isAmbient());
+					(int)(Static.ticksToMs(pe.getDuration()) / 1000), pe.isAmbient(), pe.hasParticles());
 			effects.add(e);
 		}
 		return effects;

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
@@ -11,6 +11,7 @@ import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
 import com.laytonsmith.abstraction.bukkit.BukkitMCEntityEquipment;
 import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
+import com.laytonsmith.abstraction.enums.MCVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -207,22 +208,7 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 		return blocks;
 	}
 
-	@Override
-	public void addEffect(int potionID, int strength, int seconds, boolean ambient, Target t) {
-		PotionEffect pe = new PotionEffect(PotionEffectType.getById(potionID), (int)Static.msToTicks(seconds * 1000), 
-				strength, ambient);
-		try{
-			if(le != null){
-				le.addPotionEffect(pe, true);
-			}
-		} catch(NullPointerException e){
-			Logger.getLogger(BukkitMCLivingEntity.class.getName()).log(Level.SEVERE,
-					"Bukkit appears to have derped. This is a problem with Bukkit, not CommandHelper. The effect should have still been applied.", e);
-		}
-	}
-
 	/**
-	 * This calls the 5-param constructor for PotionEffect to disable particles entirely
 	 * @param potionID - ID of the potion
 	 * @param strength - potion strength
 	 * @param seconds - duration of the potion in seconds
@@ -232,8 +218,14 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 	 */
 	@Override
 	public void addEffect(int potionID, int strength, int seconds, boolean ambient, boolean particles, Target t) {
-		PotionEffect pe = new PotionEffect(PotionEffectType.getById(potionID), (int)Static.msToTicks(seconds * 1000),
-				strength, ambient, particles);
+		PotionEffect pe;
+		if (Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_8)) {
+			pe = new PotionEffect(PotionEffectType.getById(potionID), (int)Static.msToTicks(seconds * 1000),
+					strength, ambient);
+		} else {
+			pe = new PotionEffect(PotionEffectType.getById(potionID), (int) Static.msToTicks(seconds * 1000),
+					strength, ambient, particles);
+		}
 		try{
 			if(le != null){
 				le.addPotionEffect(pe, true);
@@ -272,8 +264,14 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 	public List<MCEffect> getEffects(){
 		List<MCEffect> effects = new ArrayList<MCEffect>();
 		for(PotionEffect pe : le.getActivePotionEffects()){
-			MCEffect e = new MCEffect(pe.getType().getId(), pe.getAmplifier(), 
-					(int)(Static.ticksToMs(pe.getDuration()) / 1000), pe.isAmbient(), pe.hasParticles());
+			MCEffect e;
+			if (Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_8)) {
+				e = new MCEffect(pe.getType().getId(), pe.getAmplifier(),
+						(int) (Static.ticksToMs(pe.getDuration()) / 1000), pe.isAmbient(), true);
+			} else {
+				e = new MCEffect(pe.getType().getId(), pe.getAmplifier(),
+						(int)(Static.ticksToMs(pe.getDuration()) / 1000), pe.isAmbient(), pe.hasParticles());
+			}
 			effects.add(e);
 		}
 		return effects;

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -835,6 +835,7 @@ public class ObjectGenerator {
 			effect.set("strength", new CInt(eff.getStrength(), t), t);
 			effect.set("seconds", new CInt(eff.getSecondsRemaining(), t), t);
 			effect.set("ambient", CBoolean.get(eff.isAmbient()), t);
+			effect.set("particles", CBoolean.get(eff.hasParticles()), t);
 			ea.push(effect);
 		}
 		return ea;

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -848,6 +848,7 @@ public class ObjectGenerator {
 				CArray effect = (CArray) ea.get(key, t);
 				int potionID = 0, strength = 0, seconds = 30;
 				boolean ambient = false;
+				boolean particles = true;
 				if (effect.containsKey("id")) {
 					potionID = Static.getInt32(effect.get("id", t), t);
 				} else {
@@ -862,7 +863,14 @@ public class ObjectGenerator {
 				if (effect.containsKey("ambient")) {
 					ambient = Static.getBoolean(effect.get("ambient", t));
 				}
-				ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient));
+				if (effect.containsKey("particles")) {
+					particles = Static.getBoolean(effect.get("particles", t));
+				}
+				if (particles) {
+					ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient));
+				} else {
+					ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient, particles));
+				}
 			} else {
 				throw new Exceptions.FormatException("Expected a potion array at index" + key, t);
 			}

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -866,11 +866,7 @@ public class ObjectGenerator {
 				if (effect.containsKey("particles")) {
 					particles = Static.getBoolean(effect.get("particles", t));
 				}
-				if (particles) {
-					ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient));
-				} else {
-					ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient, particles));
-				}
+				ret.add(new MCLivingEntity.MCEffect(potionID, strength, seconds, ambient, particles));
 			} else {
 				throw new Exceptions.FormatException("Expected a potion array at index" + key, t);
 			}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -805,11 +805,7 @@ public class EntityManagement {
 			if (seconds == 0) {
 				return CBoolean.get(mob.removeEffect(effect));
 			} else {
-				if (particles) {
-					mob.addEffect(effect, strength, seconds, ambient, t);
-				} else {
-					mob.addEffect(effect, strength, seconds, ambient, particles, t);
-				}
+				mob.addEffect(effect, strength, seconds, ambient, particles, t);
 				return CBoolean.TRUE;
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -758,19 +758,21 @@ public class EntityManagement {
 
 		@Override
 		public Integer[] numArgs() {
-			return new Integer[]{3, 4, 5};
+			return new Integer[]{3, 4, 5, 6};
 		}
 
 		@Override
 		public String docs() {
-			return "boolean {entityId, potionID, strength, [seconds], [ambient]} Effect is 1-23. Seconds defaults to 30."
-					+ " If the potionID is out of range, a RangeException is thrown, because out of range potion effects"
-					+ " cause the client to crash, fairly hardcore. See http://www.minecraftwiki.net/wiki/Potion_effects"
-					+ " for a complete list of potions that can be added. To remove an effect, set the seconds to 0."
-					+ " Strength is the number of levels to add to the base power (effect level 1). Ambient takes a boolean"
-					+ " of whether the particles should be less noticeable. The function returns true if the effect was"
-					+ " added or removed as desired, and false if it wasn't (however, this currently only will happen if"
-					+ " an effect is attempted to be removed, yet isn't already on the mob).";
+			return "boolean {entityId, potionID, strength, [seconds], [ambient], [particles]} Effect is 1-23. Seconds"
+					+ " defaults to 30. If the potionID is out of range, a RangeException is thrown, because out of"
+					+ " range potion effects cause the client to crash, fairly hardcore. See"
+					+ " http://www.minecraftwiki.net/wiki/Potion_effects for a complete list of potions that can be"
+					+ " added. To remove an effect, set the seconds to 0. Strength is the number of levels to add to the"
+					+ " base power (effect level 1). Ambient takes a boolean of whether the particles should be less"
+					+ " noticeable. Particles takes a boolean of whether the particles should be visible at all. The"
+					+ " function returns true if the effect was added or removed as desired, and false if it wasn't"
+					+ " (however, this currently only will happen if an effect is attempted to be removed, yet isn't"
+					+ " already on the mob).";
 		}
 
 		@Override
@@ -789,17 +791,25 @@ public class EntityManagement {
 			int strength = Static.getInt32(args[2], t);
 			int seconds = 30;
 			boolean ambient = false;
+			boolean particles = true;
 			if (args.length >= 4) {
 				seconds = Static.getInt32(args[3], t);
 			}
 			if (args.length == 5) {
 				ambient = Static.getBoolean(args[4]);
 			}
+			if (args.length == 6) {
+				particles = Static.getBoolean(args[5]);
+			}
 
 			if (seconds == 0) {
 				return CBoolean.get(mob.removeEffect(effect));
 			} else {
-				mob.addEffect(effect, strength, seconds, ambient, t);
+				if (particles) {
+					mob.addEffect(effect, strength, seconds, ambient, t);
+				} else {
+					mob.addEffect(effect, strength, seconds, ambient, particles, t);
+				}
 				return CBoolean.TRUE;
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -2106,11 +2106,7 @@ public class PlayerManagement {
 			if (seconds == 0) {
 				return CBoolean.get(m.removeEffect(effect));
 			} else {
-				if (particles) {
-					m.addEffect(effect, strength, seconds, ambient, t);
-				} else {
-					m.addEffect(effect, strength, seconds, ambient, particles, t);
-				}
+				m.addEffect(effect, strength, seconds, ambient, particles, t);
 				return CBoolean.TRUE;
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -2170,7 +2170,8 @@ public class PlayerManagement {
 		public String docs() {
 			return "array {[player]} Returns an array of effects that are currently active on a given player."
 					+ " The array will be full of playerEffect objects, which contain three fields, \"id\","
-					+ " \"strength\", \"seconds\" remaining, and whether the effect is \"ambient\".";
+					+ " \"strength\", \"seconds\" remaining, whether the effect is \"ambient\", and whether"
+					+ " \"particles\" are enabled.";
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -2038,19 +2038,21 @@ public class PlayerManagement {
 
 		@Override
 		public Integer[] numArgs() {
-			return new Integer[]{3, 4, 5};
+			return new Integer[]{3, 4, 5, 6};
 		}
 
 		@Override
 		public String docs() {
-			return "boolean {player, potionID, strength, [seconds], [ambient]} Effect is 1-23. Seconds defaults to 30."
-					+ " If the potionID is out of range, a RangeException is thrown, because out of range potion effects"
-					+ " cause the client to crash, fairly hardcore. See http://www.minecraftwiki.net/wiki/Potion_effects"
-					+ " for a complete list of potions that can be added. To remove an effect, set the seconds to 0."
-					+ " Strength is the number of levels to add to the base power (effect level 1). Ambient takes a boolean"
-					+ " of whether the particles should be less noticeable. The function returns true if the effect was"
-					+ " added or removed as desired, and false if it wasn't (however, this currently only will happen if"
-					+ " an effect is attempted to be removed, yet isn't already on the player).";
+			return "boolean {player, potionID, strength, [seconds], [ambient], [particles]} Effect is 1-23."
+					+ " Seconds defaults to 30. If the potionID is out of range, a RangeException is thrown, because out"
+					+ " of range potion effects cause the client to crash, fairly hardcore. See"
+					+ " http://www.minecraftwiki.net/wiki/Potion_effects for a complete list of potions that can be"
+					+ " added. To remove an effect, set the seconds to 0. Strength is the number of levels to add to the"
+					+ " base power (effect level 1). Ambient takes a boolean of whether the particles should be less"
+					+ " noticeable. Particles takes a boolean of whether the particles should be visible at all. The"
+					+ " function returns true if the effect was added or removed as desired, and false if it wasn't"
+					+ " (however, this currently only will happen if an effect is attempted to be removed, yet isn't"
+					+ " already on the player).";
 		}
 
 		@Override
@@ -2090,17 +2092,25 @@ public class PlayerManagement {
 			int strength = Static.getInt32(args[2], t);
 			int seconds = 30;
 			boolean ambient = false;
+			boolean particles = true;
 			if (args.length >= 4) {
 				seconds = Static.getInt32(args[3], t);
 			}
 			if (args.length == 5) {
 				ambient = Static.getBoolean(args[4]);
 			}
+			if (args.length == 6) {
+				particles = Static.getBoolean(args[5]);
+			}
 			Static.AssertPlayerNonNull(m, t);
 			if (seconds == 0) {
 				return CBoolean.get(m.removeEffect(effect));
 			} else {
-				m.addEffect(effect, strength, seconds, ambient, t);
+				if (particles) {
+					m.addEffect(effect, strength, seconds, ambient, t);
+				} else {
+					m.addEffect(effect, strength, seconds, ambient, particles, t);
+				}
 				return CBoolean.TRUE;
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -2096,7 +2096,7 @@ public class PlayerManagement {
 			if (args.length >= 4) {
 				seconds = Static.getInt32(args[3], t);
 			}
-			if (args.length == 5) {
+			if (args.length >= 5) {
 				ambient = Static.getBoolean(args[4]);
 			}
 			if (args.length == 6) {


### PR DESCRIPTION
This allows an optional sixth parameter to `set_mob_effect()` and `set_peffect()` to configure whether particles are visible at all.  The `particles` value is also returned from `get_peffects()` and `get_mob_effects()` as a boolean.

Since I'm not 100% sure on backwards compatibility of the parameter inside Bukkit, the 5-parameter constructor for `PotionEffect` is only used if specifically requested.

Documentation has been added for all changes.