### PR TITLE
AliasCore GlobalEnv update (bugfix in set_uncaught_exception_handler())

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ true
 /preferences.*
 .DS_Store
 /test-backend/
+persistence.json

--- a/src/main/java/com/laytonsmith/PureUtilities/Common/MutableObject.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/Common/MutableObject.java
@@ -37,7 +37,7 @@ public final class MutableObject<T> {
 	 * @return
 	 */
 	public T getObject(){
-		return obj;
+		return this.obj;
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -75,6 +75,7 @@ public class AliasCore {
 	private Set<String> echoCommand = new HashSet<String>();
 	public List<File> autoIncludes;
 	public static CommandHelperPlugin parent;
+	private GlobalEnv globalEnv = null;
 
 	/**
 	 * This constructor accepts the configuration settings for the plugin, and
@@ -110,22 +111,22 @@ public class AliasCore {
 	 * @return
 	 */
 	public boolean alias(String command, final MCCommandSender player, List<Script> playerCommands) {
-
-		GlobalEnv gEnv;
-		try {
-			gEnv = new GlobalEnv(parent.executionQueue, parent.profiler, parent.persistenceNetwork,
-					MethodScriptFileLocations.getDefault().getConfigDirectory(),
-					new Profiles(MethodScriptFileLocations.getDefault().getSQLProfilesFile()),
-					new TaskManager());
-		} catch (IOException ex) {
-			Logger.getLogger(AliasCore.class.getName()).log(Level.SEVERE, null, ex);
-			return false;
-		} catch (Profiles.InvalidProfileException ex) {
-			throw ConfigRuntimeException.CreateUncatchableException(ex.getMessage(), Target.UNKNOWN);
+		if(this.globalEnv == null) {
+			try {
+				this.globalEnv = new GlobalEnv(parent.executionQueue, parent.profiler, parent.persistenceNetwork,
+						MethodScriptFileLocations.getDefault().getConfigDirectory(),
+						new Profiles(MethodScriptFileLocations.getDefault().getSQLProfilesFile()),
+						new TaskManager());
+			} catch (IOException ex) {
+				Logger.getLogger(AliasCore.class.getName()).log(Level.SEVERE, null, ex);
+				return false;
+			} catch (Profiles.InvalidProfileException ex) {
+				throw ConfigRuntimeException.CreateUncatchableException(ex.getMessage(), Target.UNKNOWN);
+			}
 		}
 		CommandHelperEnvironment cEnv = new CommandHelperEnvironment();
 		cEnv.SetCommandSender(player);
-		Environment env = Environment.createEnvironment(gEnv, cEnv);
+		Environment env = Environment.createEnvironment(this.globalEnv, cEnv);
 
 		if (player instanceof MCBlockCommandSender) {
 			cEnv.SetBlockCommandSender((MCBlockCommandSender) player);
@@ -833,4 +834,12 @@ public class AliasCore {
 			}
 		}
 	}
+	
+//	/**
+//	 * getGlobalEnv method.
+//	 * @return GlobalEnv - The global environment of this AliasCore.
+//	 */
+//	public GlobalEnv getGlobalEnv() {
+//		return this.globalEnv;
+//	}
 }

--- a/src/main/java/com/laytonsmith/core/environments/Environment.java
+++ b/src/main/java/com/laytonsmith/core/environments/Environment.java
@@ -99,8 +99,8 @@ public class Environment implements Cloneable {
 	public Environment clone() throws CloneNotSupportedException {
 		Environment clone = (Environment) super.clone();
 		clone.environments = new HashMap<>();
-		for(Class c : environments.keySet()){
-			clone.environments.put(c, environments.get(c).clone());
+		for(Class c : this.environments.keySet()){
+			clone.environments.put(c, this.environments.get(c).clone());
 		}
 		return clone;
 	}		

--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -184,6 +184,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 		if (iVariableList != null) {
 			clone.iVariableList = (IVariableList) iVariableList.clone();
 		}
+		clone.uncaughtExceptionHandler.setObject(this.uncaughtExceptionHandler.getObject());
 		return clone;
 	}
 


### PR DESCRIPTION
AliasCore's alias() method created a new GlobalEnv every time it was called. It will now keep using the same instance of GlobalEnv after the first alias() call.
