### PR TITLE
Added get_block_power and expanded is_block_powered.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCBlock.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCBlock.java
@@ -69,6 +69,8 @@ public interface MCBlock extends MCMetadatable {
 	public int getBlockPower();
 	
 	public boolean isBlockPowered();
+	
+	public boolean isBlockIndirectlyPowered();
 
 	public MCBlock getRelative(MCBlockFace face);
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBlock.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBlock.java
@@ -206,7 +206,12 @@ public class BukkitMCBlock extends BukkitMCMetadatable implements MCBlock {
 	
 	@Override
 	public boolean isBlockPowered() {
-		return b.isBlockIndirectlyPowered() || b.isBlockPowered();
+		return b.isBlockPowered();
+	}
+	
+	@Override
+	public boolean isBlockIndirectlyPowered() {
+		return b.isBlockIndirectlyPowered();
 	}
 
 	@Override


### PR DESCRIPTION
- get_block_power(locationArray) returns the redstone power supplied to
that block.
- is_block_powered(locationArray, [powerMode]) now has a powerMode
argument which can be used to select direct power, indirect power or
both (default to both, this was the previous behaviour).