### PR TITLE
Update ptexp() and set_ptexp() for 1.8

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
@@ -51,7 +51,11 @@ public interface MCPlayer extends MCCommandSender, MCHumanEntity,
 
 	public MCScoreboard getScoreboard();
 
-    public int getTotalExperience();
+	public int getTotalExperience();
+
+	public int getExpToLevel();
+
+	public int getExpAtLevel();
 
 	public float getWalkSpeed();
 	

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
@@ -20,6 +20,7 @@ import com.laytonsmith.abstraction.bukkit.BukkitMCPlayerInventory;
 import com.laytonsmith.abstraction.bukkit.BukkitMCScoreboard;
 import com.laytonsmith.abstraction.enums.MCInstrument;
 import com.laytonsmith.abstraction.enums.MCSound;
+import com.laytonsmith.abstraction.enums.MCVersion;
 import com.laytonsmith.abstraction.enums.MCWeather;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCInstrument;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCSound;
@@ -171,44 +172,37 @@ public class BukkitMCPlayer extends BukkitMCHumanEntity implements MCPlayer, MCC
         return p.getFireTicks();
     }
 
-//    public int getTotalExperience() {
-//        return p.getTotalExperience();
-//    }
-
-    // Method from Essentials plugin:
-    // https://raw.github.com/essentials/Essentials/master/Essentials/src/net/ess3/craftbukkit/SetExpFix.java
-	//This method is required because the bukkit player.getTotalExperience() method, shows exp that has been 'spent'.
-	//Without this people would be able to use exp and then still sell it.
 	@Override
 	public int getTotalExperience()
 	{
-		int exp = (int)Math.round(getExpAtLevel(p) * p.getExp());
-		int currentLevel = p.getLevel();
-
-		while (currentLevel > 0)
-		{
-			currentLevel--;
-			exp += getExpAtLevel(currentLevel);
-		}
-		return exp;
+		return p.getTotalExperience();
 	}
 
-	private static int getExpAtLevel(final Player player)
-	{
-		return getExpAtLevel(player.getLevel());
+	@Override
+	public int getExpToLevel() {
+		return p.getExpToLevel();
 	}
 
-	private static int getExpAtLevel(final int level)
-	{
-		if (level > 29)
-		{
-			return 62 + (level - 30) * 7;
+	@Override
+	public int getExpAtLevel() {
+		int level = p.getLevel();
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_8)) {
+			if (level > 30) {
+				return (int) (3.5 * Math.pow(level, 2) - 151.5 * level + 2220);
+			}
+			if(level > 15) {
+				return (int) (1.5 * Math.pow(level, 2) - 29.5 * level + 360);
+			}
+			return 17 * level;
+		} else {
+			if (level > 30) {
+				return (int) (4.5 * Math.pow(level, 2) - 162.5 * level + 2220);
+			}
+			if (level > 15) {
+				return (int) (2.5 * Math.pow(level, 2) - 40.5 * level + 360);
+			}
+			return (int) (Math.pow(level, 2) + 6 * level);
 		}
-		if (level > 15)
-		{
-			return 17 + (level - 15) * 3;
-		}
-		return 17;
 	}
 
 	@Override
@@ -478,44 +472,10 @@ public class BukkitMCPlayer extends BukkitMCHumanEntity implements MCPlayer, MCC
         p.recalculatePermissions();
     }
 
-//    public void setTotalExperience(int total) {
-//      p.setTotalExperience(0);
-//		p.setLevel(0);
-//		p.setExp(0);
-//		p.giveExp(total);
-//    }
-
-	// Method from Essentials plugin:
-	// https://raw.github.com/essentials/Essentials/master/Essentials/src/net/ess3/craftbukkit/SetExpFix.java
-	//This method is used to update both the recorded total experience and displayed total experience.
-	//We reset both types to prevent issues.
 	@Override
 	public void setTotalExperience(int total)
 	{
-        p.setExp(0);
-        p.setLevel(0);
-        p.setTotalExperience(0);
-
-		//This following code is technically redundant now, as bukkit now calulcates levels more or less correctly
-		//At larger numbers however... player.getExp(3000), only seems to give 2999, putting the below calculations off.
-		int amount = total;
-		while (amount > 0)
-		{
-			final int expToLevel = getExpAtLevel(p);
-			amount -= expToLevel;
-			if (amount >= 0)
-			{
-				// give until next level
-				p.giveExp(expToLevel);
-			}
-			else
-			{
-				// give the rest
-				amount += expToLevel;
-				p.giveExp(amount);
-				amount = 0;
-			}
-		}
+        p.setTotalExperience(total);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -1854,7 +1854,8 @@ public class PlayerManagement {
 				m = Static.GetPlayer(args[0].val(), t);
 			}
 			Static.AssertPlayerNonNull(m, t);
-			return new CInt(m.getTotalExperience(), t);
+			int texp = m.getExpAtLevel() + m.getExpToLevel() * java.lang.Math.round(m.getExp());
+			return new CInt(texp, t);
 		}
 	}
 
@@ -1915,11 +1916,11 @@ public class PlayerManagement {
 				throw new ConfigRuntimeException("Experience can't be negative", ExceptionType.RangeException, t);
 			}
 			Static.AssertPlayerNonNull(m, t);
-			m.setTotalExperience(xp);
-//            m.setLevel(0);
-//            m.setExp(0);
-//            m.setTotalExperience(0);
-//            m.giveExp(xp);
+			int score = m.getTotalExperience();
+			m.setLevel(0);
+			m.setExp(0);
+			m.giveExp(xp);
+			m.setTotalExperience(score); // reset experience score so that this function does not affect it
 			return CVoid.VOID;
 		}
 	}


### PR DESCRIPTION
TotalExperience in Minecraft is total accumulated experience, rather than current total experience. This was confusing and unhelpful to scripters so we previously changed this to return the experience necessary to get the current level + xp bar. I use a Bukkit method now to get exp for next level, but still required a method to get total exp for current level.

One debatable change: TotalExperience was previously updated to the value given in set_ptexp(), but it doesn't make sense to lower total accumulated experience. It also meant we were setting two things when ptexp() was only getting one thing. So instead I preserve the experience score.