### PR TITLE
Fixes literal keywords and decimals in labels (CMDHELPER-2990)

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -1030,6 +1030,8 @@ public final class MethodScriptCompiler {
 					val = new IVariable(t.val(), t.target);
 				} else if(t.type == TType.KEYWORD){
 					val = new CKeyword(t.val(), t.target);
+				} else if(t.type == TType.STRING){
+					val = new CString(t.val(), t.target);
 				} else {
 					val = Static.resolveConstruct(t.val(), t.target);
 				}
@@ -1835,6 +1837,7 @@ public final class MethodScriptCompiler {
 			// conditions.
 			processKeywords(node);
 			if(node.getData() instanceof CKeyword
+					|| (node.getData() instanceof CLabel && ((CLabel) node.getData()).cVal() instanceof CKeyword)
 					|| (node.getData() instanceof CFunction && KeywordList.getKeywordByName(node.getData().val()) != null)){
 				// This looks a bit confusing, but is fairly straightforward. We want to process the child elements of all
 				// remaining nodes, so that subchildren that need processing will be finished, and our current tree level will

--- a/src/main/java/com/laytonsmith/core/compiler/keywords/LiteralKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/keywords/LiteralKeyword.java
@@ -2,6 +2,7 @@ package com.laytonsmith.core.compiler.keywords;
 
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.compiler.Keyword;
+import com.laytonsmith.core.constructs.CLabel;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
@@ -14,7 +15,13 @@ public abstract class LiteralKeyword extends Keyword {
 
 	@Override
 	public int process(List<ParseTree> list, int keywordPosition) throws ConfigCompileException {
-		list.set(keywordPosition, new ParseTree(getValue(list.get(keywordPosition).getTarget()), list.get(keywordPosition).getFileOptions()));
+		if(list.get(keywordPosition).getData() instanceof CLabel) {
+			list.set(keywordPosition, new ParseTree(new CLabel(getValue(list.get(keywordPosition).getTarget())),
+					list.get(keywordPosition).getFileOptions()));
+		} else {
+			list.set(keywordPosition, new ParseTree(getValue(list.get(keywordPosition).getTarget()),
+					list.get(keywordPosition).getFileOptions()));
+		}
 		return keywordPosition;
 	}
 

--- a/src/main/java/com/laytonsmith/core/constructs/CDouble.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CDouble.java
@@ -42,6 +42,6 @@ public class CDouble extends CNumber implements Cloneable{
 
     @Override
     public boolean isDynamic() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -464,7 +464,7 @@ public class InventoryManagement {
                     try{
                         index = Integer.parseInt(key);
                     } catch(NumberFormatException e){
-                        if(key.isEmpty()){
+                        if(key.isEmpty() || key.equals("null")){
                             //It was a null key
                             index = -1;
                         } else {

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -221,7 +221,11 @@ public class OptimizationTest {
 
 	//tests the new switch syntax
 	@Test public void testSwitch1() throws Exception {
-		assertEquals("switch(@a,array(1,2),msg('1, 2'),array(3..4),sconcat(msg('3'),msg('4')),msg('default'))",
+		assertEquals("switch(@a,array(1,2),msg('1, 2'),"
+				+ "array(3..4),sconcat(msg('3'),msg('4')),"
+				+ "array(false),msg('false'),"
+				+ "array(0.7),msg(0.7),"
+				+ "msg('default'))",
 				optimize("switch(@a){"
 						+ "	case 1:"
 						+ "	case 2:"
@@ -229,6 +233,10 @@ public class OptimizationTest {
 						+ "	case 3..4:"
 						+ "		msg('3');"
 						+ "		msg('4');"
+						+ "	case false:"
+						+ "		msg('false');"
+						+ "	case 0.7:"
+						+ "		msg(0.7);"
 						+ "	case 'ignored':"
 						+ "	default:"
 						+ "		msg('default');"

--- a/src/test/java/com/laytonsmith/testing/ArrayTest.java
+++ b/src/test/java/com/laytonsmith/testing/ArrayTest.java
@@ -77,11 +77,15 @@ public class ArrayTest {
     }
 
     @Test public void testArrayKeyNormalization() throws Exception{
-        assertEquals("{false: 0}", SRun("array(false: 0)", fakePlayer));
-        assertEquals("{true: 1}", SRun("array(true: 1)", fakePlayer));
-        assertEquals("{null: empty}", SRun("array(null: empty)", fakePlayer));
+        assertEquals("{0: 0}", SRun("array(false: 0)", fakePlayer));
+        assertEquals("{false: 0}", SRun("array('false': 0)", fakePlayer));
+        assertEquals("{1: 1}", SRun("array(true: 1)", fakePlayer));
+        assertEquals("{true: 1}", SRun("array('true': 1)", fakePlayer));
+        assertEquals("{: empty}", SRun("array(null: empty)", fakePlayer));
+        assertEquals("{null: empty}", SRun("array('null': empty)", fakePlayer));
         assertEquals("{2.3: 2.3}", SRun("array(2.3: 2.3)", fakePlayer));
         assertEquals("{.3: .3}", SRun("array(.3: .3)", fakePlayer));
+        assertEquals("{.3: .3}", SRun("array('.3': .3)", fakePlayer));
     }
 
     @Test public void testArrayKeys() throws Exception{


### PR DESCRIPTION
 Allows both 'null' and null indexes in set_pinv()