### PR TITLE
Pass bind() custom parameters by reference, not value

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/EventBinding.java
+++ b/src/main/java/com/laytonsmith/core/functions/EventBinding.java
@@ -119,8 +119,7 @@ public class EventBinding {
 					throw new ConfigRuntimeException("The custom parameters must be ivariables", ExceptionType.CastException, t);
 				}
 				IVariable cur = (IVariable) var;
-				Construct ival = env.getEnv(GlobalEnv.class).GetVarList().get(cur.getName(), cur.getTarget()).ival();
-				custom_params.set(new IVariable(cur.getDefinedType(), cur.getName(), ival, t));
+				custom_params.set(env.getEnv(GlobalEnv.class).GetVarList().get(cur.getName(), cur.getTarget()));
 			}
 			Environment newEnv = env;
 			try {


### PR DESCRIPTION
This is an improved overwrite fix to the one in build 2927. This is how custom parameters functioned prior to my previous fix when using the assign() workaround. 

With this:
```
@a = array(1, 2, 3);
foreach(@b in @a) {
 // bind
}
```
I tested these custom parameters:
```
@b = @b // the old workaround
@a = 1 // this breaks the array reference outside the bind, just like prior to 2927
@b
@a
@c = @a[0];
```
I also incremented @a[0] inside the bind and outside the bind to verify the reference, in cases where it shouldn't have been passed and where it should have.