### PR TITLE
Bugfix in the neg code in the compiler.

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -1308,9 +1308,10 @@ public final class MethodScriptCompiler {
 			} else if (t.type.isSymbol()) { //Logic and math symbols
 				
 				// Attempt to find "-@var" and change it to "neg(@var)" if it's not @a - @b. Else just add the symbol.
-				// Also handles "-function()" and "-@var[index]". 
-				if (!prev1.type.isAtomicLit() && !prev1.type.equals(TType.IVARIABLE)
-						&& !prev1.type.equals(TType.VARIABLE) && t.type.equals(TType.MINUS)
+				// Also handles "-function()" and "-@var[index]".
+				if (!prev1.type.isAtomicLit() && !prev1.type.equals(TType.IVARIABLE) && !prev1.type.equals(TType.VARIABLE)
+						&& !prev1.type.equals(TType.RSQUARE_BRACKET) && !prev1.type.equals(TType.FUNC_END)
+						&& !prev1.type.equals(TType.RCURLY_BRACKET) && t.type.equals(TType.MINUS)
 						&& (next1.type.equals(TType.IVARIABLE) || next1.type.equals(TType.VARIABLE) || next1.type.equals(TType.FUNC_NAME))) {
 					
 					// Check if we are negating a value from an array, function or variable.

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -2,7 +2,6 @@ package com.laytonsmith.core;
 
 import com.laytonsmith.core.compiler.OptimizationUtilities;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
-import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.testing.StaticTest;
 import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
@@ -271,6 +270,12 @@ public class OptimizationTest {
 		
 		assertEquals("assign(@b,neg(array_get(array_get(array_get(array(array(array(2))),neg(array_get(array(1,0),1))),0),0)))",
 				optimize("@b = -array(array(array(2)))[-array(1,0)[1]][0][0]"));
+		
+		// Test behaviour where the value should not be negated.
+		assertEquals("assign(@c,subtract(@a,@b))", optimize("@c = @a - @b"));
+		assertEquals("assign(@c,subtract(array_get(@a,0),@b))", optimize("@c = @a[0] - @b"));
+		assertEquals("assign(@c,subtract(abs(@a),@b))", optimize("@c = abs(@a) - @b"));
+		assertEquals("assign(@c,subtract(if(@bool,2,3),@b))", optimize("@c = if(@bool) {2} else {3} - @b"));
 	}
 
 


### PR DESCRIPTION
Negations happend to a value after a MINUS sign, if the object in front of the MINUS sign was no variable, ivariable or atomic literal. This made @a[0] - @b and such negate @b instead of performing a subtraction.
Fixes CMDHELPER-3105