### PR TITLE
Add spectator target functions

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCPlayer.java
@@ -56,6 +56,8 @@ public interface MCPlayer extends MCCommandSender, MCHumanEntity,
 
 	public int getExpAtLevel();
 
+    public MCEntity getSpectatorTarget();
+
 	public float getWalkSpeed();
 	
 	public void setWalkSpeed(float speed);
@@ -100,6 +102,8 @@ public interface MCPlayer extends MCCommandSender, MCHumanEntity,
     public void setRemainingFireTicks(int i);
 
 	public void setScoreboard(MCScoreboard board);
+
+    public void setSpectatorTarget(MCEntity entity);
 
     public void setTempOp(Boolean value) throws Exception;
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
@@ -14,6 +14,7 @@ import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCPlayerInventory;
 import com.laytonsmith.abstraction.MCScoreboard;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
 import com.laytonsmith.abstraction.bukkit.BukkitMCItemStack;
 import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.BukkitMCPlayerInventory;
@@ -397,6 +398,26 @@ public class BukkitMCPlayer extends BukkitMCHumanEntity implements MCPlayer, MCC
     public void setRemainingFireTicks(int i) {
         p.setFireTicks(i);
     }
+
+	@Override
+	public void setSpectatorTarget(MCEntity entity) {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_8_7)) {
+			return;
+		}
+		if(entity == null) {
+			p.setSpectatorTarget(null);
+			return;
+		}
+		p.setSpectatorTarget((Entity) entity.getHandle());
+	}
+
+	@Override
+	public MCEntity getSpectatorTarget() {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_8_7)) {
+			return null;
+		}
+		return BukkitConvertor.BukkitGetCorrectEntity(p.getSpectatorTarget());
+	}
 
 	@Override
     public void setTempOp(Boolean value) throws ClassNotFoundException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -5032,11 +5032,7 @@ public class PlayerManagement {
 			if(args[offset] instanceof CNull) {
 				p.setSpectatorTarget(null);
 			} else {
-				MCEntity e = Static.getEntity(args[offset], t);
-				// spectating a non-living entity will crash the client and destroy the entity
-				if (e instanceof MCLivingEntity) {
-					p.setSpectatorTarget(e);
-				}
+				p.setSpectatorTarget(Static.getLivingEntity(args[offset], t));
 			}
 			return CVoid.VOID;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCConsoleCommandSender;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.MCLivingEntity;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCOfflinePlayer;
 import com.laytonsmith.abstraction.MCPlayer;
@@ -4907,6 +4908,136 @@ public class PlayerManagement {
 			p.setFlying(flight);
 			// We only want to set whether the player is flying; not whether the player can fly.
 			p.setAllowFlight(true);
+			return CVoid.VOID;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_1;
+		}
+	}
+
+	@api
+	public static class pspectator_target extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "pspectator_target";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{0, 1};
+		}
+
+		@Override
+		public String docs() {
+			return "void {[player]} Gets the entity that a spectator is viewing. If the player isn't spectating"
+					+ " from an entity, null is returned. If the player isn't in spectator mode, an"
+					+ " IllegalArgumentException is thrown.";
+		}
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.PlayerOfflineException, ExceptionType.IllegalArgumentException};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return false;
+		}
+
+		@Override
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			MCPlayer p;
+			if (args.length == 0) {
+				p = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
+			} else {
+				p = Static.GetPlayer(args[0], t);
+			}
+			Static.AssertPlayerNonNull(p, t);
+			if(p.getGameMode() != MCGameMode.SPECTATOR) {
+				throw new ConfigRuntimeException("Player must be in spectator mode.",
+						ExceptionType.IllegalArgumentException, t);
+			}
+			MCEntity e = p.getSpectatorTarget();
+			if(e == null) {
+				return CNull.NULL;
+			}
+			return new CString(e.getUniqueId().toString(), t);
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_1;
+		}
+	}
+
+	@api
+	public static class set_pspectator_target extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "set_pspectator_target";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1, 2};
+		}
+
+		@Override
+		public String docs() {
+			return "void {[player], entity} Sets the entity for the player to spectate. If set to null, the"
+					+ " spectator will stop following an entity. If the player is not in spectator mode an"
+					+ " IllegalArgumentException is thrown.";
+		}
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.PlayerOfflineException, ExceptionType.IllegalArgumentException,
+					ExceptionType.BadEntityException};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return false;
+		}
+
+		@Override
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			MCPlayer p;
+			int offset = 0;
+			if (args.length == 1) {
+				p = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
+			} else {
+				p = Static.GetPlayer(args[0], t);
+				offset = 1;
+			}
+			Static.AssertPlayerNonNull(p, t);
+			if(p.getGameMode() != MCGameMode.SPECTATOR) {
+				throw new ConfigRuntimeException("Player must be in spectator mode.",
+						ExceptionType.IllegalArgumentException, t);
+			}
+			if(args[offset] instanceof CNull) {
+				p.setSpectatorTarget(null);
+			} else {
+				MCEntity e = Static.getEntity(args[offset], t);
+				// spectating a non-living entity will crash the client and destroy the entity
+				if (e instanceof MCLivingEntity) {
+					p.setSpectatorTarget(e);
+				}
+			}
 			return CVoid.VOID;
 		}
 


### PR DESCRIPTION
Decided to go with set_pspectator_target(), unless someone objects. I think pspectate_entity() was the second most popular choice, but I think the two functions would be less complimentary in that case. Last chance to change it.