### PR TITLE
Lexer fix

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -725,6 +725,7 @@ public final class MethodScriptCompiler {
 			Token next = i + 1 < token_list.size() ? token_list.get(i + 1) : new Token(TType.UNKNOWN, "", t.target);
 
 			if (t.type == TType.UNKNOWN && prev1.type.isPlusMinus() && !prev2.type.isIdentifier()
+					&& !prev2.type.equals(TType.FUNC_END)
 					&& !t.val().matches("(\\@|\\$)[a-zA-Z0-9_]+")) { // Last boolean makes -@b equal to - @b, instead of a string.
 				//It is a negative/positive number. Absorb the sign
 				t.value = prev1.value + t.value;

--- a/src/main/java/com/laytonsmith/core/functions/Math.java
+++ b/src/main/java/com/laytonsmith/core/functions/Math.java
@@ -856,9 +856,9 @@ public class Math {
 				return v;
 			} else {
 				if (Static.anyDoubles(args[0])) {
-					return new CDouble(Static.getNumber(args[0], t) + value, t);
+					return new CDouble(Static.getNumber(args[0], t) - value, t);
 				} else {
-					return new CInt(Static.getInt(args[0], t) + value, t);
+					return new CInt(Static.getInt(args[0], t) - value, t);
 				}
 			}
 		}
@@ -980,9 +980,9 @@ public class Math {
 				return oldVal;
 			} else {
 				if (Static.anyDoubles(args[0])) {
-					return new CDouble(Static.getNumber(args[0], t) + value, t);
+					return new CDouble(Static.getNumber(args[0], t) - value, t);
 				} else {
-					return new CInt(Static.getInt(args[0], t) + value, t);
+					return new CInt(Static.getInt(args[0], t) - value, t);
 				}
 			}
 		}

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -276,6 +276,9 @@ public class OptimizationTest {
 		assertEquals("assign(@c,subtract(array_get(@a,0),@b))", optimize("@c = @a[0] - @b"));
 		assertEquals("assign(@c,subtract(abs(@a),@b))", optimize("@c = abs(@a) - @b"));
 		assertEquals("assign(@c,subtract(if(@bool,2,3),@b))", optimize("@c = if(@bool) {2} else {3} - @b"));
+		
+		assertEquals("assign(@b,subtract(dec(@a),2))", optimize("@b = dec(@a)-2"));
+		assertEquals("assign(@b,subtract(dec(@a),2))", optimize("@b = dec(@a)- 2"));
 	}
 
 


### PR DESCRIPTION
- func()-2 or func()+2 would lex "-2" and "+2" as strings. Now, it doesn't anymore.
- Changed dec(const) and postdec(const) so they no longer increment instead of decrement constants.