### PR TITLE
CArray creation optimizations

### DIFF
--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -747,7 +747,7 @@ public class ObjectGenerator {
 	 * @return
 	 */
 	public CArray color(MCColor color, Target t){
-		CArray ca = new CArray(t);
+		CArray ca = new CArray(t, -1);
 		ca.set("r", new CInt(color.getRed(), t), t);
 		ca.set("g", new CInt(color.getGreen(), t), t);
 		ca.set("b", new CInt(color.getBlue(), t), t);

--- a/src/main/java/com/laytonsmith/core/events/BoundEvent.java
+++ b/src/main/java/com/laytonsmith/core/events/BoundEvent.java
@@ -251,7 +251,7 @@ public class BoundEvent implements Comparable<BoundEvent> {
     //        GenericTree<Construct> root = new GenericTree<Construct>();
     //        root.setRoot(tree);
             Environment env = originalEnv.clone();
-            CArray ca = new CArray(Target.UNKNOWN);
+            CArray ca = new CArray(Target.UNKNOWN, -1);
             for (String key : activeEvent.parsedEvent.keySet()) {
                 ca.set(new CString(key, Target.UNKNOWN), activeEvent.parsedEvent.get(key), Target.UNKNOWN);
             }

--- a/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
@@ -83,7 +83,7 @@ public class BlockEvents {
             MCBlockPistonEvent event = (MCBlockPistonEvent) e;
             Map<String, Construct> map = evaluate_helper(event);
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = new CArray(Target.UNKNOWN, -1);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -149,7 +149,7 @@ public class BlockEvents {
 			CArray affected = new CArray(Target.UNKNOWN);
 			
 			for (MCBlock block : event.getPushedBlocks()) {
-				CArray blk = new CArray(Target.UNKNOWN);
+				CArray blk = new CArray(Target.UNKNOWN, -1);
 
 				int blktype = block.getTypeId();
 				blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -307,7 +307,7 @@ public class BlockEvents {
 
             map.put("player", new CString(event.getPlayer().getName(), Target.UNKNOWN));
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = new CArray(Target.UNKNOWN, -1);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -491,7 +491,7 @@ public class BlockEvents {
             int blkdata = event.getBlock().getData();
             map.put("data", new CInt(blkdata, Target.UNKNOWN));
 
-            CArray agst = new CArray(Target.UNKNOWN);
+            CArray agst = new CArray(Target.UNKNOWN, -1);
             MCBlock agstblk = event.getBlockAgainst();
             int againsttype = agstblk.getTypeId();
             agst.set("type", new CInt(againsttype, Target.UNKNOWN), Target.UNKNOWN);
@@ -503,7 +503,7 @@ public class BlockEvents {
             map.put("against", agst);
 
             MCBlockState old = event.getBlockReplacedState();
-            CArray oldarr = new CArray(Target.UNKNOWN);
+            CArray oldarr = new CArray(Target.UNKNOWN, -1);
             oldarr.set("type", new CInt(old.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
             oldarr.set("data", new CInt(old.getData().getData(), Target.UNKNOWN), Target.UNKNOWN);
             map.put("oldblock", oldarr);
@@ -627,7 +627,7 @@ public class BlockEvents {
             MCBlockBurnEvent event = (MCBlockBurnEvent) e;
             Map<String, Construct> map = evaluate_helper(event);
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = new CArray(Target.UNKNOWN, -1);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -1024,12 +1024,12 @@ public class BlockEvents {
 				MCBlockGrowEvent blockGrowEvent = (MCBlockGrowEvent) event;
 				Map<String, Construct> mapEvent = evaluate_helper(event);
 				MCBlock oldBlock = blockGrowEvent.getBlock();
-				CArray oldBlockArray = new CArray(Target.UNKNOWN);
+				CArray oldBlockArray = new CArray(Target.UNKNOWN, -1);
 				oldBlockArray.set("type", new CInt(oldBlock.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
 				oldBlockArray.set("data", new CInt(oldBlock.getData(), Target.UNKNOWN), Target.UNKNOWN);
 				mapEvent.put("oldblock", oldBlockArray);
 				MCBlockState newBlock = blockGrowEvent.getNewState();
-				CArray newBlockArray = new CArray(Target.UNKNOWN);
+				CArray newBlockArray = new CArray(Target.UNKNOWN, 1);
 				newBlockArray.set("type", new CInt(newBlock.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
 				newBlockArray.set("data", new CInt(newBlock.getData().getData(), Target.UNKNOWN), Target.UNKNOWN);
 				mapEvent.put("newblock", newBlockArray);

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -2469,7 +2469,7 @@ public class PlayerEvents {
 				MCPlayerEditBookEvent playerEditBookEvent = (MCPlayerEditBookEvent) event;
 				Map<String, Construct> mapEvent = evaluate_helper(event);
 				MCBookMeta oldBookMeta = playerEditBookEvent.getPreviousBookMeta();
-				CArray oldBookArray = new CArray(Target.UNKNOWN);
+				CArray oldBookArray = new CArray(Target.UNKNOWN, -1);
 				if (oldBookMeta.hasTitle()) {
 					oldBookArray.set("title", new CString(oldBookMeta.getTitle(), Target.UNKNOWN), Target.UNKNOWN);
 				} else {
@@ -2491,7 +2491,7 @@ public class PlayerEvents {
 				}
 				mapEvent.put("oldbook", oldBookArray);
 				MCBookMeta newBookMeta = playerEditBookEvent.getNewBookMeta();
-				CArray newBookArray = new CArray(Target.UNKNOWN);
+				CArray newBookArray = new CArray(Target.UNKNOWN, -1);
 				if (newBookMeta.hasTitle()) {
 					newBookArray.set("title", new CString(newBookMeta.getTitle(), Target.UNKNOWN), Target.UNKNOWN);
 				} else {

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -132,13 +132,12 @@ public class ArrayHandling {
 
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args.length == 0) {
-				throw new ConfigRuntimeException("Argument 1 of array_get must be an array", ExceptionType.CastException, t);
-			}
-			Construct index = new CSlice(0, -1, t);
+			Construct index;
 			Construct defaultConstruct = null;
 			if (args.length >= 2) {
 				index = args[1];
+			} else {
+				index = new CSlice(0, -1, t);
 			}
 			if (args.length >= 3) {
 				defaultConstruct = args[2];
@@ -185,17 +184,17 @@ public class ArrayHandling {
 				} else {
 					try {
 						if (!ca.inAssociativeMode()) {
-							if(args[1] instanceof CNull){
+							if(index instanceof CNull){
 								throw new Exceptions.CastException("Expected a number, but recieved null instead", t);
 							}
-							long iindex = Static.getInt(args[1], t);
+							long iindex = Static.getInt(index, t);
 							if (iindex < 0) {
 								//negative index, convert to positive index
 								iindex = ca.size() + iindex;
 							}
 							return ca.get(iindex, t);
 						} else {
-							return ca.get(args[1], t);
+							return ca.get(index, t);
 						}
 					} catch (ConfigRuntimeException e) {
 						if (e.getExceptionType() == ExceptionType.IndexOverflowException) {
@@ -211,7 +210,7 @@ public class ArrayHandling {
 							} else {
 								c = new CArray(t);
 							}
-							ca.set(args[1], c, t);
+							ca.set(index, c, t);
 							return c;
 						}
 						throw e;
@@ -231,7 +230,6 @@ public class ArrayHandling {
 						if (finish < 0) {
 							finish = aa.val().length() + finish;
 						}
-						CArray na = new CArray(t);
 						if (finish < start) {
 							//return an empty array in cases where the indexes don't make sense
 							return new CString("", t);

--- a/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
+++ b/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
@@ -119,7 +119,7 @@ public class BukkitMetadata {
 				}
 				return CNull.NULL;
 			} else {
-				CArray values = new CArray(t);
+				CArray values = new CArray(t, -1);
 				for (MCMetadataValue value : metadata) {
 					values.set(value.getOwningPlugin().getName(), Static.getMSObject(value.value(), t), t);
 				}

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -395,7 +395,7 @@ public class Cmdline {
 				}
                 return new CString(prop, t);
             } else {
-                CArray ca = new CArray(t);
+                CArray ca = new CArray(t, -1);
                 for (String key : System.getProperties().stringPropertyNames()) {
                     ca.set(key, System.getProperty(key));
                 }
@@ -473,7 +473,7 @@ public class Cmdline {
             if (args.length == 1) {
                 return new CString(System.getenv(args[0].val()), t);
             } else {
-                CArray ca = new CArray(t);
+                CArray ca = new CArray(t, -1);
                 for (String key : System.getenv().keySet()) {
                     ca.set(key, System.getenv(key));
                 }

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1451,7 +1451,7 @@ public class EntityManagement {
 			for (int i = 0; i < qty; i++) {
 				switch (entType.getAbstracted()) {
 					case DROPPED_ITEM:
-						CArray c = new CArray(t);
+						CArray c = new CArray(t, -1);
 						c.set("type", new CInt(1, t), t);
 						c.set("qty", new CInt(qty, t), t);
 						MCItemStack is = ObjectGenerator.GetGenerator().item(c, t);
@@ -1674,7 +1674,7 @@ public class EntityManagement {
 			if (eq.getHolder() instanceof MCPlayer) {
 				throw new ConfigRuntimeException(getName() + " does not work on players.", ExceptionType.BadEntityException, t);
 			}
-			CArray ret = new CArray(t);
+			CArray ret = new CArray(t, -1);
 			for (Map.Entry<MCEquipmentSlot, Float> ent : eq.getAllDropChances().entrySet()) {
 				ret.set(ent.getKey().name(), new CDouble(ent.getValue(), t), t);
 			}
@@ -2307,7 +2307,7 @@ public class EntityManagement {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCEntity entity = Static.getEntity(args[0], t);
-			CArray specArray = new CArray(t);
+			CArray specArray = new CArray(t, -1);
 
 			switch (entity.getType().getAbstracted()) {
 				case ARROW:

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -1198,7 +1198,7 @@ public class Environment {
 						throw new ConfigRuntimeException("Invalid argument for block info", ExceptionType.FormatException, t);
 				}
 			}
-			CArray array = new CArray(t);
+			CArray array = new CArray(t, -1);
 			array.set("solid", CBoolean.get(b.isSolid()), t);
 			array.set("flammable", CBoolean.get(b.isFlammable()), t);
 			array.set("transparent", CBoolean.get(b.isTransparent()), t);

--- a/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
@@ -285,7 +285,7 @@ public class ExtensionMeta {
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			Map<URL, ExtensionTracker> trackers = ExtensionManager.getTrackers();
 
-			CArray retn = new CArray(t);
+			CArray retn = new CArray(t, -1);
 
 			if (args.length == 0) {
 				for (URL url: trackers.keySet()) {
@@ -293,7 +293,7 @@ public class ExtensionMeta {
 					CArray trkdata;
 
 					if (!retn.containsKey(trk.getIdentifier())) {
-						trkdata = new CArray(t);
+						trkdata = new CArray(t, -1);
 					} else {
 						trkdata = (CArray) retn.get(trk.getIdentifier(), t);
 					}

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -1235,9 +1235,11 @@ public class Minecraft {
 				w = p.getWorld();
 			}
 			MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], w, t);
-			CArray options = new CArray(t);
+			CArray options;
 			if(args.length == 2){
 				options = Static.getArray(args[1], t);
+			} else {
+				options = new CArray(t, -1);
 			}
 			int strength = 2;
 			boolean flicker = false;
@@ -1613,7 +1615,7 @@ public class Minecraft {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCMaterial i = StaticLayer.GetConvertor().getMaterial(Static.getInt32(args[0], t));
-			CArray ret = new CArray(t);
+			CArray ret = new CArray(t, -1);
 			ret.set("maxStacksize", new CInt(i.getMaxStackSize(), t), t);
 			ret.set("maxDurability", new CInt(i.getMaxDurability(), t), t);
 			ret.set("hasGravity", CBoolean.get(i.hasGravity()), t);

--- a/src/main/java/com/laytonsmith/core/functions/Persistence.java
+++ b/src/main/java/com/laytonsmith/core/functions/Persistence.java
@@ -268,7 +268,7 @@ public class Persistence {
 			} catch(IllegalArgumentException e){
 				throw new ConfigRuntimeException(e.getMessage(), ExceptionType.FormatException, t, e);
 			}
-			CArray ca = new CArray(t);
+			CArray ca = new CArray(t, -1);
 			CHLog.GetLogger().Log(CHLog.Tags.PERSISTENCE, LogLevel.DEBUG, list.size() + " value(s) are being returned", t);
 			for (String[] e : list.keySet()) {
 				try {

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -218,7 +218,7 @@ public class SQL {
 						ResultSetMetaData md = ps.getMetaData();
 						ResultSet rs = ps.getResultSet();
 						while (rs != null && rs.next()) {
-							CArray row = new CArray(t);
+							CArray row = new CArray(t, -1);
 							for (int i = 1; i <= md.getColumnCount(); i++) {
 								Construct value;
 								int columnType = md.getColumnType(i);

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -394,7 +394,7 @@ public class Scoreboards {
 				to.set("prefix", new CString(team.getPrefix(), t), t);
 				to.set("suffix", new CString(team.getSuffix(), t), t);
 				to.set("size", new CInt(team.getSize(), t), t);
-				CArray ops = new CArray(t);
+				CArray ops = new CArray(t, -1);
 				ops.set("friendlyfire", CBoolean.get(team.allowFriendlyFire()), t);
 				ops.set("friendlyinvisibles", CBoolean.get(team.canSeeFriendlyInvisibles()), t);
 				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_8)) {
@@ -578,7 +578,7 @@ public class Scoreboards {
 			if (o == null) {
 				throw new ScoreboardException("No objective by that name exists.", t);
 			}
-			CArray dis = new CArray(t);
+			CArray dis = new CArray(t, -1);
 			if (args[1] instanceof CArray) {
 				dis = (CArray) args[1];
 			} else {
@@ -651,7 +651,7 @@ public class Scoreboards {
 			if (o == null) {
 				throw new ScoreboardException("No team by that name exists.", t);
 			}
-			CArray dis = new CArray(t);
+			CArray dis = new CArray(t, -1);
 			if (args[1] instanceof CArray) {
 				dis = (CArray) args[1];
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -113,7 +113,7 @@ public class Web {
 			}
 			CArray c;
 			if(!update){
-				c = new CArray(t);
+				c = new CArray(t, -1);
 			} else {
 				c = aCookie;
 			}
@@ -371,9 +371,9 @@ public class Web {
 				public void run() {
 					try{
 						HTTPResponse resp = WebUtility.GetPage(url, settings);
-						final CArray array = new CArray(t);
+						final CArray array = new CArray(t, -1);
 						array.set("body", new CString(resp.getContent(), t), t);
-						CArray headers = new CArray(t);
+						CArray headers = new CArray(t, -1);
 						for(String key : resp.getHeaderNames()){
 							CArray h = new CArray(t);
 							for(String val : resp.getHeaders(key)){
@@ -787,7 +787,7 @@ public class Web {
 				message.setSubject(subject);
 
 				if(!"".equals(body)){
-					CArray bodyAttachment = new CArray(t);
+					CArray bodyAttachment = new CArray(t, -1);
 					bodyAttachment.set("type", "text/plain");
 					bodyAttachment.set("content", body);
 					attachments.push(bodyAttachment, 0);

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -1176,7 +1176,7 @@ public class World {
 				throw new ConfigRuntimeException("Unknown world: " + args[0],
 						ExceptionType.InvalidWorldException, t);
 			}
-			CArray ret = new CArray(t);
+			CArray ret = new CArray(t, -1);
 			ret.set("name", new CString(w.getName(), t), t);
 			ret.set("seed", new CInt(w.getSeed(), t), t);
 			ret.set("environment", new CString(w.getEnvironment().name(), t), t);
@@ -1527,7 +1527,7 @@ public class World {
 				throw new ConfigRuntimeException("Unknown world: " + args[0].val(), ExceptionType.InvalidWorldException, t);
 			}
 			if (args.length == 1) {
-				CArray gameRules = new CArray(t);
+				CArray gameRules = new CArray(t, -1);
 				for (MCGameRule gameRule : MCGameRule.values()) {
 					gameRules.set(new CString(gameRule.getGameRule(), t), CBoolean.get(world.getGameRuleValue(gameRule)), t);
 				}


### PR DESCRIPTION
The array_get change consistently made a 1000x for() loop 7% faster.

When CArray normal arrays are created, and then later set with string index, it throws an exception, which can be costly to create. This was noticeable in profiling. I don't know the exact performance improvement from this change, but given how often this happens, it's probably significant. For example, it was throwing at least 1, and sometimes up to 3, exceptions for every event bind processed (not including exceptions thrown in the scripts).

I triple checked all the CArray(t, -1) to make sure they were appropriate and have been running these changes for a few days on my production server.