### PR TITLE
Made import/export accept an IVar as key.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -2726,7 +2726,7 @@ public class DataHandling {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{};
+			return new ExceptionType[]{ExceptionType.IllegalArgumentException};
 		}
 
 		@Override
@@ -2736,7 +2736,7 @@ public class DataHandling {
 
 		@Override
 		public boolean preResolveVariables() {
-			return false;
+			return true;
 		}
 
 		@Override
@@ -2758,7 +2758,17 @@ public class DataHandling {
 //				return CVoid.VOID;
 //			} else {
 				//Mode 2
-				String key = GetNamespace(args, null, getName(), t);
+				String key;
+				if(args.length == 1) {
+					if(!(args[0] instanceof CString)) {
+						throw new ConfigRuntimeException(this.getName() + " with 1 argument expects the argument to be a string.",
+								ExceptionType.IllegalArgumentException, t);
+					}
+					key = args[0].val();
+				} else {
+					// Handle the deprecated syntax.
+					key = GetNamespace(args, null, getName(), t);
+				}
 				return Globals.GetGlobalConstruct(key);
 //			}
 		}
@@ -2818,7 +2828,7 @@ public class DataHandling {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{ExceptionType.InsufficientArgumentsException};
+			return new ExceptionType[]{ExceptionType.InsufficientArgumentsException, ExceptionType.IllegalArgumentException};
 		}
 
 		@Override
@@ -2828,7 +2838,7 @@ public class DataHandling {
 
 		@Override
 		public boolean preResolveVariables() {
-			return false;
+			return true;
 		}
 
 		@Override
@@ -2851,12 +2861,22 @@ public class DataHandling {
 //					throw new ConfigRuntimeException("Expecting a IVariable when only one parameter is specified", ExceptionType.InsufficientArgumentsException, t);
 //				}
 //			} else {
-				String key = GetNamespace(args, args.length - 1, getName(), t);
-				Construct c = args[args.length - 1];
-				//We want to store the value contained, not the ivar itself
-				while (c instanceof IVariable) {
-					c = environment.getEnv(GlobalEnv.class).GetVarList().get(((IVariable) c).getName(), t).ival();
+				String key;
+				if(args.length == 2) {
+					if(!(args[0] instanceof CString)) {
+						throw new ConfigRuntimeException(this.getName() + " with 2 arguments expects the first argument to be a string.",
+								ExceptionType.IllegalArgumentException, t);
+					}
+					key = args[0].val();
+				} else {
+					// Handle the deprecated syntax.
+					key = GetNamespace(args, args.length - 1, getName(), t);
 				}
+				Construct c = args[args.length - 1];
+//				//We want to store the value contained, not the ivar itself
+//				while (c instanceof IVariable) {
+//					c = environment.getEnv(GlobalEnv.class).GetVarList().get(((IVariable) c).getName(), t).ival();
+//				}
 				Globals.SetGlobal(key, c);
 //			}
 			return CVoid.VOID;

--- a/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
@@ -339,6 +339,21 @@ public class DataHandlingTest {
                 + "msg(_get())", fakePlayer);
         verify(fakePlayer).sendMessage("{1, 2}");
     }
+	
+	@Test
+    public void testExportImportIvarValue() throws Exception{
+        when(fakePlayer.isOp()).thenReturn(Boolean.TRUE);
+        SRun("assign(@key, 'key1')"
+				+ "assign(@value, 'key1Value')"
+                + "export(@key, @value)"
+                + "msg(import('key1'))", fakePlayer);
+        verify(fakePlayer).sendMessage("key1Value");
+		SRun("assign(@key, 'key2')"
+				+ "assign(@value, 'key2Value')"
+                + "export('key2', @value)"
+                + "msg(import(@key))", fakePlayer);
+        verify(fakePlayer).sendMessage("key2Value");
+    }
 
     @Test(timeout = 10000)
     public void testIsBoolean() throws Exception {


### PR DESCRIPTION
Due to the removed deprecated export(@var) and import(@var), IVariables were not resolved before calling the exec. This caused the need to use export(string(@var), @value) and import(string(@var)). With this commit, it will accept IVariables and return an exception if the IVariable does not contain a CString.