### PR TITLE
Optimizations

### DIFF
--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -747,7 +747,7 @@ public class ObjectGenerator {
 	 * @return
 	 */
 	public CArray color(MCColor color, Target t){
-		CArray ca = new CArray(t);
+		CArray ca = CArray.GetAssociativeArray(t);
 		ca.set("r", new CInt(color.getRed(), t), t);
 		ca.set("g", new CInt(color.getGreen(), t), t);
 		ca.set("b", new CInt(color.getBlue(), t), t);

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -1100,9 +1100,6 @@ public final class Static {
 		MCCommandSender commandSender = env.getEnv(CommandHelperEnvironment.class).GetCommandSender();
 		String label = env.getEnv(GlobalEnv.class).GetLabel();
 		boolean perm = false;
-		if (label != null && GLOBAL_PERMISSION.equals(label)) {
-			perm = true;
-		}
 		if (commandSender != null) {
 			if (commandSender.isOp()) {
 				perm = true;

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -79,7 +79,7 @@ public class CArray extends Construct implements ArrayAccess{
 			}
 		}
 		associative_array = new TreeMap<>(comparator);
-		array = associative_mode ? new ArrayList<Construct>() : initialCapacity > -1 ? new ArrayList<Construct>(initialCapacity) : items != null ? new ArrayList<Construct>(items.length) : new ArrayList<Construct>();
+		array = associative_mode ? new ArrayList<Construct>() : initialCapacity > 0 ? new ArrayList<Construct>(initialCapacity) : items != null ? new ArrayList<Construct>(items.length) : new ArrayList<Construct>();
 		if(associative_mode){
 			if(items != null){
 				for(Construct item : items){
@@ -177,23 +177,11 @@ public class CArray extends Construct implements ArrayAccess{
 	 * @return
 	 */
 	public static CArray GetAssociativeArray(Target t){
-		return new CArray(t).forceAssociativeMode();
+		return new CArray(t, -1);
 	}
 
 	public static CArray GetAssociativeArray(Target t, Construct[] args){
-		return new CArray(t, -1, args).forceAssociativeMode();
-	}
-
-    /**
-     * This should only be used when copying an array that is already known to be associative, so integer keys will
-     * remain associative.
-     */
-    private CArray forceAssociativeMode(){
-        if(associative_array == null){
-            associative_array = new TreeMap<String, Construct>();
-        }
-        associative_mode = true;
-		return this;
+		return new CArray(t, -1, args);
     }
 
 	/**
@@ -725,13 +713,11 @@ public class CArray extends Construct implements ArrayAccess{
 			// Null checks!
 			if (o1 == null && o2 != null) {
 				return -1;
-			} else if (o1 == null && o2 == null) {
+			} else if (o1 == null) {
 				return 0;
-			} else if (o1 != null && o2 == null) {
+			} else if (o2 == null) {
 				return 1;
 			}
-			assert o1 != null;
-			assert o2 != null;
 			// This fixes a bug where occasionally (I can't totally figure out the pattern) a value
 			// would be missing from the list. I think this is ok in all cases, except that it may
 			// change the order of certain associative array's key display, however, this has never

--- a/src/main/java/com/laytonsmith/core/events/BoundEvent.java
+++ b/src/main/java/com/laytonsmith/core/events/BoundEvent.java
@@ -251,7 +251,7 @@ public class BoundEvent implements Comparable<BoundEvent> {
     //        GenericTree<Construct> root = new GenericTree<Construct>();
     //        root.setRoot(tree);
             Environment env = originalEnv.clone();
-            CArray ca = new CArray(Target.UNKNOWN);
+            CArray ca = CArray.GetAssociativeArray(Target.UNKNOWN);
             for (String key : activeEvent.parsedEvent.keySet()) {
                 ca.set(new CString(key, Target.UNKNOWN), activeEvent.parsedEvent.get(key), Target.UNKNOWN);
             }

--- a/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
@@ -83,7 +83,7 @@ public class BlockEvents {
             MCBlockPistonEvent event = (MCBlockPistonEvent) e;
             Map<String, Construct> map = evaluate_helper(event);
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = CArray.GetAssociativeArray(Target.UNKNOWN);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -149,7 +149,7 @@ public class BlockEvents {
 			CArray affected = new CArray(Target.UNKNOWN);
 			
 			for (MCBlock block : event.getPushedBlocks()) {
-				CArray blk = new CArray(Target.UNKNOWN);
+				CArray blk = CArray.GetAssociativeArray(Target.UNKNOWN);
 
 				int blktype = block.getTypeId();
 				blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -307,7 +307,7 @@ public class BlockEvents {
 
             map.put("player", new CString(event.getPlayer().getName(), Target.UNKNOWN));
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = CArray.GetAssociativeArray(Target.UNKNOWN);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -491,7 +491,7 @@ public class BlockEvents {
             int blkdata = event.getBlock().getData();
             map.put("data", new CInt(blkdata, Target.UNKNOWN));
 
-            CArray agst = new CArray(Target.UNKNOWN);
+            CArray agst = CArray.GetAssociativeArray(Target.UNKNOWN);
             MCBlock agstblk = event.getBlockAgainst();
             int againsttype = agstblk.getTypeId();
             agst.set("type", new CInt(againsttype, Target.UNKNOWN), Target.UNKNOWN);
@@ -503,7 +503,7 @@ public class BlockEvents {
             map.put("against", agst);
 
             MCBlockState old = event.getBlockReplacedState();
-            CArray oldarr = new CArray(Target.UNKNOWN);
+            CArray oldarr = CArray.GetAssociativeArray(Target.UNKNOWN);
             oldarr.set("type", new CInt(old.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
             oldarr.set("data", new CInt(old.getData().getData(), Target.UNKNOWN), Target.UNKNOWN);
             map.put("oldblock", oldarr);
@@ -627,7 +627,7 @@ public class BlockEvents {
             MCBlockBurnEvent event = (MCBlockBurnEvent) e;
             Map<String, Construct> map = evaluate_helper(event);
 
-            CArray blk = new CArray(Target.UNKNOWN);
+            CArray blk = CArray.GetAssociativeArray(Target.UNKNOWN);
 
             int blktype = event.getBlock().getTypeId();
             blk.set("type", new CInt(blktype, Target.UNKNOWN), Target.UNKNOWN);
@@ -1024,12 +1024,12 @@ public class BlockEvents {
 				MCBlockGrowEvent blockGrowEvent = (MCBlockGrowEvent) event;
 				Map<String, Construct> mapEvent = evaluate_helper(event);
 				MCBlock oldBlock = blockGrowEvent.getBlock();
-				CArray oldBlockArray = new CArray(Target.UNKNOWN);
+				CArray oldBlockArray = CArray.GetAssociativeArray(Target.UNKNOWN);
 				oldBlockArray.set("type", new CInt(oldBlock.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
 				oldBlockArray.set("data", new CInt(oldBlock.getData(), Target.UNKNOWN), Target.UNKNOWN);
 				mapEvent.put("oldblock", oldBlockArray);
 				MCBlockState newBlock = blockGrowEvent.getNewState();
-				CArray newBlockArray = new CArray(Target.UNKNOWN);
+				CArray newBlockArray = CArray.GetAssociativeArray(Target.UNKNOWN);
 				newBlockArray.set("type", new CInt(newBlock.getTypeId(), Target.UNKNOWN), Target.UNKNOWN);
 				newBlockArray.set("data", new CInt(newBlock.getData().getData(), Target.UNKNOWN), Target.UNKNOWN);
 				mapEvent.put("newblock", newBlockArray);

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -2469,7 +2469,7 @@ public class PlayerEvents {
 				MCPlayerEditBookEvent playerEditBookEvent = (MCPlayerEditBookEvent) event;
 				Map<String, Construct> mapEvent = evaluate_helper(event);
 				MCBookMeta oldBookMeta = playerEditBookEvent.getPreviousBookMeta();
-				CArray oldBookArray = new CArray(Target.UNKNOWN);
+				CArray oldBookArray = CArray.GetAssociativeArray(Target.UNKNOWN);
 				if (oldBookMeta.hasTitle()) {
 					oldBookArray.set("title", new CString(oldBookMeta.getTitle(), Target.UNKNOWN), Target.UNKNOWN);
 				} else {
@@ -2491,7 +2491,7 @@ public class PlayerEvents {
 				}
 				mapEvent.put("oldbook", oldBookArray);
 				MCBookMeta newBookMeta = playerEditBookEvent.getNewBookMeta();
-				CArray newBookArray = new CArray(Target.UNKNOWN);
+				CArray newBookArray = CArray.GetAssociativeArray(Target.UNKNOWN);
 				if (newBookMeta.hasTitle()) {
 					newBookArray.set("title", new CString(newBookMeta.getTitle(), Target.UNKNOWN), Target.UNKNOWN);
 				} else {

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -132,13 +132,12 @@ public class ArrayHandling {
 
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args.length == 0) {
-				throw new ConfigRuntimeException("Argument 1 of array_get must be an array", ExceptionType.CastException, t);
-			}
-			Construct index = new CSlice(0, -1, t);
+			Construct index;
 			Construct defaultConstruct = null;
 			if (args.length >= 2) {
 				index = args[1];
+			} else {
+				index = new CSlice(0, -1, t);
 			}
 			if (args.length >= 3) {
 				defaultConstruct = args[2];
@@ -185,17 +184,17 @@ public class ArrayHandling {
 				} else {
 					try {
 						if (!ca.inAssociativeMode()) {
-							if(args[1] instanceof CNull){
+							if(index instanceof CNull){
 								throw new Exceptions.CastException("Expected a number, but recieved null instead", t);
 							}
-							long iindex = Static.getInt(args[1], t);
+							long iindex = Static.getInt(index, t);
 							if (iindex < 0) {
 								//negative index, convert to positive index
 								iindex = ca.size() + iindex;
 							}
 							return ca.get(iindex, t);
 						} else {
-							return ca.get(args[1], t);
+							return ca.get(index, t);
 						}
 					} catch (ConfigRuntimeException e) {
 						if (e.getExceptionType() == ExceptionType.IndexOverflowException) {
@@ -211,7 +210,7 @@ public class ArrayHandling {
 							} else {
 								c = new CArray(t);
 							}
-							ca.set(args[1], c, t);
+							ca.set(index, c, t);
 							return c;
 						}
 						throw e;
@@ -231,7 +230,6 @@ public class ArrayHandling {
 						if (finish < 0) {
 							finish = aa.val().length() + finish;
 						}
-						CArray na = new CArray(t);
 						if (finish < start) {
 							//return an empty array in cases where the indexes don't make sense
 							return new CString("", t);

--- a/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
+++ b/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
@@ -119,7 +119,7 @@ public class BukkitMetadata {
 				}
 				return CNull.NULL;
 			} else {
-				CArray values = new CArray(t);
+				CArray values = CArray.GetAssociativeArray(t);
 				for (MCMetadataValue value : metadata) {
 					values.set(value.getOwningPlugin().getName(), Static.getMSObject(value.value(), t), t);
 				}

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -395,7 +395,7 @@ public class Cmdline {
 				}
                 return new CString(prop, t);
             } else {
-                CArray ca = new CArray(t);
+                CArray ca = CArray.GetAssociativeArray(t);
                 for (String key : System.getProperties().stringPropertyNames()) {
                     ca.set(key, System.getProperty(key));
                 }
@@ -473,7 +473,7 @@ public class Cmdline {
             if (args.length == 1) {
                 return new CString(System.getenv(args[0].val()), t);
             } else {
-                CArray ca = new CArray(t);
+                CArray ca = CArray.GetAssociativeArray(t);
                 for (String key : System.getenv().keySet()) {
                     ca.set(key, System.getenv(key));
                 }

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1451,7 +1451,7 @@ public class EntityManagement {
 			for (int i = 0; i < qty; i++) {
 				switch (entType.getAbstracted()) {
 					case DROPPED_ITEM:
-						CArray c = new CArray(t);
+						CArray c = CArray.GetAssociativeArray(t);
 						c.set("type", new CInt(1, t), t);
 						c.set("qty", new CInt(qty, t), t);
 						MCItemStack is = ObjectGenerator.GetGenerator().item(c, t);
@@ -1674,7 +1674,7 @@ public class EntityManagement {
 			if (eq.getHolder() instanceof MCPlayer) {
 				throw new ConfigRuntimeException(getName() + " does not work on players.", ExceptionType.BadEntityException, t);
 			}
-			CArray ret = new CArray(t);
+			CArray ret = CArray.GetAssociativeArray(t);
 			for (Map.Entry<MCEquipmentSlot, Float> ent : eq.getAllDropChances().entrySet()) {
 				ret.set(ent.getKey().name(), new CDouble(ent.getValue(), t), t);
 			}
@@ -2307,7 +2307,7 @@ public class EntityManagement {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCEntity entity = Static.getEntity(args[0], t);
-			CArray specArray = new CArray(t);
+			CArray specArray = CArray.GetAssociativeArray(t);
 
 			switch (entity.getType().getAbstracted()) {
 				case ARROW:

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -1198,7 +1198,7 @@ public class Environment {
 						throw new ConfigRuntimeException("Invalid argument for block info", ExceptionType.FormatException, t);
 				}
 			}
-			CArray array = new CArray(t);
+			CArray array = CArray.GetAssociativeArray(t);
 			array.set("solid", CBoolean.get(b.isSolid()), t);
 			array.set("flammable", CBoolean.get(b.isFlammable()), t);
 			array.set("transparent", CBoolean.get(b.isTransparent()), t);

--- a/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
@@ -285,7 +285,7 @@ public class ExtensionMeta {
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			Map<URL, ExtensionTracker> trackers = ExtensionManager.getTrackers();
 
-			CArray retn = new CArray(t);
+			CArray retn = CArray.GetAssociativeArray(t);
 
 			if (args.length == 0) {
 				for (URL url: trackers.keySet()) {
@@ -293,7 +293,7 @@ public class ExtensionMeta {
 					CArray trkdata;
 
 					if (!retn.containsKey(trk.getIdentifier())) {
-						trkdata = new CArray(t);
+						trkdata = CArray.GetAssociativeArray(t);
 					} else {
 						trkdata = (CArray) retn.get(trk.getIdentifier(), t);
 					}

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -1235,9 +1235,11 @@ public class Minecraft {
 				w = p.getWorld();
 			}
 			MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], w, t);
-			CArray options = new CArray(t);
+			CArray options;
 			if(args.length == 2){
 				options = Static.getArray(args[1], t);
+			} else {
+				options = CArray.GetAssociativeArray(t);
 			}
 			int strength = 2;
 			boolean flicker = false;
@@ -1613,7 +1615,7 @@ public class Minecraft {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCMaterial i = StaticLayer.GetConvertor().getMaterial(Static.getInt32(args[0], t));
-			CArray ret = new CArray(t);
+			CArray ret = CArray.GetAssociativeArray(t);
 			ret.set("maxStacksize", new CInt(i.getMaxStackSize(), t), t);
 			ret.set("maxDurability", new CInt(i.getMaxDurability(), t), t);
 			ret.set("hasGravity", CBoolean.get(i.hasGravity()), t);

--- a/src/main/java/com/laytonsmith/core/functions/Persistence.java
+++ b/src/main/java/com/laytonsmith/core/functions/Persistence.java
@@ -268,7 +268,7 @@ public class Persistence {
 			} catch(IllegalArgumentException e){
 				throw new ConfigRuntimeException(e.getMessage(), ExceptionType.FormatException, t, e);
 			}
-			CArray ca = new CArray(t);
+			CArray ca = CArray.GetAssociativeArray(t);
 			CHLog.GetLogger().Log(CHLog.Tags.PERSISTENCE, LogLevel.DEBUG, list.size() + " value(s) are being returned", t);
 			for (String[] e : list.keySet()) {
 				try {

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -218,7 +218,7 @@ public class SQL {
 						ResultSetMetaData md = ps.getMetaData();
 						ResultSet rs = ps.getResultSet();
 						while (rs != null && rs.next()) {
-							CArray row = new CArray(t);
+							CArray row = CArray.GetAssociativeArray(t);
 							for (int i = 1; i <= md.getColumnCount(); i++) {
 								Construct value;
 								int columnType = md.getColumnType(i);

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -394,7 +394,7 @@ public class Scoreboards {
 				to.set("prefix", new CString(team.getPrefix(), t), t);
 				to.set("suffix", new CString(team.getSuffix(), t), t);
 				to.set("size", new CInt(team.getSize(), t), t);
-				CArray ops = new CArray(t);
+				CArray ops = CArray.GetAssociativeArray(t);
 				ops.set("friendlyfire", CBoolean.get(team.allowFriendlyFire()), t);
 				ops.set("friendlyinvisibles", CBoolean.get(team.canSeeFriendlyInvisibles()), t);
 				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_8)) {
@@ -578,7 +578,7 @@ public class Scoreboards {
 			if (o == null) {
 				throw new ScoreboardException("No objective by that name exists.", t);
 			}
-			CArray dis = new CArray(t);
+			CArray dis = CArray.GetAssociativeArray(t);
 			if (args[1] instanceof CArray) {
 				dis = (CArray) args[1];
 			} else {
@@ -651,7 +651,7 @@ public class Scoreboards {
 			if (o == null) {
 				throw new ScoreboardException("No team by that name exists.", t);
 			}
-			CArray dis = new CArray(t);
+			CArray dis = CArray.GetAssociativeArray(t);
 			if (args[1] instanceof CArray) {
 				dis = (CArray) args[1];
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -113,7 +113,7 @@ public class Web {
 			}
 			CArray c;
 			if(!update){
-				c = new CArray(t);
+				c = CArray.GetAssociativeArray(t);
 			} else {
 				c = aCookie;
 			}
@@ -371,9 +371,9 @@ public class Web {
 				public void run() {
 					try{
 						HTTPResponse resp = WebUtility.GetPage(url, settings);
-						final CArray array = new CArray(t);
+						final CArray array = CArray.GetAssociativeArray(t);
 						array.set("body", new CString(resp.getContent(), t), t);
-						CArray headers = new CArray(t);
+						CArray headers = CArray.GetAssociativeArray(t);
 						for(String key : resp.getHeaderNames()){
 							CArray h = new CArray(t);
 							for(String val : resp.getHeaders(key)){
@@ -787,7 +787,7 @@ public class Web {
 				message.setSubject(subject);
 
 				if(!"".equals(body)){
-					CArray bodyAttachment = new CArray(t);
+					CArray bodyAttachment = CArray.GetAssociativeArray(t);
 					bodyAttachment.set("type", "text/plain");
 					bodyAttachment.set("content", body);
 					attachments.push(bodyAttachment, 0, t);

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -1176,7 +1176,7 @@ public class World {
 				throw new ConfigRuntimeException("Unknown world: " + args[0],
 						ExceptionType.InvalidWorldException, t);
 			}
-			CArray ret = new CArray(t);
+			CArray ret = CArray.GetAssociativeArray(t);
 			ret.set("name", new CString(w.getName(), t), t);
 			ret.set("seed", new CInt(w.getSeed(), t), t);
 			ret.set("environment", new CString(w.getEnvironment().name(), t), t);
@@ -1527,7 +1527,7 @@ public class World {
 				throw new ConfigRuntimeException("Unknown world: " + args[0].val(), ExceptionType.InvalidWorldException, t);
 			}
 			if (args.length == 1) {
-				CArray gameRules = new CArray(t);
+				CArray gameRules = CArray.GetAssociativeArray(t);
 				for (MCGameRule gameRule : MCGameRule.values()) {
 					gameRules.set(new CString(gameRule.getGameRule(), t), CBoolean.get(world.getGameRuleValue(gameRule)), t);
 				}


### PR DESCRIPTION
So after the previous PR, I changed and used the GetAssociativeArray() methods and removed the now unused forceAssocativeMode() method. I also fixed the array assignment in the constructor so that it appropriately sets the initial capacity if given items, and removed some impossible conditions in the compare() method.

For those who didn't see the previous PR, the primary goal is to avoid the extra cost of switching from a normal array to an associative array, since to do so it creates and throws an exception. Every event was throwing 1-3 exceptions by default, and this was adding up in some profiling I did.