### PR TITLE
Added type check to to_lower and to_upper.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/StringHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/StringHandling.java
@@ -661,7 +661,7 @@ public class StringHandling {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{};
+			return new ExceptionType[]{ExceptionType.FormatException};
 		}
 
 		@Override
@@ -681,6 +681,10 @@ public class StringHandling {
 
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
+			if (!(args[0] instanceof CString)) {
+				throw new ConfigRuntimeException(this.getName() + " expects a string as first argument, but type "
+						+ args[0].typeof() + " was found.", ExceptionType.FormatException, t);
+			}
 			return new CString(args[0].val().toUpperCase(), t);
 		}
 
@@ -720,7 +724,7 @@ public class StringHandling {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{};
+			return new ExceptionType[]{ExceptionType.FormatException};
 		}
 
 		@Override
@@ -740,6 +744,10 @@ public class StringHandling {
 
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
+			if (!(args[0] instanceof CString)) {
+				throw new ConfigRuntimeException(this.getName() + " expects a string as first argument, but type "
+						+ args[0].typeof() + " was found.", ExceptionType.FormatException, t);
+			}
 			return new CString(args[0].val().toLowerCase(), t);
 		}
 


### PR DESCRIPTION
to_lower used to stringify the argument passed to it. This change will
give a user an appropriate exception when passing anything else to the
function. If a player would like to stringify the argument anyways, he
could do that using the string() function.