### PR TITLE
Fix leak for non-repeating tasks

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/AbstractConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/AbstractConvertor.java
@@ -194,6 +194,9 @@ public abstract class AbstractConvertor implements Convertor{
 					task.run();
 					if(!repeater){
 						unregister();
+						synchronized(tasks){
+							tasks.remove(id);
+						}
 					}
 				}
 			}, initialDelay, interval);


### PR DESCRIPTION
Tasks created with set_timeout() are not being removed.

I'm not sure if this is where/how you want to do this, so feel free to do your own fix. Since the tracker is down, I thought I'd offer this PR instead.