### PR TITLE
BugFix in set_pheld_slot

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -1917,7 +1917,7 @@ public class InventoryManagement {
 			
 			int slot;
 			try {
-				slot = Integer.parseInt(args[0].val());
+				slot = Integer.parseInt(args[args.length - 1].val());
 			} catch(NumberFormatException e) {
 				throw new ConfigRuntimeException("Slot number must be an integer in range of [0-8].",
 							Exceptions.ExceptionType.FormatException, t);


### PR DESCRIPTION
When the player argument was supplied, it would also use it as the slot
number. This has been fixed.