### PR TITLE
Fixed CCE in assign.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -229,41 +229,46 @@ public class DataHandling {
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
 			IVariableList list = env.getEnv(GlobalEnv.class).GetVarList();
-			int offset = 0;
-			CClassType type = CClassType.AUTO;
+			int offset;
+			CClassType type;
 			String name;
 			if(args.length == 3){
 				offset = 1;
-				if(!(args[offset + 0] instanceof IVariable)) {
-					throw new ConfigRuntimeException(getName() + " with 3 arguments only accepts an ivariable as the second argument", ExceptionType.CastException, t);
+				if(!(args[offset] instanceof IVariable)){
+					throw new ConfigRuntimeException(getName() +
+							" with 3 arguments only accepts an ivariable as the second argument.",
+							ExceptionType.CastException, t);
 				}
-				name = ((IVariable) args[offset + 0]).getName();
+				name = ((IVariable) args[offset]).getName();
 				if(list.has(name) && env.getEnv(GlobalEnv.class).GetFlag("no-check-duplicate-assign") == null){
 					if(env.getEnv(GlobalEnv.class).GetFlag("closure-warn-overwrite") != null){
-						CHLog.GetLogger().Log(CHLog.Tags.RUNTIME, LogLevel.ERROR, "The variable " + name + " is hiding another value of the"
+						CHLog.GetLogger().Log(CHLog.Tags.RUNTIME, LogLevel.ERROR,
+								"The variable " + name + " is hiding another value of the"
 								+ " same name in the main scope.", t);
 					} else {
 						CHLog.GetLogger().Log(CHLog.Tags.RUNTIME, LogLevel.ERROR, name + " was already defined at "
-								+ list.get(name, t, true).getDefinedTarget() + " but is being redefined", t);
+								+ list.get(name, t, true).getDefinedTarget() + " but is being redefined.", t);
 					}
 				}
 				type = ArgumentValidation.getClassType(args[0], t);
+			} else {
+				offset = 0;
+				if(!(args[offset] instanceof IVariable)){
+					throw new ConfigRuntimeException(getName() +
+							" with 2 arguments only accepts an ivariable as the second argument.",
+							ExceptionType.CastException, t);
+				}
+				name = ((IVariable) args[offset]).getName();
+				type = list.get(name, t, true).getDefinedType();
 			}
-			name = ((IVariable) args[offset + 0]).getName();
 			Construct c = args[offset + 1];
-			while (c instanceof IVariable) {
+			while(c instanceof IVariable){
 				IVariable cur = (IVariable) c;
 				c = list.get(cur.getName(), cur.getTarget()).ival();
 			}
-			if (args[offset + 0] instanceof IVariable) {
-				if(args.length == 2){
-					type = list.get(name, t, true).getDefinedType();
-				}
-				IVariable v = new IVariable(type, name, c, t);
-				list.set(v);
-				return v;
-			}
-			throw new ConfigRuntimeException(getName() + " only accepts an ivariable or array reference as the first argument", ExceptionType.CastException, t);
+			IVariable v = new IVariable(type, name, c, t);
+			list.set(v);
+			return v;
 		}
 
 		@Override


### PR DESCRIPTION
- When trying to assign something to a non-IVariable with 2 arguments,
it would throw a ClassCastException when the first argument is no
IVariable. This is because the type check was in the wrong place.
- Removed double checks, double assignments and useless code.