### PR TITLE
Feature: stringed arrays render strings correctly

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -498,6 +498,8 @@ public class CArray extends Construct implements ArrayAccess{
 						v = ((CArray)value).getString(arrays, t);
 						arrays.pop();
 					}
+				} else if(value instanceof CString ){
+					v = "'" + value.val().replaceAll( "'", "\\'") + "'";
 				} else {
 					v = value.val();
 				}
@@ -525,6 +527,8 @@ public class CArray extends Construct implements ArrayAccess{
 							arrays.add(((CArray)value));
 							v = ((CArray)value).getString(arrays, t);
 						}
+					} else if(value instanceof CString ){
+						v = "'" + value.val().replaceAll( "'", "\\'") + "'";
 					} else {
 						v = value.val();
 					}


### PR DESCRIPTION
When stringing a array it will now wrap all strings inside the array with ticks and cancelling any ticks inside that string