### PR TITLE
Changed the ANSI reset code used in console().

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/TermColors.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/TermColors.java
@@ -196,7 +196,7 @@ public final class TermColors {
             }
         }
 		if(type.equals("reset")){
-			return "\033[0m";
+			return "\033[m";
 		}
         return "";
     }


### PR DESCRIPTION
\033[0m resets the ANSI color to normal. The default bukkit output color
is not always normal, so \033[m should be used instead. This is also
what Bukkit uses.