### PR TITLE
Rewrite player_move and vehicle_move to use server events. Add world prefilters.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
@@ -42,34 +42,10 @@ import org.bukkit.World;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerBedEnterEvent;
-import org.bukkit.event.player.PlayerBedLeaveEvent;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerChatTabCompleteEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.event.player.PlayerEditBookEvent;
-import org.bukkit.event.player.PlayerEvent;
-import org.bukkit.event.player.PlayerExpChangeEvent;
-import org.bukkit.event.player.PlayerFishEvent;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerItemConsumeEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerKickEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerPortalEvent;
-import org.bukkit.event.player.PlayerPreLoginEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerPreLoginEvent.Result;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.event.player.PlayerToggleFlightEvent;
-import org.bukkit.event.player.PlayerToggleSneakEvent;
-import org.bukkit.event.player.PlayerToggleSprintEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -970,6 +946,46 @@ public class BukkitPlayerEvents {
 		@Override
 		public void setCancelled(boolean bln) {
 			ptse.setCancelled(bln);
+		}
+	}
+
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCPlayerMoveEvent extends BukkitMCPlayerEvent
+			implements MCPlayerMoveEvent {
+		PlayerMoveEvent pme;
+		int threshold;
+		MCLocation from;
+
+		public BukkitMCPlayerMoveEvent(PlayerMoveEvent event, int threshold, MCLocation from) {
+			super(event);
+			this.pme = event;
+			this.threshold = threshold;
+			this.from = from;
+		}
+
+		@Override
+		public int getThreshold() {
+			return threshold;
+		};
+
+		@Override
+		public MCLocation getFrom() {
+			return new BukkitMCLocation(from);
+		};
+
+		@Override
+		public MCLocation getTo() {
+			return new BukkitMCLocation(pme.getTo());
+		};
+
+		@Override
+		public boolean isCancelled() {
+			return pme.isCancelled();
+		}
+
+		@Override
+		public void setCancelled(boolean bln) {
+			pme.setCancelled(bln);
 		}
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
@@ -2,14 +2,17 @@ package com.laytonsmith.abstraction.bukkit.events;
 
 import com.laytonsmith.abstraction.Implementation;
 import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
+import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
 import com.laytonsmith.abstraction.enums.MCCollisionType;
 import com.laytonsmith.abstraction.events.MCVehicleBlockCollideEvent;
 import com.laytonsmith.abstraction.events.MCVehicleEnitityCollideEvent;
 import com.laytonsmith.abstraction.events.MCVehicleEnterExitEvent;
 import com.laytonsmith.abstraction.events.MCVehicleEvent;
+import com.laytonsmith.abstraction.events.MCVehicleMoveEvent;
 import com.laytonsmith.annotations.abstraction;
 import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
 import org.bukkit.event.vehicle.VehicleCollisionEvent;
@@ -17,6 +20,7 @@ import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
 import org.bukkit.event.vehicle.VehicleEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
+import org.bukkit.event.vehicle.VehicleMoveEvent;
 
 /**
  * 
@@ -124,6 +128,49 @@ public class BukkitVehicleEvents {
 				return null;
 			}
 			return BukkitConvertor.BukkitGetCorrectEntity(vee.getExited());
+		}
+	}
+
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCVehicleMoveEvent extends BukkitMCVehicleEvent
+			implements MCVehicleMoveEvent {
+
+		VehicleMoveEvent vme;
+		int threshold;
+		boolean cancelled;
+		MCLocation from;
+
+		public BukkitMCVehicleMoveEvent(VehicleMoveEvent event, int threshold, MCLocation from) {
+			super(event);
+			vme = event;
+			this.threshold = threshold;
+			this.cancelled = false;
+			this.from = from;
+		}
+
+		@Override
+		public int getThreshold() {
+			return threshold;
+		}
+
+		@Override
+		public MCLocation getFrom() {
+			return new BukkitMCLocation(from);
+		}
+
+		@Override
+		public MCLocation getTo() {
+			return new BukkitMCLocation(vme.getTo());
+		}
+
+		@Override
+		public void setCancelled(boolean state) {
+			cancelled = state;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return cancelled;
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
@@ -1,40 +1,24 @@
 package com.laytonsmith.abstraction.bukkit.events.drivers;
 
+import com.laytonsmith.abstraction.MCLocation;
+import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
-import com.laytonsmith.abstraction.bukkit.events.BukkitPlayerEvents;
+import com.laytonsmith.abstraction.bukkit.events.BukkitPlayerEvents.*;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
+import com.laytonsmith.core.events.drivers.PlayerEvents;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerBedEnterEvent;
-import org.bukkit.event.player.PlayerBedLeaveEvent;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerChatTabCompleteEvent;
-import org.bukkit.event.player.PlayerEditBookEvent;
-import org.bukkit.event.player.PlayerExpChangeEvent;
-import org.bukkit.event.player.PlayerFishEvent;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerItemConsumeEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerKickEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerPortalEvent;
-import org.bukkit.event.player.PlayerPreLoginEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.event.player.PlayerToggleFlightEvent;
-import org.bukkit.event.player.PlayerToggleSneakEvent;
-import org.bukkit.event.player.PlayerToggleSprintEvent;
+import org.bukkit.event.player.*;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -49,57 +33,61 @@ public class BukkitPlayerListener implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onFoodLevelChange(FoodLevelChangeEvent e) {
-		BukkitPlayerEvents.BukkitMCFoodLevelChangeEvent pke = new BukkitPlayerEvents.BukkitMCFoodLevelChangeEvent(e);
+		BukkitMCFoodLevelChangeEvent pke = new BukkitMCFoodLevelChangeEvent(e);
 		EventUtils.TriggerListener(Driver.FOOD_LEVEL_CHANGED, "food_level_changed", pke);
     }
 	
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerKick(PlayerKickEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerKickEvent pke = new BukkitPlayerEvents.BukkitMCPlayerKickEvent(e);
+		BukkitMCPlayerKickEvent pke = new BukkitMCPlayerKickEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_KICK, "player_kick", pke);
     }
 	
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerBedEnter(PlayerBedEnterEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerBedEvent be = new BukkitPlayerEvents.BukkitMCPlayerBedEvent(e);
+		BukkitMCPlayerBedEvent be = new BukkitMCPlayerBedEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_BED_EVENT, "player_enter_bed", be);
     }
 	
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerBedLeave(PlayerBedLeaveEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerBedEvent be = new BukkitPlayerEvents.BukkitMCPlayerBedEvent(e);
+		BukkitMCPlayerBedEvent be = new BukkitMCPlayerBedEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_BED_EVENT, "player_leave_bed", be);
     }
     
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerLogin(PlayerLoginEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerLoginEvent ple = new BukkitPlayerEvents.BukkitMCPlayerLoginEvent(e);
+		BukkitMCPlayerLoginEvent ple = new BukkitMCPlayerLoginEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_LOGIN, "player_login", ple);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerPreLogin(PlayerPreLoginEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerPreLoginEvent pple = new BukkitPlayerEvents.BukkitMCPlayerPreLoginEvent(e);
+		BukkitMCPlayerPreLoginEvent pple = new BukkitMCPlayerPreLoginEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_PRELOGIN, "player_prelogin", pple);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerJoin(PlayerJoinEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerJoinEvent pje = new BukkitPlayerEvents.BukkitMCPlayerJoinEvent(e);
+		BukkitMCPlayerJoinEvent pje = new BukkitMCPlayerJoinEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_JOIN, "player_join", pje);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerInteract(PlayerInteractEvent e) {
-		BukkitPlayerEvents.BukkitMCPlayerInteractEvent pie = new BukkitPlayerEvents.BukkitMCPlayerInteractEvent(e);
+		BukkitMCPlayerInteractEvent pie = new BukkitMCPlayerInteractEvent(e);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT, "player_interact", pie);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT, "pressure_plate_activated", pie);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerRespawn(PlayerRespawnEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerRespawnEvent pre = new BukkitPlayerEvents.BukkitMCPlayerRespawnEvent(event);
+		BukkitMCPlayerRespawnEvent pre = new BukkitMCPlayerRespawnEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_SPAWN, "player_spawn", pre);
+		// Reset player_move lastLocations
+		for(Integer i : PlayerEvents.GetThresholdList()) {
+			PlayerEvents.GetLastLocations(i).put(event.getPlayer().getName(), new BukkitMCLocation(event.getRespawnLocation()));
+		}
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled=true)
@@ -112,7 +100,7 @@ public class BukkitPlayerListener implements Listener {
 		
 		if(event.isAsynchronous()){
 			//The async event gets priority, and if cancelled, doesn't trigger a normal player_chat event.
-			BukkitPlayerEvents.BukkitMCPlayerChatEvent pce = new BukkitPlayerEvents.BukkitMCPlayerChatEvent(event);
+			BukkitMCPlayerChatEvent pce = new BukkitMCPlayerChatEvent(event);
 			EventUtils.TriggerListener(Driver.PLAYER_CHAT, "async_player_chat", pce);
 
 			if(event.isCancelled()){
@@ -206,13 +194,13 @@ public class BukkitPlayerListener implements Listener {
 	}
 
 	private void fireChat(AsyncPlayerChatEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerChatEvent pce = new BukkitPlayerEvents.BukkitMCPlayerChatEvent(event);
+		BukkitMCPlayerChatEvent pce = new BukkitMCPlayerChatEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_CHAT, "player_chat", pce);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerQuit(PlayerQuitEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerQuitEvent pqe = new BukkitPlayerEvents.BukkitMCPlayerQuitEvent(event);
+		BukkitMCPlayerQuitEvent pqe = new BukkitMCPlayerQuitEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_QUIT, "player_quit", pqe);
 	}
 
@@ -221,7 +209,7 @@ public class BukkitPlayerListener implements Listener {
 		BukkitMCPlayer currentPlayer = (BukkitMCPlayer) Static.GetPlayer(event.getPlayer().getName(), Target.UNKNOWN);
 		//Apparently this happens sometimes, so prevent it
 		if (!event.getFrom().equals(currentPlayer._Player().getWorld())) {
-			BukkitPlayerEvents.BukkitMCWorldChangedEvent wce = new BukkitPlayerEvents.BukkitMCWorldChangedEvent(event);
+			BukkitMCWorldChangedEvent wce = new BukkitMCWorldChangedEvent(event);
 			EventUtils.TriggerListener(Driver.WORLD_CHANGED, "world_changed", wce);
 		}
 	}
@@ -232,69 +220,104 @@ public class BukkitPlayerListener implements Listener {
 			return;
 		}
 		
-		BukkitPlayerEvents.BukkitMCPlayerTeleportEvent pte = new BukkitPlayerEvents.BukkitMCPlayerTeleportEvent(event);
+		BukkitMCPlayerTeleportEvent pte = new BukkitMCPlayerTeleportEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_TELEPORT, "player_teleport", pte);
+		if(!pte.isCancelled()) {
+			// Reset player_move lastLocations
+			for(Integer i : PlayerEvents.GetThresholdList()) {
+				PlayerEvents.GetLastLocations(i).put(event.getPlayer().getName(), new BukkitMCLocation(event.getTo()));
+			}
+		}
 	}
 	
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPortalEnter(PlayerPortalEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerPortalEvent pe = new BukkitPlayerEvents.BukkitMCPlayerPortalEvent(event);
+		BukkitMCPlayerPortalEvent pe = new BukkitMCPlayerPortalEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_PORTAL_TRAVEL, "player_portal_travel", pe);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onConsume(PlayerItemConsumeEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerItemConsumeEvent pic = 
-				new BukkitPlayerEvents.BukkitMCPlayerItemConsumeEvent(event);
+		BukkitMCPlayerItemConsumeEvent pic = new BukkitMCPlayerItemConsumeEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_CONSUME, "player_consume", pic);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onFish(PlayerFishEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerFishEvent fish = new BukkitPlayerEvents.BukkitMCPlayerFishEvent(event);
+		BukkitMCPlayerFishEvent fish = new BukkitMCPlayerFishEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_FISH, "player_fish", fish);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onGamemodeChange(PlayerGameModeChangeEvent event) {
-		BukkitPlayerEvents.BukkitMCGamemodeChangeEvent e = new BukkitPlayerEvents.BukkitMCGamemodeChangeEvent(event);
+		BukkitMCGamemodeChangeEvent e = new BukkitMCGamemodeChangeEvent(event);
 		EventUtils.TriggerListener(Driver.GAMEMODE_CHANGE, "gamemode_change", e);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onChatTab(PlayerChatTabCompleteEvent event) {
-		BukkitPlayerEvents.BukkitMCChatTabCompleteEvent e = new BukkitPlayerEvents.BukkitMCChatTabCompleteEvent(event);
+		BukkitMCChatTabCompleteEvent e = new BukkitMCChatTabCompleteEvent(event);
 		EventUtils.TriggerListener(Driver.TAB_COMPLETE, "tab_complete_chat", e);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onExpChange(PlayerExpChangeEvent event) {
-		BukkitPlayerEvents.BukkitMCExpChangeEvent e = new BukkitPlayerEvents.BukkitMCExpChangeEvent(event);
+		BukkitMCExpChangeEvent e = new BukkitMCExpChangeEvent(event);
 		EventUtils.TriggerListener(Driver.EXP_CHANGE, "exp_change", e);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerEditBook(PlayerEditBookEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerEditBookEvent pebe = new BukkitPlayerEvents.BukkitMCPlayerEditBookEvent(event);
+		BukkitMCPlayerEditBookEvent pebe = new BukkitMCPlayerEditBookEvent(event);
 		EventUtils.TriggerListener(Driver.BOOK_EDITED, "book_edited", pebe);
 	}
 	
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerToggleFlightEvent ptfe = new BukkitPlayerEvents.BukkitMCPlayerToggleFlightEvent(event);
+		BukkitMCPlayerToggleFlightEvent ptfe = new BukkitMCPlayerToggleFlightEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_FLIGHT, "player_toggle_flight", ptfe);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleSneak(PlayerToggleSneakEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerToggleSneakEvent ptse = new BukkitPlayerEvents.BukkitMCPlayerToggleSneakEvent(event);
+		BukkitMCPlayerToggleSneakEvent ptse = new BukkitMCPlayerToggleSneakEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_SNEAK, "player_toggle_sneak", ptse);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleSprint(PlayerToggleSprintEvent event) {
-		BukkitPlayerEvents.BukkitMCPlayerToggleSprintEvent ptse = new BukkitPlayerEvents.BukkitMCPlayerToggleSprintEvent(event);
+		BukkitMCPlayerToggleSprintEvent ptse = new BukkitMCPlayerToggleSprintEvent(event);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_SPRINT, "player_toggle_sprint", ptse);
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPlayerMove(PlayerMoveEvent event) {
+		Location from = event.getFrom();
+		Location to = event.getTo();
+		if(from.getX() == to.getX() && from.getY() == to.getY() && from.getZ() == to.getZ()) {
+			return;
+		}
+		String p = event.getPlayer().getName();
+		for(Integer threshold : PlayerEvents.GetThresholdList()) {
+			Map<String, MCLocation> lastLocations = PlayerEvents.GetLastLocations(threshold);
+			if(!lastLocations.containsKey(p)) {
+				lastLocations.put(p, new BukkitMCLocation(from));
+				continue;
+			}
+			MCLocation last = lastLocations.get(p);
+			if (!to.getWorld().getName().equals(last.getWorld().getName())) {
+				lastLocations.put(p, new BukkitMCLocation(to));
+				continue;
+			}
+			MCLocation movedTo = new BukkitMCLocation(to);
+			if (last.distance(movedTo) > threshold) {
+				BukkitMCPlayerMoveEvent pme = new BukkitMCPlayerMoveEvent(event, threshold, last);
+				EventUtils.TriggerListener(Driver.PLAYER_MOVE, "player_move", pme);
+				if (!pme.isCancelled()) {
+					lastLocations.put(p, movedTo);
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/com/laytonsmith/core/events/AbstractEvent.java
+++ b/src/main/java/com/laytonsmith/core/events/AbstractEvent.java
@@ -54,7 +54,17 @@ public abstract class AbstractEvent implements Event, Comparable<Event> {
      */
 	@Override
     public void bind(BoundEvent event) {
-        throw new UnsupportedOperationException("Not supported yet.");
+
+    }
+
+	/**
+	 * If the event needs to run special code when a player unbinds the event, it
+	 * can be done here. By default, an UnsupportedOperationException is thrown,
+	 * but is caught and ignored.
+	 */
+	@Override
+	public void unbind(BoundEvent event) {
+
     }
 
     /**

--- a/src/main/java/com/laytonsmith/core/events/Event.java
+++ b/src/main/java/com/laytonsmith/core/events/Event.java
@@ -114,6 +114,15 @@ public interface Event extends Comparable<Event>, Documentation{
     public void bind(BoundEvent event);
 
     /**
+     * This function is called once a script unbinds this event. It may throw an
+     * UnsupportedOperationException if it is not needed. The BoundEvent is sent,
+     * in case the event can do some further optimization based on it.
+     * @param event The event that is triggering bind. Things like the prefilters and
+     * environment are available with the event.
+     */
+    public void unbind(BoundEvent event);
+
+    /**
      * This function is called once when the plugin starts up, to give this
      * event a chance to make a hook into the server if it needs it.
      * It may throw an UnsupportedOperationException if it is not needed.

--- a/src/main/java/com/laytonsmith/core/events/EventUtils.java
+++ b/src/main/java/com/laytonsmith/core/events/EventUtils.java
@@ -62,10 +62,7 @@ public final class EventUtils {
 		}
 		SortedSet<BoundEvent> set = event_handles.get(event.driver());
 		set.add(b);
-		try {
-			event.bind(b);
-		} catch (UnsupportedOperationException e) {
-		}
+		event.bind(b);
 	}
 
 	/**
@@ -82,6 +79,7 @@ public final class EventUtils {
 			while (i.hasNext()) {
 				BoundEvent b = i.next();
 				if (b.getId().equals(id)) {
+					b.getEventDriver().unbind(b);
 					i.remove();
 					return;
 				}

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -1,14 +1,11 @@
 package com.laytonsmith.core.events.drivers;
 
 import com.laytonsmith.PureUtilities.Common.StringUtils;
-import com.laytonsmith.PureUtilities.Point3D;
 import com.laytonsmith.PureUtilities.Version;
-import com.laytonsmith.abstraction.Implementation;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCVehicle;
-import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.enums.MCCollisionType;
 import com.laytonsmith.abstraction.enums.MCEntityType;
 import com.laytonsmith.abstraction.events.MCVehicleBlockCollideEvent;
@@ -39,17 +36,11 @@ import com.laytonsmith.core.exceptions.EventException;
 import com.laytonsmith.core.exceptions.PrefilterNonMatchException;
 import com.laytonsmith.core.functions.Exceptions.ExceptionType;
 
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
@@ -319,156 +310,25 @@ public class VehicleEvents {
 		}
 	}
 
+	private static final Set<Integer> thresholdList = new HashSet<>();
+
+	public static Set<Integer> GetThresholdList(){
+		return thresholdList;
+	}
+
+	private static final Map<Integer, Map<UUID, MCLocation>> lastVehicleLocations = new HashMap<>();
+
+	public static Map<UUID, MCLocation> GetLastLocations(Integer i){
+		if (!lastVehicleLocations.containsKey(i)) {
+			HashMap<UUID, MCLocation> newLocation = new HashMap<>();
+			lastVehicleLocations.put(i, newLocation);
+			return newLocation;
+		}
+		return(lastVehicleLocations.get(i));
+	}
+
 	@api
 	public static class vehicle_move extends AbstractEvent {
-
-		private static Thread thread = null;
-		private Set<Integer> thresholdList = new HashSet<Integer>();
-		private Map<Integer, Map<UUID, MCLocation>> thresholds = new HashMap<>();
-
-		@Override
-		public void bind(BoundEvent event) {
-			Map<String, Construct> prefilters = event.getPrefilter();
-			if (prefilters.containsKey("threshold")) {
-				int i = Static.getInt32(prefilters.get("threshold"), Target.UNKNOWN);
-				thresholdList.add(i);
-			}
-			if (thread == null) {
-				thresholdList.add(1);
-				thread = new Thread(new Runnable() {
-					@Override
-					public void run() {
-						outerLoop:
-						while (true) {
-							if (thread != Thread.currentThread()) {
-								//If it's a different thread, kill it.
-								return;
-							}
-
-							List<MCVehicle> vehicles = null;
-							try {
-								vehicles = Static.getVehicles();
-							} catch (ConcurrentModificationException ex) {
-								continue outerLoop;
-							}
-
-							for (final MCVehicle v : vehicles) {
-								final MCLocation current = ((MCEntity) v).asyncGetLocation();
-								Point3D currentPoint = new Point3D(current.getX(), current.getY(), current.getZ());
-								//We need to loop through all the thresholds
-								//and see if any of the points meet them. If so,
-								//we know we need to fire the event. If none of them
-								//match, carry on with the next vehicle. As soon as
-								//one matches though, we can't quit the loop, because
-								//we have to set all the thresholds.
-								thresholdLoop:
-								for (final Integer i : thresholdList) {
-									if (thresholds.containsKey(i) && thresholds.get(i).containsKey(v.getUniqueId())) {
-										final MCLocation last = thresholds.get(i).get(v.getUniqueId());
-										if (!v.getWorld().getName().equals(last.getWorld().getName())) {
-											//They moved worlds. simply put their new location in here, then
-											//continue.
-											thresholds.get(i).put(v.getUniqueId(), v.getLocation());
-											continue thresholdLoop;
-										}
-										Point3D lastPoint = new Point3D(last.getX(), last.getY(), last.getZ());
-										double distance = lastPoint.distance(currentPoint);
-										if (distance > i) {
-											//We've met the threshold.
-											//Well, we're still not sure. To run the prefilters on this thread,
-											//we're gonna simulate a prefilter match now. We have to run this manually,
-											//because each bind could have a different threshold, and it will be expecting
-											//THIS from location. Other binds will be expecting other from locations.
-											final MCVehicleMoveEvent fakeEvent = new MCVehicleMoveEvent() {
-												boolean cancelled = false;
-
-												@Override
-												public int getThreshold() {
-													return i;
-												}
-
-												@Override
-												public MCLocation getFrom() {
-													return last;
-												}
-
-												@Override
-												public MCLocation getTo() {
-													return current;
-												}
-
-												@Override
-												public Object _GetObject() {
-													return null;
-												}
-
-												@Override
-												public void setCancelled(boolean state) {
-													cancelled = state;
-												}
-
-												@Override
-												public boolean isCancelled() {
-													return cancelled;
-												}
-
-												@Override
-												public MCVehicle getVehicle() {
-													return v;
-												}
-											};
-											//We need to run the prefilters on this thread, so we have
-											//to do this all by hand.
-											final SortedSet<BoundEvent> toRun = EventUtils.GetMatchingEvents(Driver.VEHICLE_MOVE, vehicle_move.this.getName(), fakeEvent, vehicle_move.this);
-											//Ok, now the events to be run need to actually be run on the main server thread, so let's run that now.
-											try {
-												StaticLayer.GetConvertor().runOnMainThreadAndWait(new Callable<Object>() {
-													@Override
-													public Object call() throws Exception {
-														EventUtils.FireListeners(toRun, vehicle_move.this, fakeEvent);
-														return null;
-													}
-												});
-											} catch (Exception ex) {
-												Logger.getLogger(VehicleEvents.class.getName()).log(Level.SEVERE, null, ex);
-											}
-											if (fakeEvent.isCancelled()) {
-												//Put them back at the from location
-												v.teleport(last);
-											} else {
-												thresholds.get(i).put(v.getUniqueId(), current);
-											}
-										}
-									} else {
-										//If there is no location here, just put the current location in there.
-										if (!thresholds.containsKey(i)) {
-											thresholds.put(i, new HashMap<UUID, MCLocation>());
-										}
-										thresholds.get(i).put(v.getUniqueId(), v.asyncGetLocation());
-									}
-								}
-							}
-							synchronized (vehicle_move.this) {
-								try {
-									//Throttle this thread just a little
-									vehicle_move.this.wait(10);
-								} catch (InterruptedException ex) {
-									//
-								}
-							}
-						}
-					}
-				}, Implementation.GetServerType().getBranding() + "VehicleMoveEventRunner");
-				thread.start();
-				StaticLayer.GetConvertor().addShutdownHook(new Runnable() {
-					@Override
-					public void run() {
-						thresholdList.clear();
-						thread = null;
-					}
-				});
-			}
-		}
 
 		@Override
 		public String getName() {
@@ -478,12 +338,51 @@ public class VehicleEvents {
 		@Override
 		public String docs() {
 			return "{vehicletype: <macro> the entitytype of the vehicle | passengertype: <macro>"
-					+ " the enitytype of the passenger} Fires when an vehicle is moving."
-					+ " {from: Get the previous position | to: Get the next position"
+					+ " the enitytype of the passenger | world: <string> the world the vehicle is in}"
+					+ " Fires when a vehicle is moving. Due to the high frequency of this event, prefilters are"
+					+ " extremely important to use -- especially threshold."
+					+ "{world | from: Get the previous position | to: Get the next position"
 					+ " | vehicletype | passengertype | id: entityID | passenger: entityID"
 					+ " | player: player name if passenger is a player, null otherwise}"
 					+ " {}"
 					+ " {}";
+		}
+
+		@Override
+		public void hook() {
+			thresholdList.clear();
+			lastVehicleLocations.clear();
+		}
+
+		@Override
+		public void bind(BoundEvent event) {
+			int threshold = 1;
+			Map<String, Construct> prefilters = event.getPrefilter();
+			if(prefilters.containsKey("threshold")) {
+				threshold = Static.getInt32(prefilters.get("threshold"), Target.UNKNOWN);
+			}
+			thresholdList.add(threshold);
+		}
+
+		@Override
+		public void unbind(BoundEvent event) {
+			int threshold = 1;
+			Map<String, Construct> prefilters = event.getPrefilter();
+			if(prefilters.containsKey("threshold")) {
+				threshold = Static.getInt32(prefilters.get("threshold"), Target.UNKNOWN);
+			}
+			for (BoundEvent b : EventUtils.GetEvents(event.getDriver())) {
+				if (b.getId().equals(event.getId())) {
+					continue;
+				}
+				if (b.getPrefilter().containsKey("threshold")) {
+					if(threshold == Static.getInt(b.getPrefilter().get("threshold"), Target.UNKNOWN)) {
+						return;
+					}
+				}
+			}
+			thresholdList.remove(threshold);
+			lastVehicleLocations.remove(threshold);
 		}
 
 		@Override
@@ -500,25 +399,22 @@ public class VehicleEvents {
 
 		@Override
 		public boolean isCancelled(BindableEvent o) {
-			if (o instanceof MCVehicleMoveEvent) {
-				return ((MCVehicleMoveEvent) o).isCancelled();
-			} else {
-				return false;
-			}
+			return o instanceof MCVehicleMoveEvent && ((MCVehicleMoveEvent) o).isCancelled();
 		}
 
 		@Override
 		public boolean matches(Map<String, Construct> prefilter, BindableEvent e) throws PrefilterNonMatchException {
 			if (e instanceof MCVehicleMoveEvent) {
 				MCVehicleMoveEvent event = (MCVehicleMoveEvent) e;
-
-				if (!event.getFrom().getWorld().getName().equals(event.getTo().getWorld().getName())) {
+				if(prefilter.containsKey("threshold")) {
+					if(Static.getInt(prefilter.get("threshold"), Target.UNKNOWN) != event.getThreshold()) {
+						return false;
+					}
+				} else if(event.getThreshold() != 1) {
 					return false;
 				}
-
-				if(prefilter.containsKey("threshold")) {
-					Prefilters.match(prefilter, "threshold", event.getThreshold(), PrefilterType.MATH_MATCH);
-				} else if(event.getThreshold() != 1) {
+				if(prefilter.containsKey("world")
+						&& !prefilter.get("world").val().equals(event.getFrom().getWorld().getName())) {
 					return false;
 				}
 				if (prefilter.containsKey("from")) {
@@ -566,9 +462,10 @@ public class VehicleEvents {
 			if (event instanceof MCVehicleMoveEvent) {
 				MCVehicleMoveEvent e = (MCVehicleMoveEvent) event;
 				Target t = Target.UNKNOWN;
-				Map<String, Construct> ret = evaluate_helper(e);
-				ret.put("from", ObjectGenerator.GetGenerator().location(((MCVehicleMoveEvent) e).getFrom()));
-				ret.put("to", ObjectGenerator.GetGenerator().location(((MCVehicleMoveEvent) e).getTo()));
+				Map<String, Construct> ret = new HashMap<>();
+				ret.put("world", new CString(e.getFrom().getWorld().getName(), t));
+				ret.put("from", ObjectGenerator.GetGenerator().location(e.getFrom()));
+				ret.put("to", ObjectGenerator.GetGenerator().location(e.getTo()));
 				ret.put("vehicletype", new CString(e.getVehicle().getType().name(), t));
 				ret.put("id", new CString(e.getVehicle().getUniqueId().toString(), t));
 


### PR DESCRIPTION
This is a major internal change to how player_move and vehicle_move events are fired. The old method uses threading to reduce overhead, but it had low accuracy and was prone to ConcurrentModificationExceptions. (in some cases causing data corruption, though this could be significantly improved) This uses actual server events to avoid threading problems, but maintains most of the benefit of thresholds. But since thresholds are calculated on the main thread, it does increase overhead. And since it isn't throttled to 500ms, it can fire more frequently at a threshold of 1. (200-250ms when walking) That part is probably not that bad, because before it would fire all player_move events every 500ms, which could cause micro-stutter. Also, now if you cancel, it cancels the actual event, creating invisible barriers at the thresholds rather than sending the player to the threshold-from location. This also means that plugins that cancel the event later wouldn't be known to the script, much like other events.

In addition, I added an unbind() method to events so that I could clean up thresholds in lastPlayerLocations properly and keep that overhead down.

I'm currently running this on my live server, and while it takes the most overall time of all events (with two non-trivial binds at 1 and 10 thresholds) it doesn't take much time per tick.

There's a lot to discuss here. If you have any questions or concerns, please post them. Some of you may even think this is a non-starter and we should just fix the async event, which is fair. Personally I'd rather have something like this implementation, though it could probably be improved/optimized more.