### PR TITLE
Optimizations

### DIFF
--- a/src/main/java/com/laytonsmith/core/ArgumentValidation.java
+++ b/src/main/java/com/laytonsmith/core/ArgumentValidation.java
@@ -1,20 +1,12 @@
 package com.laytonsmith.core;
 
 import com.laytonsmith.annotations.typeof;
-import com.laytonsmith.core.constructs.CArray;
-import com.laytonsmith.core.constructs.CBoolean;
-import com.laytonsmith.core.constructs.CByteArray;
-import com.laytonsmith.core.constructs.CClassType;
-import com.laytonsmith.core.constructs.CDouble;
-import com.laytonsmith.core.constructs.CInt;
-import com.laytonsmith.core.constructs.CMutablePrimitive;
-import com.laytonsmith.core.constructs.CNull;
-import com.laytonsmith.core.constructs.CString;
-import com.laytonsmith.core.constructs.Construct;
-import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.constructs.*;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Exceptions;
 import com.laytonsmith.core.natives.interfaces.ArrayAccess;
+
+import java.util.regex.Pattern;
 
 /**
  * This class provides a way to validate, parse, and manipulate arguments passed
@@ -157,6 +149,36 @@ public class ArgumentValidation {
 					Exceptions.ExceptionType.CastException, t);
 		}
 		return d;
+	}
+
+	// Matches a string that will be successfully parsed by Double.parseDouble(String)
+	// Based on https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#valueOf-java.lang.String-
+	private static final Pattern VALID_DOUBLE = Pattern.compile(
+			"[\\x00-\\x20]*" + // leading whitespace
+			"[+-]?(" +
+				"(" +
+					"((\\p{Digit}+)(\\.)?((\\p{Digit}+)?)([eE][+-]?(\\p{Digit}+))?)" +
+					"|" +
+					"(\\.(\\p{Digit}+)([eE][+-]?(\\p{Digit}+))?)" +
+				"|" +
+					// Hexadecimal strings
+					"((" +
+					"(0[xX](\\p{XDigit}+)(\\.)?)" +
+					"|" +
+					"(0[xX](\\p{XDigit}+)?(\\.)(\\p{XDigit}+))" +
+					")[pP][+-]?(\\p{Digit}+))" +
+				")[fFdD]?" +
+			")[\\x00-\\x20]*" // trailing whitespace
+	);
+
+	/**
+	 * Validates that a construct's value is a number or string that can be returned by GetNumber()
+	 *
+	 * @param c Construct
+	 * @return boolean
+	 */
+	public static boolean isNumber(Construct c) {
+		return c instanceof CNumber || VALID_DOUBLE.matcher(c.val()).matches();
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -564,19 +564,16 @@ public final class Static {
 	public static MCItemStack ParseItemNotation(String functionName, String notation, int qty, Target t) {
 		int type = 0;
 		short data = 0;
-		MCItemStack is = null;
-		if (notation.matches("\\d*:\\d*")) {
+		MCItemStack is;
 			String[] sData = notation.split(":");
 			try {
-				type = (int) Integer.parseInt(sData[0]);
+			type = Integer.parseInt(sData[0]);
 				if (sData.length > 1) {
 					data = (short) Integer.parseInt(sData[1]);
 				}
 			} catch (NumberFormatException e) {
-				throw new ConfigRuntimeException("Item value passed to " + functionName + " is invalid: " + notation, ExceptionType.FormatException, t);
-			}
-		} else {
-			type = Static.getInt32(Static.resolveConstruct(notation, t), t);
+			throw new ConfigRuntimeException("Item value passed to " + functionName + " is invalid: " + notation,
+					ExceptionType.FormatException, t);
 		}
 
 		is = StaticLayer.GetItemStack(type, qty);

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -504,7 +504,7 @@ public final class Static {
 			m.sendMessage(msg);
 		} else {
 			msg = Static.MCToANSIColors(msg);
-			if (msg.matches("(?sm).*\033.*")) {
+			if (msg.contains("\033")) {
 				//We have terminal colors, we need to reset them at the end
 				msg += TermColors.reset();
 			}

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -5,6 +5,7 @@ import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.breakable;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.seealso;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHVersion;
 import com.laytonsmith.core.Optimizable;
 import com.laytonsmith.core.ParseTree;
@@ -782,8 +783,7 @@ public class BasicLogic {
 			}
 			if(Static.anyNulls(args)){
 				boolean equals = true;
-				for(int i = 0; i < args.length; i++){
-					Construct c = args[i];
+				for(Construct c : args){
 					if(!(c instanceof CNull)){
 						equals = false;
 					}
@@ -817,16 +817,22 @@ public class BasicLogic {
 				}
 			}
 			try {
+				// Validate that these are numbers, so that getNumber doesn't throw an exception.
+				if(!ArgumentValidation.isNumber(args[0])) {
+					return CBoolean.FALSE;
+				}
 				boolean equals = true;
 				for (int i = 1; i < args.length; i++) {
+					if(!ArgumentValidation.isNumber(args[i])) {
+						return CBoolean.FALSE;
+					}
 					double arg1 = Static.getNumber(args[i - 1], t);
 					double arg2 = Static.getNumber(args[i], t);
 					if (arg1 != arg2) {
-						equals = false;
-						break;
+						return CBoolean.FALSE;
 					}
 				}
-				return CBoolean.get(equals);
+				return CBoolean.TRUE;
 			} catch (ConfigRuntimeException e) {
 				return CBoolean.FALSE;
 			}

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -81,7 +81,7 @@ public class Cmdline {
         public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			String msg = Static.MCToANSIColors(args[0].val());
             StreamUtils.GetSystemOut().print(msg);
-            if (msg.matches("(?m).*\033.*")) {
+            if (msg.contains("\033")) {
                 //We have color codes in it, we need to reset them
                 StreamUtils.GetSystemOut().print(TermColors.reset());
             }
@@ -146,7 +146,7 @@ public class Cmdline {
 			String msg = Static.MCToANSIColors(args[0].val());
 			PrintStream se = StreamUtils.GetSystemErr();
             se.print(msg);
-            if (msg.matches("(?m).*\033.*")) {
+            if (msg.contains("\033")) {
                 //We have color codes in it, we need to reset them
                 se.print(TermColors.reset());
             }

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -61,7 +61,7 @@ public class Echoes {
 					Static.SendMessage(env.getEnv(CommandHelperEnvironment.class).GetCommandSender(), b.toString(), t);
 				} else {
 					String mes = Static.MCToANSIColors(b.toString());
-					if(mes.matches("(?m).*\033.*")){
+					if(mes.contains("\033")){
 						//We have terminal colors, we need to reset them at the end
 						mes += TermColors.reset();
 					}
@@ -133,7 +133,7 @@ public class Echoes {
 				Static.SendMessage(p, b.toString(), t);
 			} else {
 				String mes = Static.MCToANSIColors(b.toString());
-				if(mes.matches("(?m).*\033.*")){
+				if(mes.contains("\033")){
 					//We have terminal colors, we need to reset them at the end
 					mes += TermColors.reset();
 				}
@@ -614,7 +614,7 @@ public class Echoes {
                 prefix = Static.getBoolean(args[1]);
             }
             mes = (prefix?"CommandHelper: ":"") + Static.MCToANSIColors(mes);
-            if(mes.matches("(?m).*\033.*")){
+            if(mes.contains("\033")){
                 //We have terminal colors, we need to reset them at the end
                 mes += TermColors.reset();
             }

--- a/src/main/java/com/laytonsmith/core/functions/Enchantments.java
+++ b/src/main/java/com/laytonsmith/core/functions/Enchantments.java
@@ -449,7 +449,7 @@ public class Enchantments {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{ExceptionType.EnchantmentException, ExceptionType.CastException};
+			return new ExceptionType[]{ExceptionType.EnchantmentException, ExceptionType.FormatException};
 		}
 
 		@Override
@@ -556,7 +556,7 @@ public class Enchantments {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{ExceptionType.CastException};
+			return new ExceptionType[]{ExceptionType.FormatException};
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -84,47 +84,49 @@ public class Environment {
 		}
 
 		@Override
-		public Construct exec(Target t, com.laytonsmith.core.environments.Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
-			double x = 0;
-			double y = 0;
-			double z = 0;
+		public Construct exec(Target t, com.laytonsmith.core.environments.Environment env, Construct... args)
+				throws CancelCommandException, ConfigRuntimeException {
+			int x;
+			int y;
+			int z;
 			MCWorld w = null;
-			MCCommandSender sender = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
-			String world = null;
-			if (sender instanceof MCPlayer) {
-				w = ((MCPlayer) sender).getWorld();
+			MCPlayer player = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
+			if (player != null) {
+				w = player.getWorld();
 			}
-			if (args.length == 1 || args.length == 2) {
-				if (args[0] instanceof CArray) {
-					MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], w, t);
-					x = loc.getX();
-					y = loc.getY();
-					z = loc.getZ();
-					world = loc.getWorld().getName();
-				} else {
-					throw new ConfigRuntimeException("get_block_at expects param 1 to be an array", ExceptionType.CastException, t);
+			if (args.length < 3) {
+				if (!(args[0] instanceof CArray)) {
+					throw new ConfigRuntimeException("get_block_at expects param 1 to be an array",
+							ExceptionType.CastException, t);
 				}
+				MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], w, t);
+				x = loc.getBlockX();
+				y = loc.getBlockY();
+				z = loc.getBlockZ();
+				w = loc.getWorld();
 				if (args.length == 2) {
-					world = args[1].val();
+					w = Static.getServer().getWorld(args[1].val());
+					if (w == null) {
+						throw new ConfigRuntimeException("The specified world " + args[1].val() + " doesn't exist",
+								ExceptionType.InvalidWorldException, t);
+					}
 				}
-			} else if (args.length == 3 || args.length == 4) {
-				x = Static.getDouble(args[0], t);
-				y = Static.getDouble(args[1], t);
-				z = Static.getDouble(args[2], t);
+			} else {
+				x = (int) java.lang.Math.floor(Static.getNumber(args[0], t));
+				y = (int) java.lang.Math.floor(Static.getNumber(args[1], t));
+				z = (int) java.lang.Math.floor(Static.getNumber(args[2], t));
 				if (args.length == 4) {
-					world = args[3].val();
+					w = Static.getServer().getWorld(args[3].val());
+					if (w == null) {
+						throw new ConfigRuntimeException("The specified world " + args[4].val() + " doesn't exist",
+								ExceptionType.InvalidWorldException, t);
+					}
 				}
-			}
-			if (world != null) {
-				w = Static.getServer().getWorld(world);
 			}
 			if (w == null) {
-				throw new ConfigRuntimeException("The specified world " + world + " doesn't exist", ExceptionType.InvalidWorldException, t);
+				throw new ConfigRuntimeException("No world was provided", ExceptionType.InvalidWorldException, t);
 			}
-			x = java.lang.Math.floor(x);
-			y = java.lang.Math.floor(y);
-			z = java.lang.Math.floor(z);
-			MCBlock b = w.getBlockAt((int) x, (int) y, (int) z);
+			MCBlock b = w.getBlockAt(x, y, z);
 			if (b == null) {
 				throw new ConfigRuntimeException(
 						"Could not find the block in " + this.getName() + " (are you running in cmdline mode?)",
@@ -164,7 +166,8 @@ public class Environment {
 
 		@Override
 		public ExceptionType[] thrown() {
-			return new ExceptionType[]{ExceptionType.CastException, ExceptionType.LengthException, ExceptionType.FormatException, ExceptionType.InvalidWorldException};
+			return new ExceptionType[]{ExceptionType.CastException, ExceptionType.LengthException,
+					ExceptionType.FormatException, ExceptionType.InvalidWorldException};
 		}
 
 		@Override
@@ -178,68 +181,59 @@ public class Environment {
 		}
 
 		@Override
-		public Construct exec(Target t, com.laytonsmith.core.environments.Environment env, Construct... args) throws CancelCommandException, ConfigRuntimeException {
-			double x = 0;
-			double y = 0;
-			double z = 0;
+		public Construct exec(Target t, com.laytonsmith.core.environments.Environment env, Construct... args)
+				throws CancelCommandException, ConfigRuntimeException {
+			int x;
+			int y;
+			int z;
 			boolean physics = true;
-			String id = null;
-			String world = null;
+			String id;
 			MCWorld w = null;
-			MCCommandSender sender = env.getEnv(CommandHelperEnvironment.class).GetCommandSender();
-			if (sender instanceof MCPlayer) {
-				w = ((MCPlayer) sender).getWorld();
+			MCPlayer player = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
+			if (player != null) {
+				w = player.getWorld();
 			}
 			if (args.length < 4) {
 				if (!(args[0] instanceof CArray)) {
-					throw new ConfigRuntimeException("set_block_at expects param 1 to be an array", ExceptionType.CastException, t);
+					throw new ConfigRuntimeException("set_block_at expects param 1 to be an array",
+							ExceptionType.CastException, t);
 				}
 				MCLocation l = ObjectGenerator.GetGenerator().location(args[0], w, t);
 				x = l.getBlockX();
 				y = l.getBlockY();
 				z = l.getBlockZ();
-				world = l.getWorld().getName();
+				w = l.getWorld();
 				id = args[1].val();
 				if (args.length == 3) {
 					physics = Static.getBoolean(args[2]);
 				}
 
 			} else {
-				x = Static.getNumber(args[0], t);
-				y = Static.getNumber(args[1], t);
-				z = Static.getNumber(args[2], t);
+				x = (int) java.lang.Math.floor(Static.getNumber(args[0], t));
+				y = (int) java.lang.Math.floor(Static.getNumber(args[1], t));
+				z = (int) java.lang.Math.floor(Static.getNumber(args[2], t));
 				id = args[3].val();
 				if (args.length >= 5) {
-					world = args[4].val();
+					w = Static.getServer().getWorld(args[4].val());
+					if (w == null) {
+						throw new ConfigRuntimeException("The specified world " + args[4].val() + " doesn't exist",
+								ExceptionType.InvalidWorldException, t);
+					}
+				} else if (w == null) {
+					throw new ConfigRuntimeException("No world was provided",
+							ExceptionType.InvalidWorldException, t);
 				}
 				if (args.length == 6) {
 					physics = Static.getBoolean(args[2]);
 				}
 			}
-			if (world != null) {
-				w = Static.getServer().getWorld(world);
-			}
-			if (w == null) {
-				throw new ConfigRuntimeException("The specified world " + world + " doesn't exist", ExceptionType.InvalidWorldException, t);
-			}
-			x = java.lang.Math.floor(x);
-			y = java.lang.Math.floor(y);
-			z = java.lang.Math.floor(z);
-			int ix = (int) x;
-			int iy = (int) y;
-			int iz = (int) z;
-			MCBlock b = w.getBlockAt(ix, iy, iz);
+			MCBlock b = w.getBlockAt(x, y, z);
 			String[] dataAndMeta = id.split(":");
 			int data;
-			byte meta;
+			byte meta = 0;
 			try {
-				if(dataAndMeta.length == 1) {
-					meta = 0;
-				} else if(dataAndMeta.length == 2) {
+				if(dataAndMeta.length == 2) {
 					meta = Byte.parseByte(dataAndMeta[1]); // Throws NumberFormatException.
-				} else {
-					throw new ConfigRuntimeException("id must be formatted as such: 'x:y' where x and y are integers",
-							ExceptionType.FormatException, t);
 				}
 				data = Integer.parseInt(dataAndMeta[0]); // Throws NumberFormatException.
 			} catch(NumberFormatException e) {


### PR DESCRIPTION
The big one here is number validation for equals. This reduces false string equals operation time by ~93.5%, which is HUGE for switch() with many cases. It sacrifices a small amount of performance with some numbers for a massive false string performance gain. String/num equals combinations all seem within 30% of each other now.

I rewrote get/set_block_at because it was doing some things redundantly and inconsistently.