### PR TITLE
Cleanup classfile reading and upgrade to latest ASM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,12 @@
 			<groupId>org.java.net.substance</groupId>
 			<artifactId>substance</artifactId>
 			<version>6.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>asm</groupId>
+					<artifactId>asm-all</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- MCStats (this appears to no longer be working)
 		<dependency>
@@ -349,16 +355,10 @@
 			<type>jar</type>
 			<version>1.9</version>
 		</dependency>
-		<!-- If ASM doesn't end up working out, this could also be used
 		<dependency>
-			<groupId>org.apache.bcel</groupId>
-			<artifactId>bcel</artifactId>
-			<version>6.0-SNAPSHOT</version>
-		</dependency>-->
-		<dependency>
-			<groupId>asm</groupId>
+			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-all</artifactId>
-			<version>3.3.1</version>
+			<version>5.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>jline</groupId>
@@ -504,7 +504,7 @@
 									<include>mysql:mysql-connector-java:jar:*</include>
 									<include>commons-codec:commons-codec:jar:*</include>
 									<!--<include>org.apache.bcel:bcel:jar:*</include>-->
-									<include>asm:asm-all:jar:*</include>
+									<include>org.ow2.asm:asm-all:jar:*</include>
 									<include>jline:jline:jar:*</include>
 									<include>javax.mail:mail:jar:*</include>
 									<include>javax.activation:activation:jar:*</include>
@@ -674,7 +674,7 @@
 									</includes>
 								</filter>-->
 								<filter>
-									<artifact>asm:asm-all:jar:*</artifact>
+									<artifact>org.ow2.asm:asm-all:jar:*</artifact>
 									<includes>
 										<include>**</include>
 									</includes>

--- a/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassMirror/ClassMirrorVisitor.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/ClassLoading/ClassMirror/ClassMirrorVisitor.java
@@ -1,0 +1,155 @@
+package com.laytonsmith.PureUtilities.ClassLoading.ClassMirror;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.objectweb.asm.Opcodes.*;
+
+public class ClassMirrorVisitor extends ClassVisitor {
+
+    private final ClassMirror.ClassInfo classInfo;
+
+    ClassMirrorVisitor(ClassMirror.ClassInfo info) {
+        super(Opcodes.ASM5);
+        this.classInfo = info;
+    }
+
+    public ClassMirrorVisitor() {
+        this(new ClassMirror.ClassInfo());
+    }
+
+    public ClassMirror<?> getMirror(URL source) {
+        Preconditions.checkState(done, "Not done visiting %s", classInfo.name == null ? "none" : classInfo.name);
+        return new ClassMirror<Object>(this.classInfo, source);
+    }
+
+    private boolean done;
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        Preconditions.checkState(!done, "Can't visit %s, because we already visited %s", name, classInfo.name); // Ensure we never visit more than one class
+        if ((access & ACC_ENUM) == ACC_ENUM) classInfo.isEnum = true;
+        if ((access & ACC_INTERFACE) == ACC_INTERFACE) classInfo.isInterface = true;
+        classInfo.modifiers = new ModifierMirror(ModifierMirror.Type.CLASS, access);
+        classInfo.name = name;
+        classInfo.classReferenceMirror = new ClassReferenceMirror(Type.getObjectType(name).getDescriptor());
+        classInfo.superClass = superName;
+        classInfo.interfaces = interfaces;
+        super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        final AnnotationMirror mirror = new AnnotationMirror(new ClassReferenceMirror(desc), visible);
+        return new AnnotationMirrorVisitor(super.visitAnnotation(desc, visible), mirror) {
+            @Override
+            public void visitEnd() {
+                classInfo.annotations.add(mirror);
+                super.visitEnd();
+            }
+        };
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+        final FieldMirror fieldMirror = new FieldMirror(
+                classInfo.classReferenceMirror,
+                new ModifierMirror(ModifierMirror.Type.FIELD, access),
+                new ClassReferenceMirror(desc),
+                name,
+                value
+        );
+        return new FieldVisitor(ASM5, super.visitField(access, name, desc, signature, value)) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                final AnnotationMirror annotationMirror = new AnnotationMirror(new ClassReferenceMirror(desc), visible);
+                return new AnnotationMirrorVisitor(super.visitAnnotation(desc, visible), annotationMirror) {
+                    @Override
+                    public void visitEnd() {
+                        fieldMirror.addAnnotation(annotationMirror);
+                        super.visitEnd();
+                    }
+                };
+            }
+
+            @Override
+            public void visitEnd() {
+                classInfo.fields.add(fieldMirror);
+                super.visitEnd();
+            }
+        };
+    }
+
+    private static final Pattern INITIALIZER_PATTERN = Pattern.compile("<(cl)?init>");
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        if (INITIALIZER_PATTERN.matcher(name).matches()) return null; // Ignore constructors and static initializers
+        List<ClassReferenceMirror> parameterMirrors = new ArrayList<>();
+        for (Type type : Type.getArgumentTypes(desc)) {
+            parameterMirrors.add(new ClassReferenceMirror(type.getDescriptor()));
+        }
+        final MethodMirror methodMirror = new MethodMirror(
+                classInfo.classReferenceMirror,
+                    new ModifierMirror(ModifierMirror.Type.METHOD, access),
+                new ClassReferenceMirror(Type.getReturnType(desc).getDescriptor()),
+                name,
+                parameterMirrors,
+                (access & ACC_VARARGS) == ACC_VARARGS,
+                (access & ACC_SYNTHETIC) == ACC_SYNTHETIC
+        );
+        return new MethodVisitor(ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                final AnnotationMirror annotationMirror = new AnnotationMirror(new ClassReferenceMirror<>(desc), visible);
+                return new AnnotationMirrorVisitor(super.visitAnnotation(desc, visible), annotationMirror) {
+                    @Override
+                    public void visitEnd() {
+                        methodMirror.addAnnotation(annotationMirror);
+                    }
+                };
+            }
+
+            @Override
+            public void visitEnd() {
+                classInfo.methods.add(methodMirror);
+                super.visitEnd();
+            }
+        };
+    }
+
+    @Override
+    public void visitEnd() {
+        this.done = true;
+        super.visitEnd();
+    }
+
+    private static class AnnotationMirrorVisitor extends AnnotationVisitor {
+
+        private final AnnotationMirror mirror;
+
+        public AnnotationMirrorVisitor(AnnotationVisitor next, AnnotationMirror mirror) {
+            super(ASM5, next);
+            this.mirror = mirror;
+        }
+
+        @Override
+        public void visit(String name, Object value) {
+            if (value instanceof Type) value = ((Type) value).getDescriptor();
+            mirror.addAnnotationValue(name, value);
+            super.visit(name, value);
+        }
+    }
+}


### PR DESCRIPTION
Fixes compatibility with PaperSpigot and TacoSpigot.
You were using a very old version of ASM, which can't read java 8 jars.
Since PaperSpigot updated to 1.8, you need to update ASM in order to support them.

Unlike #339 I can confirm that metadata-caching works.
All unit-tests pass, but I don't have scripts to test with.