### PR TITLE
Exception fixes

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CClosure.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClosure.java
@@ -184,8 +184,6 @@ public class CClosure extends Construct {
             try {
                 MethodScriptCompiler.execute(newNode, environment, null, environment.getEnv(GlobalEnv.class).GetScript());
             } catch (LoopManipulationException e){
-				// Not normal, but pop anyways.
-				stManager.popStackTraceElement();
 				//This shouldn't ever happen.
 				LoopManipulationException lme = ((LoopManipulationException)e);
 				Target t = lme.getTarget();
@@ -194,7 +192,6 @@ public class CClosure extends Construct {
 			} catch (FunctionReturnException ex){
 				// Check the return type of the closure to see if it matches the defined type
 				// Normal execution.
-				stManager.popStackTraceElement();
 				Construct ret = ex.getReturn();
 				if(!InstanceofUtil.isInstanceof(ret, returnType)){
 					throw new CRECastException("Expected closure to return a value of type " + returnType.val()
@@ -203,21 +200,18 @@ public class CClosure extends Construct {
 				// Now rethrow it
 				throw ex;
 			} catch (CancelCommandException e){
-				stManager.popStackTraceElement();
 				// die()
 			} catch(ConfigRuntimeException ex){
 				if(ex instanceof AbstractCREException){
 					((AbstractCREException)ex).freezeStackTraceElements(stManager);
 				}
-				stManager.popStackTraceElement();
 				throw ex;
 			} catch(Throwable t){
 				// Not sure. Pop and re-throw.
-				stManager.popStackTraceElement();
 				throw t;
+			} finally {
+				stManager.popStackTraceElement();
 			}
-			// Normal execution.
-			stManager.popStackTraceElement();
 			// If we got here, then there was no return type. This is fine, but only for returnType void or auto.
 			if(!(returnType.equals(CClassType.AUTO) || returnType.equals(CClassType.VOID))){
 				throw new CRECastException("Expecting closure to return a value of type " + returnType.val() + ","

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
@@ -133,7 +133,7 @@ public abstract class AbstractCREException extends ConfigRuntimeException implem
 	}
 	
 	private static Construct getCausedBy(Throwable causedBy){
-		if(causedBy == null){
+		if(causedBy == null || !(causedBy instanceof CRECausedByWrapper)){
 			return CNull.NULL;
 		}
 		CRECausedByWrapper cre = (CRECausedByWrapper) causedBy;


### PR DESCRIPTION
For reference, the relevant part of the core error is this:

```
java.lang.ClassCastException: java.lang.IndexOutOfBoundsException cannot be cast to com.laytonsmith.core.exceptions.CRE.CRECausedByWrapper
        at com.laytonsmith.core.exceptions.CRE.AbstractCREException.getCausedBy(AbstractCREException.java:139)
        at com.laytonsmith.core.exceptions.CRE.AbstractCREException.getExceptionObject(AbstractCREException.java:105)
        at com.laytonsmith.core.functions.Exceptions$complex_try.execs(Exceptions.java:444)
```