### PR TITLE
Map existing Sound ENUM to new Sound ENUM

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
@@ -256,7 +256,7 @@ public class BukkitMCWorld extends BukkitMCMetadatable implements MCWorld {
 	@Override
 	public void playSound(MCLocation l, MCSound sound, float volume, float pitch) {
 		w.playSound(((BukkitMCLocation) l).asLocation(),
-				BukkitMCSound.getConvertor().getConcreteEnum(sound), volume, pitch);
+				((BukkitMCSound) sound).getConcrete(), volume, pitch);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCPlayer.java
@@ -539,7 +539,7 @@ public class BukkitMCPlayer extends BukkitMCHumanEntity implements MCPlayer, MCC
 	@Override
 	public void playSound(MCLocation l, MCSound sound, float volume, float pitch) {
 		p.playSound(((BukkitMCLocation) l).asLocation(),
-				BukkitMCSound.getConvertor().getConcreteEnum(sound), volume, pitch);
+				((BukkitMCSound) sound).getConcrete(), volume, pitch);
 	}
 	
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitEntityEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitEntityEvents.java
@@ -504,7 +504,7 @@ public class BukkitEntityEvents {
 				e.getPlayer().getInventory().addItem(s.asItemStack());
 				//and for added realism :)
 				e.getPlayer().getWorld().playSound(e.getItem().getLocation(),
-						BukkitMCSound.getConvertor().getConcreteEnum(MCSound.ITEM_PICKUP), 1, 2);
+						((BukkitMCSound) MCSound.valueOf("ITEM_PICKUP")).getConcrete(), 1, 2);
 			}
 		}
 

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCSound.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCSound.java
@@ -1,206 +1,286 @@
 package com.laytonsmith.abstraction.enums;
 
+import com.laytonsmith.PureUtilities.ClassLoading.DynamicEnum;
+import com.laytonsmith.annotations.MDynamicEnum;
 import com.laytonsmith.annotations.MEnum;
+import com.laytonsmith.core.Static;
 
-@MEnum("Sound")
-public enum MCSound {
-	AMBIENCE_CAVE,
-	AMBIENCE_RAIN,
-	AMBIENCE_THUNDER,
-	ANVIL_BREAK,
-	ANVIL_LAND,
-	ANVIL_USE,
-	ARROW_HIT,
-	BURP,
-	CHEST_CLOSE,
-	CHEST_OPEN,
-	CLICK,
-	DOOR_CLOSE,
-	DOOR_OPEN,
-	DRINK,
-	EAT,
-	EXPLODE,
-	FALL_BIG,
-	FALL_SMALL,
-	FIRE,
-	FIRE_IGNITE,
-	FIZZ,
-	FUSE,
-	GLASS,
-	HURT_FLESH,
-	ITEM_BREAK,
-	ITEM_PICKUP,
-	LAVA,
-	LAVA_POP,
-	LEVEL_UP,
-	MINECART_BASE,
-	MINECART_INSIDE,
-	NOTE_BASS,
-	NOTE_PIANO,
-	NOTE_BASS_DRUM,
-	NOTE_STICKS,
-	NOTE_BASS_GUITAR,
-	NOTE_SNARE_DRUM,
-	NOTE_PLING,
-	ORB_PICKUP,
-	PISTON_EXTEND,
-	PISTON_RETRACT,
-	PORTAL,
-	PORTAL_TRAVEL,
-	PORTAL_TRIGGER,
-	SHOOT_ARROW,
-	SPLASH,
-	SPLASH2,
-	STEP_GRASS,
-	STEP_GRAVEL,
-	STEP_LADDER,
-	STEP_SAND,
-	STEP_SNOW,
-	STEP_STONE,
-	STEP_WOOD,
-	STEP_WOOL,
-	SWIM,
-	WATER,
-	WOOD_CLICK,
-	// Mob sounds
-	BAT_DEATH,
-	BAT_HURT,
-	BAT_IDLE,
-	BAT_LOOP,
-	BAT_TAKEOFF,
-	BLAZE_BREATH,
-	BLAZE_DEATH,
-	BLAZE_HIT,
-	CAT_HISS,
-	CAT_HIT,
-	CAT_MEOW,
-	CAT_PURR,
-	CAT_PURREOW,
-	CHICKEN_IDLE,
-	CHICKEN_HURT,
-	CHICKEN_EGG_POP,
-	CHICKEN_WALK,
-	COW_IDLE,
-	COW_HURT,
-	COW_WALK,
-	CREEPER_HISS,
-	CREEPER_DEATH,
-	ENDERDRAGON_DEATH,
-	ENDERDRAGON_GROWL,
-	ENDERDRAGON_HIT,
-	ENDERDRAGON_WINGS,
-	ENDERMAN_DEATH,
-	ENDERMAN_HIT,
-	ENDERMAN_IDLE,
-	ENDERMAN_TELEPORT,
-	ENDERMAN_SCREAM,
-	ENDERMAN_STARE,
-	GHAST_SCREAM,
-	GHAST_SCREAM2,
-	GHAST_CHARGE,
-	GHAST_DEATH,
-	GHAST_FIREBALL,
-	GHAST_MOAN,
-	HORSE_DEATH,
-	HORSE_SKELETON_HIT,
-	IRONGOLEM_DEATH,
-	IRONGOLEM_HIT,
-	IRONGOLEM_THROW,
-	IRONGOLEM_WALK,
-	MAGMACUBE_WALK,
-	MAGMACUBE_WALK2,
-	MAGMACUBE_JUMP,
-	PIG_IDLE,
-	PIG_DEATH,
-	PIG_WALK,
-	SHEEP_IDLE,
-	SHEEP_SHEAR,
-	SHEEP_WALK,
-	SILVERFISH_HIT,
-	SILVERFISH_KILL,
-	SILVERFISH_IDLE,
-	SILVERFISH_WALK,
-	SKELETON_IDLE,
-	SKELETON_DEATH,
-	SKELETON_HURT,
-	SKELETON_WALK,
-	SLIME_ATTACK,
-	SLIME_WALK,
-	SLIME_WALK2,
-	SPIDER_IDLE,
-	SPIDER_DEATH,
-	SPIDER_WALK,
-	WITHER_DEATH,
-	WITHER_HURT,
-	WITHER_IDLE,
-	WITHER_SHOOT,
-	WITHER_SPAWN,
-	WOLF_BARK,
-	WOLF_DEATH,
-	WOLF_GROWL,
-	WOLF_HOWL,
-	WOLF_HURT,
-	WOLF_PANT,
-	WOLF_SHAKE,
-	WOLF_WALK,
-	WOLF_WHINE,
-	ZOMBIE_METAL,
-	ZOMBIE_WALK,
-	ZOMBIE_WOOD,
-	ZOMBIE_WOODBREAK,
-	ZOMBIE_IDLE,
-	ZOMBIE_DEATH,
-	ZOMBIE_HURT,
-	ZOMBIE_INFECT,
-	ZOMBIE_UNFECT,
-	ZOMBIE_REMEDY,
-	ZOMBIE_PIG_IDLE,
-	ZOMBIE_PIG_ANGRY,
-	ZOMBIE_PIG_DEATH,
-	ZOMBIE_PIG_HURT,
-	// Dig Sounds
-	DIG_WOOL,
-	DIG_GRASS,
-	DIG_GRAVEL,
-	DIG_SAND,
-	DIG_SNOW,
-	DIG_STONE,
-	DIG_WOOD,
-	// Fireworks
-	FIREWORK_BLAST,
-	FIREWORK_BLAST2,
-	FIREWORK_LARGE_BLAST,
-	FIREWORK_LARGE_BLAST2,
-	FIREWORK_TWINKLE,
-	FIREWORK_TWINKLE2,
-	FIREWORK_LAUNCH,
-	SUCCESSFUL_HIT,
-	// Horses
-	HORSE_ANGRY,
-	HORSE_ARMOR,
-	HORSE_BREATHE,
-	HORSE_GALLOP,
-	HORSE_HIT,
-	HORSE_IDLE,
-	HORSE_JUMP,
-	HORSE_LAND,
-	HORSE_SADDLE,
-	HORSE_SOFT,
-	HORSE_WOOD,
-	DONKEY_ANGRY,
-	DONKEY_DEATH,
-	DONKEY_HIT,
-	DONKEY_IDLE,
-	HORSE_SKELETON_DEATH,
-	HORSE_SKELETON_IDLE,
-	HORSE_ZOMBIE_DEATH,
-	HORSE_ZOMBIE_HIT,
-	HORSE_ZOMBIE_IDLE,
-	// Villager
-	VILLAGER_DEATH,
-	VILLAGER_HAGGLE,
-	VILLAGER_HIT,
-	VILLAGER_IDLE,
-	VILLAGER_NO,
-	VILLAGER_YES
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@MDynamicEnum("Sound")
+public abstract class MCSound<Concrete> extends DynamicEnum<MCSound.MCVanillaSound, Concrete> {
+
+	// To be filled by the implementer
+	protected static Map<String, MCSound> mappings;
+
+	public static MCSound NULL = null;
+
+	public MCSound(MCVanillaSound mcVanillaSound, Concrete concrete) {
+		super(mcVanillaSound, concrete);
+	}
+
+	public static MCSound valueOf(String test) throws IllegalArgumentException {
+		if (mappings == null) {
+			return null;
+		}
+		MCSound ret = mappings.get(test);
+		if (ret == null) {
+			throw new IllegalArgumentException("Unknown sound: " + test);
+		}
+		return ret;
+	}
+
+	public static Set<String> types() {
+		if (NULL == null) { // docs mode
+			Set<String> dummy = new HashSet<>();
+			for (final MCVanillaSound s : MCVanillaSound.values()) {
+				dummy.add(s.name());
+			}
+			return dummy;
+		}
+		return mappings.keySet();
+	}
+
+	public static Collection<MCSound> values() {
+		if (NULL == null) { // docs mode
+			ArrayList<MCSound> dummy = new ArrayList<>();
+			for (final MCVanillaSound s : MCVanillaSound.values()) {
+				dummy.add(new MCSound<Object>(s, null) {
+					@Override
+					public String name() {
+						return s.name();
+					}
+
+					@Override
+					public String concreteName() {
+						return s.name();
+					}
+				});
+			}
+			return dummy;
+		}
+		return mappings.values();
+	}
+
+	@MEnum("VanillaSound")
+	public enum MCVanillaSound {
+		AMBIENCE_CAVE,
+		AMBIENCE_RAIN,
+		AMBIENCE_THUNDER,
+		ANVIL_BREAK,
+		ANVIL_LAND,
+		ANVIL_USE,
+		ARROW_HIT,
+		BURP,
+		CHEST_CLOSE,
+		CHEST_OPEN,
+		CLICK,
+		DOOR_CLOSE,
+		DOOR_OPEN,
+		DRINK,
+		EAT,
+		EXPLODE,
+		FALL_BIG,
+		FALL_SMALL,
+		FIRE,
+		FIRE_IGNITE,
+		FIZZ,
+		FUSE,
+		GLASS,
+		HURT_FLESH,
+		ITEM_BREAK,
+		ITEM_PICKUP,
+		LAVA,
+		LAVA_POP,
+		LEVEL_UP,
+		MINECART_BASE,
+		MINECART_INSIDE,
+		NOTE_BASS,
+		NOTE_PIANO,
+		NOTE_BASS_DRUM,
+		NOTE_STICKS,
+		NOTE_BASS_GUITAR,
+		NOTE_SNARE_DRUM,
+		NOTE_PLING,
+		ORB_PICKUP,
+		PISTON_EXTEND,
+		PISTON_RETRACT,
+		PORTAL,
+		PORTAL_TRAVEL,
+		PORTAL_TRIGGER,
+		SHOOT_ARROW,
+		SPLASH,
+		SPLASH2,
+		STEP_GRASS,
+		STEP_GRAVEL,
+		STEP_LADDER,
+		STEP_SAND,
+		STEP_SNOW,
+		STEP_STONE,
+		STEP_WOOD,
+		STEP_WOOL,
+		SUCCESSFUL_HIT,
+		SWIM,
+		WATER,
+		WOOD_CLICK,
+		// Mob sounds
+		BAT_DEATH,
+		BAT_HURT,
+		BAT_IDLE,
+		BAT_LOOP,
+		BAT_TAKEOFF,
+		BLAZE_BREATH,
+		BLAZE_DEATH,
+		BLAZE_HIT,
+		CAT_HISS,
+		CAT_HIT,
+		CAT_MEOW,
+		CAT_PURR,
+		CAT_PURREOW,
+		CHICKEN_IDLE,
+		CHICKEN_HURT,
+		CHICKEN_EGG_POP,
+		CHICKEN_WALK,
+		COW_IDLE,
+		COW_HURT,
+		COW_WALK,
+		CREEPER_HISS,
+		CREEPER_DEATH,
+		ENDERDRAGON_DEATH,
+		ENDERDRAGON_GROWL,
+		ENDERDRAGON_HIT,
+		ENDERDRAGON_WINGS,
+		ENDERMAN_DEATH,
+		ENDERMAN_HIT,
+		ENDERMAN_IDLE,
+		ENDERMAN_TELEPORT,
+		ENDERMAN_SCREAM,
+		ENDERMAN_STARE,
+		GHAST_SCREAM,
+		GHAST_SCREAM2,
+		GHAST_CHARGE,
+		GHAST_DEATH,
+		GHAST_FIREBALL,
+		GHAST_MOAN,
+		HORSE_DEATH,
+		HORSE_SKELETON_HIT,
+		IRONGOLEM_DEATH,
+		IRONGOLEM_HIT,
+		IRONGOLEM_THROW,
+		IRONGOLEM_WALK,
+		MAGMACUBE_WALK,
+		MAGMACUBE_WALK2,
+		MAGMACUBE_JUMP,
+		PIG_IDLE,
+		PIG_DEATH,
+		PIG_WALK,
+		SHEEP_IDLE,
+		SHEEP_SHEAR,
+		SHEEP_WALK,
+		SILVERFISH_HIT,
+		SILVERFISH_KILL,
+		SILVERFISH_IDLE,
+		SILVERFISH_WALK,
+		SKELETON_IDLE,
+		SKELETON_DEATH,
+		SKELETON_HURT,
+		SKELETON_WALK,
+		SLIME_ATTACK,
+		SLIME_WALK,
+		SLIME_WALK2,
+		SPIDER_IDLE,
+		SPIDER_DEATH,
+		SPIDER_WALK,
+		WITHER_DEATH,
+		WITHER_HURT,
+		WITHER_IDLE,
+		WITHER_SHOOT,
+		WITHER_SPAWN,
+		WOLF_BARK,
+		WOLF_DEATH,
+		WOLF_GROWL,
+		WOLF_HOWL,
+		WOLF_HURT,
+		WOLF_PANT,
+		WOLF_SHAKE,
+		WOLF_WALK,
+		WOLF_WHINE,
+		ZOMBIE_METAL,
+		ZOMBIE_WALK,
+		ZOMBIE_WOOD,
+		ZOMBIE_WOODBREAK,
+		ZOMBIE_IDLE,
+		ZOMBIE_DEATH,
+		ZOMBIE_HURT,
+		ZOMBIE_INFECT,
+		ZOMBIE_UNFECT,
+		ZOMBIE_REMEDY,
+		ZOMBIE_PIG_IDLE,
+		ZOMBIE_PIG_ANGRY,
+		ZOMBIE_PIG_DEATH,
+		ZOMBIE_PIG_HURT,
+		// Dig Sounds
+		DIG_WOOL,
+		DIG_GRASS,
+		DIG_GRAVEL,
+		DIG_SAND,
+		DIG_SNOW,
+		DIG_STONE,
+		DIG_WOOD,
+		// Fireworks
+		FIREWORK_BLAST,
+		FIREWORK_BLAST2,
+		FIREWORK_LARGE_BLAST,
+		FIREWORK_LARGE_BLAST2,
+		FIREWORK_TWINKLE,
+		FIREWORK_TWINKLE2,
+		FIREWORK_LAUNCH,
+		// Horses
+		HORSE_ANGRY,
+		HORSE_ARMOR,
+		HORSE_BREATHE,
+		HORSE_GALLOP,
+		HORSE_HIT,
+		HORSE_IDLE,
+		HORSE_JUMP,
+		HORSE_LAND,
+		HORSE_SADDLE,
+		HORSE_SOFT,
+		HORSE_WOOD,
+		DONKEY_ANGRY,
+		DONKEY_DEATH,
+		DONKEY_HIT,
+		DONKEY_IDLE,
+		HORSE_SKELETON_DEATH,
+		HORSE_SKELETON_IDLE,
+		HORSE_ZOMBIE_DEATH,
+		HORSE_ZOMBIE_HIT,
+		HORSE_ZOMBIE_IDLE,
+		// Villager
+		VILLAGER_DEATH,
+		VILLAGER_HAGGLE,
+		VILLAGER_HIT,
+		VILLAGER_IDLE,
+		VILLAGER_NO,
+		VILLAGER_YES,
+		UNKNOWN(MCVersion.NEVER);
+
+		private final MCVersion since;
+
+		MCVanillaSound() {
+			this(MCVersion.MC1_0);
+		}
+
+		MCVanillaSound(MCVersion since) {
+			this.since = since;
+		}
+
+		public boolean existsInCurrent() {
+			return Static.getServer().getMinecraftVersion().gte(since);
+		}
+	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCSound.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCSound.java
@@ -1,28 +1,485 @@
+
 package com.laytonsmith.abstraction.enums.bukkit;
 
-import com.laytonsmith.abstraction.Implementation;
-import com.laytonsmith.abstraction.enums.EnumConvertor;
 import com.laytonsmith.abstraction.enums.MCSound;
-import com.laytonsmith.annotations.abstractionenum;
+import com.laytonsmith.abstraction.enums.MCVersion;
+import com.laytonsmith.core.CHLog;
+import com.laytonsmith.core.Static;
+import com.laytonsmith.core.constructs.Target;
 import org.bukkit.Sound;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 /**
- * 
- * @author jb_aero
+ *
+ *
  */
-@abstractionenum(
-		implementation=Implementation.Type.BUKKIT,
-		forAbstractEnum=MCSound.class,
-		forConcreteEnum=Sound.class
-		)
-public class BukkitMCSound extends EnumConvertor<MCSound, Sound> {
+public class BukkitMCSound extends MCSound<Sound> {
 
-	private static com.laytonsmith.abstraction.enums.bukkit.BukkitMCSound instance;
+	public BukkitMCSound(MCVanillaSound vanillaSound, Sound sound) {
+		super(vanillaSound, sound);
+	}
 
-	public static com.laytonsmith.abstraction.enums.bukkit.BukkitMCSound getConvertor() {
-		if (instance == null) {
-			instance = new com.laytonsmith.abstraction.enums.bukkit.BukkitMCSound();
+	@Override
+	public String name() {
+		return getAbstracted() == MCVanillaSound.UNKNOWN ? concreteName() : getAbstracted().name();
+	}
+
+	@Override
+	public String concreteName() {
+		return getConcrete() == null ? "null" : getConcrete().name();
+	}
+
+	public static BukkitMCSound valueOfConcrete(Sound test) {
+		for (MCSound t : mappings.values()) {
+			if (((BukkitMCSound) t).getConcrete().equals(test)) {
+				return (BukkitMCSound) t;
+			}
 		}
-		return instance;
+		return (BukkitMCSound) NULL;
+	}
+
+	public static BukkitMCSound valueOfConcrete(String test) {
+		try {
+			return valueOfConcrete(Sound.valueOf(test));
+		} catch (IllegalArgumentException iae) {
+			return (BukkitMCSound) NULL;
+		}
+	}
+
+	// This way we don't take up extra memory on non-bukkit implementations
+	public static void build() {
+		mappings = new HashMap<>();
+		NULL = new BukkitMCSound(MCVanillaSound.UNKNOWN, null);
+		ArrayList<Sound> counted = new ArrayList<>();
+		for (MCVanillaSound v : MCVanillaSound.values()) {
+			if (v.existsInCurrent()) {
+				Sound sound = getBukkitType(v);
+				if (sound == null) {
+					CHLog.GetLogger().e(CHLog.Tags.RUNTIME, "Could not find a matching sound for " + v.name()
+							+ ". This is an error, please report this to the bug tracker.", Target.UNKNOWN);
+					continue;
+				}
+				BukkitMCSound wrapper = new BukkitMCSound(v, sound);
+				mappings.put(v.name(), wrapper);
+				counted.add(sound);
+			}
+		}
+		for (Sound s : Sound.values()) {
+			if (!counted.contains(s)) {
+				mappings.put(s.name(), new BukkitMCSound(MCVanillaSound.UNKNOWN, s));
+			}
+		}
+	}
+
+	private static Sound getBukkitType(MCVanillaSound v) {
+		if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_9)){
+			switch(v){
+				case AMBIENCE_CAVE:
+					return Sound.AMBIENT_CAVE;
+				case AMBIENCE_RAIN:
+					return Sound.WEATHER_RAIN;
+				case AMBIENCE_THUNDER:
+					return Sound.ENTITY_LIGHTNING_THUNDER;
+				case ANVIL_BREAK:
+					return Sound.BLOCK_ANVIL_DESTROY;
+				case ANVIL_LAND:
+					return Sound.BLOCK_ANVIL_LAND;
+				case ANVIL_USE:
+					return Sound.BLOCK_ANVIL_USE;
+				case ARROW_HIT:
+					return Sound.ENTITY_ARROW_HIT;
+				case BURP:
+					return Sound.ENTITY_PLAYER_BURP;
+				case CHEST_CLOSE:
+					return Sound.BLOCK_CHEST_CLOSE;
+				case CHEST_OPEN:
+					return Sound.BLOCK_CHEST_OPEN;
+				case CLICK:
+					return Sound.UI_BUTTON_CLICK;
+				case DOOR_CLOSE:
+					return Sound.BLOCK_WOODEN_DOOR_CLOSE;
+				case DOOR_OPEN:
+					return Sound.BLOCK_WOODEN_DOOR_OPEN;
+				case DRINK:
+					return Sound.ENTITY_GENERIC_DRINK;
+				case EAT:
+					return Sound.ENTITY_GENERIC_EAT;
+				case EXPLODE:
+					return Sound.ENTITY_GENERIC_EXPLODE;
+				case FALL_BIG:
+					return Sound.ENTITY_GENERIC_BIG_FALL;
+				case FALL_SMALL:
+					return Sound.ENTITY_GENERIC_SMALL_FALL;
+				case FIRE:
+					return Sound.BLOCK_FIRE_AMBIENT;
+				case FIRE_IGNITE:
+					return Sound.ITEM_FLINTANDSTEEL_USE;
+				case FIZZ:
+					return Sound.ENTITY_GENERIC_EXTINGUISH_FIRE;
+				case FUSE:
+					return Sound.ENTITY_TNT_PRIMED;
+				case GLASS:
+					return Sound.BLOCK_GLASS_BREAK;
+				case HURT_FLESH:
+					return Sound.ENTITY_GENERIC_HURT;
+				case ITEM_BREAK:
+					return Sound.ENTITY_ITEM_BREAK;
+				case ITEM_PICKUP:
+					return Sound.ENTITY_ITEM_PICKUP;
+				case LAVA:
+					return Sound.BLOCK_LAVA_AMBIENT;
+				case LAVA_POP:
+					return Sound.BLOCK_LAVA_POP;
+				case LEVEL_UP:
+					return Sound.ENTITY_PLAYER_LEVELUP;
+				case MINECART_BASE:
+					return Sound.ENTITY_MINECART_RIDING;
+				case MINECART_INSIDE:
+					return Sound.ENTITY_MINECART_INSIDE;
+				case NOTE_BASS:
+					return Sound.BLOCK_NOTE_BASS;
+				case NOTE_PIANO:
+					return Sound.BLOCK_NOTE_HARP;
+				case NOTE_BASS_DRUM:
+					return Sound.BLOCK_NOTE_BASEDRUM;
+				case NOTE_STICKS:
+					return Sound.BLOCK_NOTE_HAT;
+				case NOTE_BASS_GUITAR:
+					return Sound.BLOCK_NOTE_BASS;
+				case NOTE_SNARE_DRUM:
+					return Sound.BLOCK_NOTE_SNARE;
+				case NOTE_PLING:
+					return Sound.BLOCK_NOTE_PLING;
+				case ORB_PICKUP:
+					return Sound.ENTITY_EXPERIENCE_ORB_PICKUP;
+				case PISTON_EXTEND:
+					return Sound.BLOCK_PISTON_EXTEND;
+				case PISTON_RETRACT:
+					return Sound.BLOCK_PISTON_CONTRACT;
+				case PORTAL:
+					return Sound.BLOCK_PORTAL_AMBIENT;
+				case PORTAL_TRAVEL:
+					return Sound.BLOCK_PORTAL_TRAVEL;
+				case PORTAL_TRIGGER:
+					return Sound.BLOCK_PORTAL_TRIGGER;
+				case SHOOT_ARROW:
+					return Sound.ENTITY_ARROW_SHOOT;
+				case SPLASH:
+					return Sound.ENTITY_BOBBER_SPLASH;
+				case SPLASH2:
+					return Sound.ENTITY_GENERIC_SPLASH;
+				case STEP_GRASS:
+					return Sound.BLOCK_GRASS_STEP;
+				case STEP_GRAVEL:
+					return Sound.BLOCK_GRAVEL_STEP;
+				case STEP_LADDER:
+					return Sound.BLOCK_LADDER_STEP;
+				case STEP_SAND:
+					return Sound.BLOCK_SAND_STEP;
+				case STEP_SNOW:
+					return Sound.BLOCK_SNOW_STEP;
+				case STEP_STONE:
+					return Sound.BLOCK_STONE_STEP;
+				case STEP_WOOD:
+					return Sound.BLOCK_WOOD_STEP;
+				case STEP_WOOL:
+					return Sound.BLOCK_CLOTH_STEP;
+				case SUCCESSFUL_HIT:
+					return Sound.ENTITY_ARROW_HIT_PLAYER;
+				case SWIM:
+					return Sound.ENTITY_GENERIC_SWIM;
+				case WATER:
+					return Sound.BLOCK_WATER_AMBIENT;
+				case WOOD_CLICK:
+					return Sound.BLOCK_WOOD_BUTTON_CLICK_ON;
+
+				// Mob sounds
+				case BAT_DEATH:
+					return Sound.ENTITY_BAT_DEATH;
+				case BAT_HURT:
+					return Sound.ENTITY_BAT_HURT;
+				case BAT_IDLE:
+					return Sound.ENTITY_BAT_AMBIENT;
+				case BAT_LOOP:
+					return Sound.ENTITY_BAT_LOOP;
+				case BAT_TAKEOFF:
+					return Sound.ENTITY_BAT_TAKEOFF;
+				case BLAZE_BREATH:
+					return Sound.ENTITY_BLAZE_AMBIENT;
+				case BLAZE_DEATH:
+					return Sound.ENTITY_BLAZE_DEATH;
+				case BLAZE_HIT:
+					return Sound.ENTITY_BLAZE_HURT;
+				case CAT_HISS:
+					return Sound.ENTITY_CAT_HISS;
+				case CAT_HIT:
+					return Sound.ENTITY_CAT_HURT;
+				case CAT_MEOW:
+					return Sound.ENTITY_CAT_AMBIENT;
+				case CAT_PURR:
+					return Sound.ENTITY_CAT_PURR;
+				case CAT_PURREOW:
+					return Sound.ENTITY_CAT_PURREOW;
+				case CHICKEN_IDLE:
+					return Sound.ENTITY_CHICKEN_AMBIENT;
+				case CHICKEN_HURT:
+					return Sound.ENTITY_CHICKEN_HURT;
+				case CHICKEN_EGG_POP:
+					return Sound.ENTITY_CHICKEN_EGG;
+				case CHICKEN_WALK:
+					return Sound.ENTITY_CHICKEN_STEP;
+				case COW_IDLE:
+					return Sound.ENTITY_COW_AMBIENT;
+				case COW_HURT:
+					return Sound.ENTITY_COW_HURT;
+				case COW_WALK:
+					return Sound.ENTITY_COW_STEP;
+				case CREEPER_HISS:
+					return Sound.ENTITY_CREEPER_HURT;
+				case CREEPER_DEATH:
+					return Sound.ENTITY_CREEPER_DEATH;
+				case ENDERDRAGON_DEATH:
+					return Sound.ENTITY_ENDERDRAGON_DEATH;
+				case ENDERDRAGON_GROWL:
+					return Sound.ENTITY_ENDERDRAGON_GROWL;
+				case ENDERDRAGON_HIT:
+					return Sound.ENTITY_ENDERDRAGON_HURT;
+				case ENDERDRAGON_WINGS:
+					return Sound.ENTITY_ENDERDRAGON_FLAP;
+				case ENDERMAN_DEATH:
+					return Sound.ENTITY_ENDERMEN_DEATH;
+				case ENDERMAN_HIT:
+					return Sound.ENTITY_ENDERMEN_HURT;
+				case ENDERMAN_IDLE:
+					return Sound.ENTITY_ENDERMEN_AMBIENT;
+				case ENDERMAN_TELEPORT:
+					return Sound.ENTITY_ENDERMEN_TELEPORT;
+				case ENDERMAN_SCREAM:
+					return Sound.ENTITY_ENDERMEN_SCREAM;
+				case ENDERMAN_STARE:
+					return Sound.ENTITY_ENDERMEN_STARE;
+				case GHAST_SCREAM:
+					return Sound.ENTITY_GHAST_HURT;
+				case GHAST_SCREAM2:
+					return Sound.ENTITY_GHAST_SCREAM;
+				case GHAST_CHARGE:
+					return Sound.ENTITY_GHAST_WARN;
+				case GHAST_DEATH:
+					return Sound.ENTITY_GHAST_DEATH;
+				case GHAST_FIREBALL:
+					return Sound.ENTITY_GHAST_SHOOT;
+				case GHAST_MOAN:
+					return Sound.ENTITY_GHAST_AMBIENT;
+				case HORSE_DEATH:
+					return Sound.ENTITY_HORSE_DEATH;
+				case HORSE_SKELETON_HIT:
+					return Sound.ENTITY_SKELETON_HORSE_HURT;
+				case IRONGOLEM_DEATH:
+					return Sound.ENTITY_IRONGOLEM_DEATH;
+				case IRONGOLEM_HIT:
+					return Sound.ENTITY_IRONGOLEM_HURT;
+				case IRONGOLEM_THROW:
+					return Sound.ENTITY_IRONGOLEM_ATTACK;
+				case IRONGOLEM_WALK:
+					return Sound.ENTITY_IRONGOLEM_STEP;
+				case MAGMACUBE_WALK:
+					return Sound.ENTITY_SMALL_MAGMACUBE_SQUISH;
+				case MAGMACUBE_WALK2:
+					return Sound.ENTITY_MAGMACUBE_SQUISH;
+				case MAGMACUBE_JUMP:
+					return Sound.ENTITY_MAGMACUBE_JUMP;
+				case PIG_IDLE:
+					return Sound.ENTITY_PIG_AMBIENT;
+				case PIG_DEATH:
+					return Sound.ENTITY_PIG_DEATH;
+				case PIG_WALK:
+					return Sound.ENTITY_PIG_STEP;
+				case SHEEP_IDLE:
+					return Sound.ENTITY_SHEEP_AMBIENT;
+				case SHEEP_SHEAR:
+					return Sound.ENTITY_SHEEP_SHEAR;
+				case SHEEP_WALK:
+					return Sound.ENTITY_SHEEP_STEP;
+				case SILVERFISH_HIT:
+					return Sound.ENTITY_SILVERFISH_HURT;
+				case SILVERFISH_KILL:
+					return Sound.ENTITY_SILVERFISH_DEATH;
+				case SILVERFISH_IDLE:
+					return Sound.ENTITY_SILVERFISH_AMBIENT;
+				case SILVERFISH_WALK:
+					return Sound.ENTITY_SILVERFISH_STEP;
+				case SKELETON_IDLE:
+					return Sound.ENTITY_SKELETON_AMBIENT;
+				case SKELETON_DEATH:
+					return Sound.ENTITY_SKELETON_DEATH;
+				case SKELETON_HURT:
+					return Sound.ENTITY_SKELETON_HURT;
+				case SKELETON_WALK:
+					return Sound.ENTITY_SKELETON_STEP;
+				case SLIME_ATTACK:
+					return Sound.ENTITY_SLIME_ATTACK;
+				case SLIME_WALK:
+					return Sound.ENTITY_SMALL_SLIME_HURT;
+				case SLIME_WALK2:
+					return Sound.ENTITY_SLIME_SQUISH;
+				case SPIDER_IDLE:
+					return Sound.ENTITY_SPIDER_AMBIENT;
+				case SPIDER_DEATH:
+					return Sound.ENTITY_SPIDER_DEATH;
+				case SPIDER_WALK:
+					return Sound.ENTITY_SPIDER_STEP;
+				case WITHER_DEATH:
+					return Sound.ENTITY_WITHER_DEATH;
+				case WITHER_HURT:
+					return Sound.ENTITY_WITHER_HURT;
+				case WITHER_IDLE:
+					return Sound.ENTITY_WITHER_AMBIENT;
+				case WITHER_SHOOT:
+					return Sound.ENTITY_WITHER_SHOOT;
+				case WITHER_SPAWN:
+					return Sound.ENTITY_WITHER_SPAWN;
+				case WOLF_BARK:
+					return Sound.ENTITY_WOLF_AMBIENT;
+				case WOLF_DEATH:
+					return Sound.ENTITY_WOLF_DEATH;
+				case WOLF_GROWL:
+					return Sound.ENTITY_WOLF_GROWL;
+				case WOLF_HOWL:
+					return Sound.ENTITY_WOLF_HOWL;
+				case WOLF_HURT:
+					return Sound.ENTITY_WOLF_HURT;
+				case WOLF_PANT:
+					return Sound.ENTITY_WOLF_PANT;
+				case WOLF_SHAKE:
+					return Sound.ENTITY_WOLF_SHAKE;
+				case WOLF_WALK:
+					return Sound.ENTITY_WOLF_STEP;
+				case WOLF_WHINE:
+					return Sound.ENTITY_WOLF_WHINE;
+				case ZOMBIE_METAL:
+					return Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR;
+				case ZOMBIE_WALK:
+					return Sound.ENTITY_ZOMBIE_STEP;
+				case ZOMBIE_WOOD:
+					return Sound.ENTITY_ZOMBIE_ATTACK_DOOR_WOOD;
+				case ZOMBIE_WOODBREAK:
+					return Sound.ENTITY_ZOMBIE_BREAK_DOOR_WOOD;
+				case ZOMBIE_IDLE:
+					return Sound.ENTITY_ZOMBIE_AMBIENT;
+				case ZOMBIE_DEATH:
+					return Sound.ENTITY_ZOMBIE_DEATH;
+				case ZOMBIE_HURT:
+					return Sound.ENTITY_ZOMBIE_HURT;
+				case ZOMBIE_INFECT:
+					return Sound.ENTITY_ZOMBIE_INFECT;
+				case ZOMBIE_UNFECT:
+					return Sound.ENTITY_ZOMBIE_VILLAGER_CONVERTED;
+				case ZOMBIE_REMEDY:
+					return Sound.ENTITY_ZOMBIE_VILLAGER_CURE;
+				case ZOMBIE_PIG_IDLE:
+					return Sound.ENTITY_ZOMBIE_PIG_AMBIENT;
+				case ZOMBIE_PIG_ANGRY:
+					return Sound.ENTITY_ZOMBIE_PIG_ANGRY;
+				case ZOMBIE_PIG_DEATH:
+					return Sound.ENTITY_ZOMBIE_PIG_DEATH;
+				case ZOMBIE_PIG_HURT:
+					return Sound.ENTITY_ZOMBIE_PIG_HURT;
+
+				// Dig Sounds
+				case DIG_WOOL:
+					return Sound.BLOCK_CLOTH_BREAK;
+				case DIG_GRASS:
+					return Sound.BLOCK_GRASS_BREAK;
+				case DIG_GRAVEL:
+					return Sound.BLOCK_GRAVEL_BREAK;
+				case DIG_SAND:
+					return Sound.BLOCK_SAND_BREAK;
+				case DIG_SNOW:
+					return Sound.BLOCK_SNOW_BREAK;
+				case DIG_STONE:
+					return Sound.BLOCK_STONE_BREAK;
+				case DIG_WOOD:
+					return Sound.BLOCK_WOOD_BREAK;
+
+				// Fireworks
+				case FIREWORK_BLAST:
+					return Sound.ENTITY_FIREWORK_BLAST;
+				case FIREWORK_BLAST2:
+					return Sound.ENTITY_FIREWORK_BLAST_FAR;
+				case FIREWORK_LARGE_BLAST:
+					return Sound.ENTITY_FIREWORK_LARGE_BLAST;
+				case FIREWORK_LARGE_BLAST2:
+					return Sound.ENTITY_FIREWORK_LARGE_BLAST_FAR;
+				case FIREWORK_TWINKLE:
+					return Sound.ENTITY_FIREWORK_TWINKLE;
+				case FIREWORK_TWINKLE2:
+					return Sound.ENTITY_FIREWORK_TWINKLE_FAR;
+				case FIREWORK_LAUNCH:
+					return Sound.ENTITY_FIREWORK_LAUNCH;
+
+				// Horses
+				case HORSE_ANGRY:
+					return Sound.ENTITY_HORSE_ANGRY;
+				case HORSE_ARMOR:
+					return Sound.ENTITY_HORSE_ARMOR;
+				case HORSE_BREATHE:
+					return Sound.ENTITY_HORSE_BREATHE;
+				case HORSE_GALLOP:
+					return Sound.ENTITY_HORSE_GALLOP;
+				case HORSE_HIT:
+					return Sound.ENTITY_HORSE_HURT;
+				case HORSE_IDLE:
+					return Sound.ENTITY_HORSE_AMBIENT;
+				case HORSE_JUMP:
+					return Sound.ENTITY_HORSE_JUMP;
+				case HORSE_LAND:
+					return Sound.ENTITY_HORSE_LAND;
+				case HORSE_SADDLE:
+					return Sound.ENTITY_HORSE_SADDLE;
+				case HORSE_SOFT:
+					return Sound.ENTITY_HORSE_STEP;
+				case HORSE_WOOD:
+					return Sound.ENTITY_HORSE_STEP_WOOD;
+				case DONKEY_ANGRY:
+					return Sound.ENTITY_DONKEY_ANGRY;
+				case DONKEY_DEATH:
+					return Sound.ENTITY_DONKEY_DEATH;
+				case DONKEY_HIT:
+					return Sound.ENTITY_DONKEY_HURT;
+				case DONKEY_IDLE:
+					return Sound.ENTITY_DONKEY_AMBIENT;
+				case HORSE_SKELETON_DEATH:
+					return Sound.ENTITY_SKELETON_HORSE_DEATH;
+				case HORSE_SKELETON_IDLE:
+					return Sound.ENTITY_SKELETON_HORSE_AMBIENT;
+				case HORSE_ZOMBIE_DEATH:
+					return Sound.ENTITY_ZOMBIE_HORSE_DEATH;
+				case HORSE_ZOMBIE_HIT:
+					return Sound.ENTITY_ZOMBIE_HORSE_HURT;
+				case HORSE_ZOMBIE_IDLE:
+					return Sound.ENTITY_ZOMBIE_HORSE_AMBIENT;
+
+				// Villager
+				case VILLAGER_DEATH:
+					return Sound.ENTITY_VILLAGER_DEATH;
+				case VILLAGER_HAGGLE:
+					return Sound.ENTITY_VILLAGER_TRADING;
+				case VILLAGER_HIT:
+					return Sound.ENTITY_VILLAGER_HURT;
+				case VILLAGER_IDLE:
+					return Sound.ENTITY_VILLAGER_AMBIENT;
+				case VILLAGER_NO:
+					return Sound.ENTITY_VILLAGER_NO;
+				case VILLAGER_YES:
+					return Sound.ENTITY_VILLAGER_YES;
+			}
+		}
+		try {
+			return Sound.valueOf(v.name());
+		} catch (IllegalArgumentException iae) {
+			return null;
+		}
 	}
 }

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
@@ -41,6 +41,7 @@ import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCBiomeType;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCEntityType;
+import com.laytonsmith.abstraction.enums.bukkit.BukkitMCSound;
 import com.laytonsmith.annotations.EventIdentifier;
 import com.laytonsmith.core.AliasCore;
 import com.laytonsmith.core.CHLog;
@@ -320,6 +321,7 @@ public class CommandHelperPlugin extends JavaPlugin {
 		}
 		BukkitMCEntityType.build();
 		BukkitMCBiomeType.build();
+		BukkitMCSound.build();
 
 		//Metrics
 		// MCStats no longer appears to be supported. If it comes back, this code can be re-added

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -1052,7 +1052,7 @@ public class Environment {
 					+ " player or an array of players to play the sound to, if"
 					+ " not given, all players can potentially hear it. ----"
 					+ " Possible sounds: "
-					+ StringUtils.Join(MCSound.values(), ", ", ", or ", " or ");
+					+ StringUtils.Join(MCSound.types(), ", ", ", or ", " or ");
 		}
 
 		@Override


### PR DESCRIPTION
This uses the same dynamic ENUM system as BiomeType and EntityType to build a map of old sound names to the same sounds in the new ENUM. This maintains backwards compatibility with scripts and MC versions.

This does not add the new sounds. It's going to be tricky to decide on the names for that and I just need to get this out.

In the future we could decide to ditch the old ENUM in favor of the new one, then just convert the new ENUM to the old via the same mechanism if MCVersion is less than 1.9. Of course, this would soft-break existing scripts. (currently scripts don't fail, but the sounds don't play)