### PR TITLE
Added backwards compatibility to player_interact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
 				<role>contributor</role>
 			</roles>
 		</contributor>
+		<contributor>
+			<name>Pieter12345/Woesh0007</name>
+			<roles>
+				<role>contributor</role>
+			</roles>
+		</contributor>
 	</contributors>
 	<issueManagement>
 		<system>sk89q's Youtrack</system>

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
@@ -551,12 +551,21 @@ public class BukkitPlayerEvents {
             return new BukkitMCItemStack(pie.getItem());
         }
 		
+		/**
+		 * @since Bukkit 1.9
+		 * @throws UnsupportedOperationException When this method does not exist in the current Bukkit version.
+		 */
 		@Override
-		public MCEquipmentSlot getHand() {
-		    if(pie.getHand() == EquipmentSlot.HAND) {
-		        return MCEquipmentSlot.WEAPON;
-		    }
-		    return MCEquipmentSlot.OFF_HAND;
+		public MCEquipmentSlot getHand() throws UnsupportedOperationException {
+			try {
+				if(pie.getHand() == EquipmentSlot.HAND) {
+					return MCEquipmentSlot.WEAPON;
+				}
+				return MCEquipmentSlot.OFF_HAND;
+			} catch(NoSuchMethodError e) {
+				throw new UnsupportedOperationException(
+						"getHand() method does not exist in Bukkit version: " + Bukkit.getBukkitVersion());
+			}
 		}
     }
 

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -860,18 +860,28 @@ public class PlayerEvents {
         public boolean matches(Map<String, Construct> prefilter, BindableEvent e) throws PrefilterNonMatchException {
             if(e instanceof MCPlayerInteractEvent){
                 MCPlayerInteractEvent pie = (MCPlayerInteractEvent)e;
-                MCEquipmentSlot h = pie.getHand();
                 CString hand;
+				MCEquipmentSlot h;
+				
+				try {
+					h = pie.getHand();
+				} catch(UnsupportedOperationException ex) {
+					h = null; // We are likely on a pre-1.9 server.
+				}
                 
                 if(((MCPlayerInteractEvent)e).getAction().equals(MCAction.PHYSICAL)){
                     return false;
                 }
                 
-                if(h == MCEquipmentSlot.WEAPON) {
-                   hand = new CString("main_hand", Target.UNKNOWN);
-                } else {
-                    hand = new CString("off_hand", Target.UNKNOWN);
-                }
+				if(h == null) {
+					if(h == MCEquipmentSlot.WEAPON) {
+						hand = new CString("main_hand", Target.UNKNOWN);
+					} else {
+						hand = new CString("off_hand", Target.UNKNOWN);
+					}
+				} else {
+					hand = null;
+				}
                 
                 if(prefilter.containsKey("button")){
                     if(pie.getAction().equals(MCAction.LEFT_CLICK_AIR) || pie.getAction().equals(MCAction.LEFT_CLICK_BLOCK)){
@@ -889,7 +899,9 @@ public class PlayerEvents {
                 Prefilters.match(prefilter, "item", Static.ParseItemNotation(pie.getItem()), PrefilterType.ITEM_MATCH);
                 Prefilters.match(prefilter, "block", Static.ParseItemNotation(pie.getClickedBlock()), PrefilterType.ITEM_MATCH);
                 Prefilters.match(prefilter, "player", pie.getPlayer().getName(), PrefilterType.MACRO);
-                Prefilters.match(prefilter, "hand", hand, PrefilterType.STRING_MATCH);
+				if(hand != null) {
+					Prefilters.match(prefilter, "hand", hand, PrefilterType.STRING_MATCH);
+				}
 
                 return true;
             }
@@ -903,7 +915,12 @@ public class PlayerEvents {
                 Map<String, Construct> map = evaluate_helper(e);
                 //map.put("player", new CString(pie.getPlayer().getName(), Target.UNKNOWN));
                 MCAction a = pie.getAction();
-                MCEquipmentSlot h = pie.getHand();
+				MCEquipmentSlot h;
+				try {
+					h = pie.getHand();
+				} catch(UnsupportedOperationException ex) {
+					h = null; // We are likely on a pre-1.9 server.
+				}
                 map.put("action", new CString(a.name().toLowerCase(), Target.UNKNOWN));
                 map.put("block", new CString(Static.ParseItemNotation(pie.getClickedBlock()), Target.UNKNOWN));
                 if(a == MCAction.LEFT_CLICK_AIR || a == MCAction.LEFT_CLICK_BLOCK){
@@ -917,11 +934,13 @@ public class PlayerEvents {
                 }
 				map.put("world", new CString(pie.getPlayer().getWorld().getName(), Target.UNKNOWN));
                 map.put("item", new CString(Static.ParseItemNotation(pie.getItem()), Target.UNKNOWN));
-                if(h == MCEquipmentSlot.WEAPON) {
-                    map.put("hand", new CString("main_hand", Target.UNKNOWN));
-                } else {
-                    map.put("hand", new CString("off_hand", Target.UNKNOWN));
-                }
+                if(h != null) {
+					if(h == MCEquipmentSlot.WEAPON) {
+						map.put("hand", new CString("main_hand", Target.UNKNOWN));
+					} else {
+						map.put("hand", new CString("off_hand", Target.UNKNOWN));
+					}
+				}
                 
                 return map;
             } else {


### PR DESCRIPTION
Since the getHand() method in PlayerInteractEvent does not exist in
Bukkit versions prior to 1.9, it became incompatible with those version
after this was added to CH. This fixes that.