### PR TITLE
Catch CancellationExceptions when shutting down.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -117,6 +117,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
@@ -274,6 +275,11 @@ public class BukkitConvertor extends AbstractConvertor {
 					return null;
 				}
 			});
+		} catch(CancellationException ex) {
+			// Ignore the Exception when the plugin is disabled (server shutting down).
+			if(CommandHelperPlugin.self.isEnabled()) {
+				java.util.logging.Logger.getLogger(BukkitConvertor.class.getName()).log(Level.SEVERE, null, ex);
+			}
 		} catch (InterruptedException | ExecutionException ex) {
 			java.util.logging.Logger.getLogger(BukkitConvertor.class.getName()).log(Level.SEVERE, null, ex);
 		}


### PR DESCRIPTION
When the MC server shuts down and CommandHelper is disabled, scheduling
a task will result in a CancellationException. This Exception is now
caught and ignored or logged based on whether CommandHelper was still
enabled or not (before this commit, it was a raw stacktrace on the
console from a Timer thread).