### PR TITLE
Update Firework meta

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCFireworkBuilder.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCFireworkBuilder.java
@@ -1,16 +1,7 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.laytonsmith.abstraction;
 
-import com.laytonsmith.abstraction.entities.MCFirework;
 import com.laytonsmith.abstraction.enums.MCFireworkType;
 
-/**
- *
- *
- */
 public interface MCFireworkBuilder {
 
 	/**
@@ -35,12 +26,6 @@ public interface MCFireworkBuilder {
 	 * @return
 	 */
 	MCFireworkBuilder addFadeColor(MCColor color);
-	/**
-	 * Sets the launch strength of the firework
-	 * @param i
-	 * @return
-	 */
-	MCFireworkBuilder setStrength(int i);
 
 	/**
 	 * Sets the firework type of the firework.
@@ -48,18 +33,11 @@ public interface MCFireworkBuilder {
 	 * @return
 	 */
 	MCFireworkBuilder setType(MCFireworkType type);
-	/**
-	 * Launches the firework from the specified location, upward.
-	 * @param l
-	 * @return entityID of the firework
-	 */
-	MCFirework launch(MCLocation l);
 
 	/**
-	 * Given the entered builder data, create a firework meta with these attributes
-	 * for a given MCFireworkMeta
-	 * @return
+	 * Returns the firework effect object created by this builder
+	 * @return MCFireworkEffect
 	 */
-	void createFireworkMeta(MCFireworkMeta meta);
+	MCFireworkEffect build();
 
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCFireworkEffect.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCFireworkEffect.java
@@ -1,0 +1,15 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.enums.MCFireworkType;
+
+import java.util.List;
+
+public interface MCFireworkEffect extends AbstractionObject {
+
+	boolean hasFlicker();
+	boolean hasTrail();
+	List<MCColor> getColors();
+	List<MCColor> getFadeColors();
+	MCFireworkType getType();
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCFireworkEffectMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCFireworkEffectMeta.java
@@ -1,0 +1,9 @@
+package com.laytonsmith.abstraction;
+
+public interface MCFireworkEffectMeta extends MCItemMeta {
+
+	boolean hasEffect();
+	MCFireworkEffect getEffect();
+	void setEffect(MCFireworkEffect effect);
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCFireworkMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCFireworkMeta.java
@@ -1,21 +1,12 @@
 package com.laytonsmith.abstraction;
 
-import com.laytonsmith.abstraction.enums.MCFireworkType;
 import java.util.List;
 
 public interface MCFireworkMeta extends MCItemMeta {
 
 	int getStrength();
 	void setStrength(int strength);
-
-	boolean getFlicker();
-
-	boolean getTrail();
-
-	List<MCColor> getColors();
-
-	List<MCColor> getFadeColors();
-
-	MCFireworkType getType();
+	List<MCFireworkEffect> getEffects();
+	void addEffect(MCFireworkEffect effect);
 
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCWorld.java
@@ -4,6 +4,7 @@ package com.laytonsmith.abstraction;
 
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.entities.MCFallingBlock;
+import com.laytonsmith.abstraction.entities.MCFirework;
 import com.laytonsmith.abstraction.enums.MCBiomeType;
 import com.laytonsmith.abstraction.enums.MCDifficulty;
 import com.laytonsmith.abstraction.enums.MCEffect;
@@ -95,7 +96,9 @@ public interface MCWorld extends MCMetadatable {
 
 	public MCFallingBlock spawnFallingBlock(MCLocation loc, int type, byte data);
 
-    public MCBiomeType getBiome(int x, int z);
+	public MCFirework launchFirework(MCLocation l, int strength, List<MCFireworkEffect> effects);
+
+	public MCBiomeType getBiome(int x, int z);
 
     public void setBiome(int x, int z, MCBiomeType type);
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -102,6 +102,7 @@ import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
@@ -444,6 +445,9 @@ public class BukkitConvertor extends AbstractConvertor {
 		}
 		if (im instanceof EnchantmentStorageMeta) {
 			return new BukkitMCEnchantmentStorageMeta((EnchantmentStorageMeta) im);
+		}
+		if (im instanceof FireworkEffectMeta) {
+			return new BukkitMCFireworkEffectMeta((FireworkEffectMeta) im);
 		}
 		if (im instanceof FireworkMeta) {
 			return new BukkitMCFireworkMeta((FireworkMeta) im);

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkBuilder.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkBuilder.java
@@ -1,33 +1,17 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.laytonsmith.abstraction.bukkit;
 
 import com.laytonsmith.abstraction.MCColor;
 import com.laytonsmith.abstraction.MCFireworkBuilder;
-import com.laytonsmith.abstraction.MCFireworkMeta;
-import com.laytonsmith.abstraction.MCLocation;
-import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFirework;
-import com.laytonsmith.abstraction.entities.MCFirework;
+import com.laytonsmith.abstraction.MCFireworkEffect;
 import com.laytonsmith.abstraction.enums.MCFireworkType;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCFireworkType;
 import org.bukkit.FireworkEffect;
-import org.bukkit.Location;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Firework;
-import org.bukkit.inventory.meta.FireworkMeta;
 
-/**
- *
- *
- */
 public class BukkitMCFireworkBuilder implements MCFireworkBuilder {
 	private FireworkEffect.Builder builder;
-	private int strength;
+
 	public BukkitMCFireworkBuilder(){
 		builder = FireworkEffect.builder();
-		strength = 0;
 	}
 
 	@Override
@@ -61,31 +45,8 @@ public class BukkitMCFireworkBuilder implements MCFireworkBuilder {
 	}
 
 	@Override
-	public MCFireworkBuilder setStrength(int i) {
-		strength = i;
-		return this;
+	public MCFireworkEffect build(){
+		return new BukkitMCFireworkEffect(builder.build());
 	}
-
-	@Override
-	public MCFirework launch(MCLocation l) {
-		FireworkEffect fe = builder.build();
-		Location ll = ((BukkitMCLocation)l).asLocation();
-		Firework fw = (Firework)ll.getWorld().spawnEntity(ll, EntityType.FIREWORK);
-		FireworkMeta fwmeta = fw.getFireworkMeta();
-		fwmeta.addEffect(fe);
-		fwmeta.setPower(strength);
-		fw.setFireworkMeta(fwmeta);
-		return new BukkitMCFirework(fw);
-	}
-
-	@Override
-	public void createFireworkMeta(MCFireworkMeta meta) {
-		FireworkMeta m = ((BukkitMCFireworkMeta)meta).fm;
-		FireworkEffect fem = builder.build();
-		m.clearEffects();
-		m.addEffect(fem);
-		m.setPower(strength);
-	}
-
 
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkEffect.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkEffect.java
@@ -1,0 +1,74 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCColor;
+import com.laytonsmith.abstraction.MCFireworkEffect;
+import com.laytonsmith.abstraction.enums.MCFireworkType;
+import com.laytonsmith.abstraction.enums.bukkit.BukkitMCFireworkType;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BukkitMCFireworkEffect implements MCFireworkEffect {
+
+	FireworkEffect fe;
+	public BukkitMCFireworkEffect(FireworkEffect fe) {
+		this.fe = fe;
+	}
+
+	@Override
+	public boolean hasFlicker() {
+		return fe.hasFlicker();
+	}
+
+	@Override
+	public boolean hasTrail(){
+		return fe.hasTrail();
+	}
+
+	@Override
+	public List<MCColor> getColors() {
+		List<Color> colors = fe.getColors();
+		List<MCColor> c = new ArrayList<>();
+		for(Color cc : colors){
+			c.add(BukkitMCColor.GetMCColor(cc));
+		}
+		return c;
+	}
+
+	@Override
+	public List<MCColor> getFadeColors() {
+		List<Color> colors = fe.getFadeColors();
+		List<MCColor> c = new ArrayList<>();
+		for(Color cc : colors){
+			c.add(BukkitMCColor.GetMCColor(cc));
+		}
+		return c;
+	}
+
+	@Override
+	public MCFireworkType getType() {
+		return BukkitMCFireworkType.getConvertor().getAbstractedEnum(fe.getType());
+	}
+
+	@Override
+	public FireworkEffect getHandle(){
+		return fe;
+	}
+
+	@Override
+	public boolean equals(Object obj){
+		return obj instanceof BukkitMCFireworkEffect && fe.equals(obj);
+	}
+
+	@Override
+	public int hashCode(){
+		return fe.hashCode();
+	}
+
+	@Override
+	public String toString(){
+		return fe.toString();
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkEffectMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkEffectMeta.java
@@ -1,0 +1,35 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCFireworkEffect;
+import com.laytonsmith.abstraction.MCFireworkEffectMeta;
+import org.bukkit.FireworkEffect;
+import org.bukkit.inventory.meta.FireworkEffectMeta;
+
+public class BukkitMCFireworkEffectMeta extends BukkitMCItemMeta implements MCFireworkEffectMeta {
+
+	FireworkEffectMeta fem;
+	public BukkitMCFireworkEffectMeta(FireworkEffectMeta im) {
+		super(im);
+		fem = im;
+	}
+
+	@Override
+	public boolean hasEffect(){
+		return fem.hasEffect();
+	}
+
+	@Override
+	public MCFireworkEffect getEffect(){
+		FireworkEffect effect = fem.getEffect();
+		if(effect == null){
+			return null;
+		}
+		return new BukkitMCFireworkEffect(fem.getEffect());
+	}
+
+	@Override
+	public void setEffect(MCFireworkEffect effect){
+		fem.setEffect((FireworkEffect) effect.getHandle());
+	}
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFireworkMeta.java
@@ -1,14 +1,12 @@
 package com.laytonsmith.abstraction.bukkit;
 
-import com.laytonsmith.abstraction.MCColor;
+import com.laytonsmith.abstraction.MCFireworkEffect;
 import com.laytonsmith.abstraction.MCFireworkMeta;
-import com.laytonsmith.abstraction.enums.MCFireworkType;
-import com.laytonsmith.abstraction.enums.bukkit.BukkitMCFireworkType;
-import java.util.ArrayList;
-import java.util.List;
-import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.inventory.meta.FireworkMeta;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BukkitMCFireworkMeta extends BukkitMCItemMeta implements MCFireworkMeta {
 
@@ -34,58 +32,17 @@ public class BukkitMCFireworkMeta extends BukkitMCItemMeta implements MCFirework
 	}
 
 	@Override
-	public boolean getFlicker() {
-		for(FireworkEffect effect : fm.getEffects()){
-			if(effect.hasFlicker()){
-				return true;
-			}
+	public List<MCFireworkEffect> getEffects() {
+		List<MCFireworkEffect> effects = new ArrayList<>();
+		for(FireworkEffect effect : fm.getEffects()) {
+			effects.add(new BukkitMCFireworkEffect(effect));
 		}
-		return false;
+		return effects;
 	}
 
 	@Override
-	public boolean getTrail() {
-		for(FireworkEffect effect : fm.getEffects()){
-			if(effect.hasTrail()){
-				return true;
-			}
-		}
-		return false;
-	}
-
-	@Override
-	public List<MCColor> getColors() {
-		for(FireworkEffect effect : fm.getEffects()){
-			List<Color> colors = effect.getColors();
-			List<MCColor> c = new ArrayList<>();
-			for(Color cc : colors){
-				c.add(BukkitMCColor.GetMCColor(cc));
-			}
-			return c;
-		}
-		return new ArrayList<>();
-	}
-
-	@Override
-	public List<MCColor> getFadeColors() {
-		for(FireworkEffect effect : fm.getEffects()){
-			List<Color> colors = effect.getFadeColors();
-			List<MCColor> c = new ArrayList<>();
-			for(Color cc : colors){
-				c.add(BukkitMCColor.GetMCColor(cc));
-			}
-			return c;
-		}
-		return new ArrayList<>();
-	}
-
-	@Override
-	public MCFireworkType getType() {
-		for(FireworkEffect effect : fm.getEffects()){
-			return BukkitMCFireworkType.getConvertor().getAbstractedEnum(effect.getType());
-		}
-		// This is the default type
-		return null;
+	public void addEffect(MCFireworkEffect effect){
+		fm.addEffect((FireworkEffect) effect.getHandle());
 	}
 
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
@@ -5,6 +5,7 @@ package com.laytonsmith.abstraction.bukkit;
 import com.laytonsmith.abstraction.AbstractionObject;
 import com.laytonsmith.abstraction.MCChunk;
 import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCFireworkEffect;
 import com.laytonsmith.abstraction.MCItem;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLightningStrike;
@@ -16,12 +17,14 @@ import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEntity;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFallingBlock;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCFirework;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCHorse;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCItem;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCLightningStrike;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCLivingEntity;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import com.laytonsmith.abstraction.entities.MCFallingBlock;
+import com.laytonsmith.abstraction.entities.MCFirework;
 import com.laytonsmith.abstraction.entities.MCHorse;
 import com.laytonsmith.abstraction.enums.*;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCBiomeType;
@@ -42,12 +45,14 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import org.bukkit.Chunk;
 import org.bukkit.Effect;
+import org.bukkit.FireworkEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.*;
+import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.material.MaterialData;
 
 import java.util.ArrayList;
@@ -680,6 +685,18 @@ public class BukkitMCWorld extends BukkitMCMetadatable implements MCWorld {
 	public MCFallingBlock spawnFallingBlock(MCLocation loc, int type, byte data) {
 		Location mcloc = (Location)((BukkitMCLocation)loc).getHandle();
 		return new BukkitMCFallingBlock(w.spawnFallingBlock(mcloc, type, data));
+	}
+
+	@Override
+	public MCFirework launchFirework(MCLocation l, int strength, List<MCFireworkEffect> effects){
+		Firework firework = (Firework) w.spawnEntity(((BukkitMCLocation) l).asLocation(), EntityType.FIREWORK);
+		FireworkMeta meta = firework.getFireworkMeta();
+		meta.setPower(strength);
+		for(MCFireworkEffect effect : effects){
+			meta.addEffect((FireworkEffect) effect.getHandle());
+		}
+		firework.setFireworkMeta(meta);
+		return new BukkitMCFirework(firework);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -7,6 +7,8 @@ import com.laytonsmith.abstraction.MCColor;
 import com.laytonsmith.abstraction.MCEnchantment;
 import com.laytonsmith.abstraction.MCEnchantmentStorageMeta;
 import com.laytonsmith.abstraction.MCFireworkBuilder;
+import com.laytonsmith.abstraction.MCFireworkEffect;
+import com.laytonsmith.abstraction.MCFireworkEffectMeta;
 import com.laytonsmith.abstraction.MCFireworkMeta;
 import com.laytonsmith.abstraction.MCFurnaceRecipe;
 import com.laytonsmith.abstraction.MCItemFactory;
@@ -372,7 +374,7 @@ public class ObjectGenerator {
     }
 
 	public Construct itemMeta(MCItemStack is, Target t) {
-		Construct ret, display, lore, color, title, author, pages, owner, stored, firework;
+		Construct ret, display, lore, color, title, author, pages, owner, stored;
 		CArray enchants, effects;
 		if (!is.hasItemMeta()) {
 			ret = CNull.NULL;
@@ -410,29 +412,23 @@ public class ObjectGenerator {
 
 			// Specific ItemMeta
 
-			if(meta instanceof MCFireworkMeta){
-				firework = CArray.GetAssociativeArray(t);
-				CArray cf = (CArray) firework;
-				MCFireworkMeta mcfm = (MCFireworkMeta) meta;
-				cf.set("strength", new CInt(mcfm.getStrength(), t), t);
-				cf.set("flicker", CBoolean.get(mcfm.getFlicker()), t);
-				cf.set("trail", CBoolean.get(mcfm.getTrail()), t);
-				MCFireworkType type = mcfm.getType();
-				if(type != null){
-					cf.set("type", new CString(mcfm.getType().name(), t), t);
+			if(meta instanceof  MCFireworkEffectMeta){
+				MCFireworkEffectMeta mcfem = (MCFireworkEffectMeta) meta;
+				MCFireworkEffect effect = mcfem.getEffect();
+				if(effect == null){
+					ma.set("effect", CNull.NULL, t);
 				} else {
-					cf.set("type", CNull.NULL, t);
+					ma.set("effect", fireworkEffect(effect, t), t);
 				}
-				CArray colors = new CArray(t);
-				for(MCColor c : mcfm.getColors()){
-					colors.push(ObjectGenerator.GetGenerator().color(c, t), t);
+			} else if(meta instanceof MCFireworkMeta){
+				MCFireworkMeta mcfm = (MCFireworkMeta) meta;
+				CArray firework = CArray.GetAssociativeArray(t);
+				firework.set("strength", new CInt(mcfm.getStrength(), t), t);
+				CArray fe = new CArray(t);
+				for(MCFireworkEffect effect : mcfm.getEffects()) {
+					fe.push(fireworkEffect(effect, t), t);
 				}
-				cf.set("colors", colors, t);
-				CArray fadeColors = new CArray(t);
-				for(MCColor c : mcfm.getFadeColors()){
-					fadeColors.push(ObjectGenerator.GetGenerator().color(c, t), t);
-				}
-				cf.set("fade", fadeColors, t);
+				firework.set("effects", fe, t);
 				ma.set("firework", firework, t);
 			} else if (meta instanceof MCLeatherArmorMeta) {
 				color = color(((MCLeatherArmorMeta) meta).getColor(), t);
@@ -570,74 +566,47 @@ public class ObjectGenerator {
 
 				// Specific Item Meta
 
-				if(ma.containsKey("firework") && ma.get("firework", t) instanceof CArray && meta instanceof MCFireworkMeta){
+				if(meta instanceof MCFireworkEffectMeta){
+					MCFireworkEffectMeta femeta = (MCFireworkEffectMeta) meta;
+					if(ma.containsKey("effect")){
+						Construct cfem = ma.get("effect", t);
+						if(cfem instanceof CArray){
+							femeta.setEffect(fireworkEffect((CArray) cfem, t));
+						} else if(!(cfem instanceof CNull)){
+							throw new CREFormatException("FireworkCharge effect was expected to be an array or null.", t);
+						}
+					}
+				} else if(meta instanceof MCFireworkMeta){
 					MCFireworkMeta fmeta = (MCFireworkMeta) meta;
-					MCFireworkBuilder builder = StaticLayer.GetConvertor().GetFireworkBuilder();
-					CArray fwdata = (CArray) ma.get("firework", t);
-					if(fwdata.containsKey("strength")){
-						builder.setStrength(Static.getInt32(fwdata.get("strength", t), t));
-					}
-					if(fwdata.containsKey("flicker")){
-						builder.setFlicker(Static.getBoolean(fwdata.get("flicker", t)));
-					}
-					if(fwdata.containsKey("trail")){
-						builder.setTrail(Static.getBoolean(fwdata.get("trail", t)));
-					}
-					if(fwdata.containsKey("colors")){
-						Construct colors = fwdata.get("colors", t);
-						CArray ccolors;
-						if(colors instanceof CString){
-							ccolors = new CArray(t, colors);
-						} else if(colors instanceof CArray){
-							ccolors = (CArray) colors;
-						} else {
-							throw new CREFormatException("Expecting an array or string for colors parameter, but found " + colors.typeof(), t);
-						}
-						for(Construct color : ccolors.asList()){
-							MCColor mccolor;
-							if(color instanceof CString){
-								mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
-							} else if(color instanceof CArray){
-								mccolor = color((CArray)color, t);
-							} else {
-								throw new CREFormatException("Expecting individual color to be an array or string, but found " + color.typeof(), t);
+					if(ma.containsKey("firework")){
+						Construct construct = ma.get("firework", t);
+						if(construct instanceof CArray){
+							CArray firework = (CArray) construct;
+							if(firework.containsKey("strength")){
+								fmeta.setStrength(Static.getInt32(firework.get("strength", t), t));
 							}
-							builder.addColor(mccolor);
-						}
-						if(ccolors.isEmpty()){
-							builder.addColor(MCColor.WHITE);
-						}
-					}
-					if(fwdata.containsKey("fade")){
-						Construct colors = fwdata.get("fade", t);
-						CArray ccolors;
-						if(colors instanceof CString){
-							ccolors = new CArray(t, colors);
-						} else if(colors instanceof CArray){
-							ccolors = (CArray) colors;
-						} else {
-							throw new CREFormatException("Expecting an array or string for fade parameter, but found " + colors.typeof(), t);
-						}
-						for(Construct color : ccolors.asList()){
-							MCColor mccolor;
-							if(color instanceof CString){
-								mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
-							} else if(color instanceof CArray){
-								mccolor = color((CArray)color, t);
+							if(firework.containsKey("effects")){
+								// New style (supports multiple effects)
+								Construct effects = firework.get("effects", t);
+								if(effects instanceof CArray){
+									for(Construct effect : ((CArray) effects).asList()){
+										if(effect instanceof CArray){
+											fmeta.addEffect(fireworkEffect((CArray) effect, t));
+										} else {
+											throw new CREFormatException("Firework effect was expected to be an array.", t);
+										}
+									}
+								} else {
+									throw new CREFormatException("Firework effects was expected to be an array.", t);
+								}
 							} else {
-								throw new CREFormatException("Expecting individual color to be an array or string, but found " + color.typeof(), t);
+								// Old style (supports only one effect)
+								fmeta.addEffect(fireworkEffect(firework, t));
 							}
-							builder.addColor(mccolor);
+						} else {
+							throw new CREFormatException("Firework was expected to be an array.", t);
 						}
 					}
-					if(fwdata.containsKey("type") && !(fwdata.get("type", t) instanceof CNull)){
-						try {
-							builder.setType(MCFireworkType.valueOf(fwdata.get("type", t).val()));
-						} catch(IllegalArgumentException ex){
-							throw new CREFormatException(ex.getMessage(), t, ex);
-						}
-					}
-					builder.createFireworkMeta(fmeta);
 				} else if (meta instanceof MCLeatherArmorMeta) {
 					if (ma.containsKey("color")) {
 						Construct ci = ma.get("color", t);
@@ -1021,6 +990,117 @@ public class ObjectGenerator {
 		} catch(IllegalArgumentException ex){
 			throw new CREFormatException(ex.getMessage(), t, ex);
 		}
+	}
+
+	public CArray fireworkEffect(MCFireworkEffect mcfe, Target t) {
+		CArray fe = CArray.GetAssociativeArray(t);
+		fe.set("flicker", CBoolean.get(mcfe.hasFlicker()), t);
+		fe.set("trail", CBoolean.get(mcfe.hasTrail()), t);
+		MCFireworkType type = mcfe.getType();
+		if(type != null){
+			fe.set("type", new CString(mcfe.getType().name(), t), t);
+		} else {
+			fe.set("type", CNull.NULL, t);
+		}
+		CArray colors = new CArray(t);
+		for(MCColor c : mcfe.getColors()){
+			colors.push(ObjectGenerator.GetGenerator().color(c, t), t);
+		}
+		fe.set("colors", colors, t);
+		CArray fadeColors = new CArray(t);
+		for(MCColor c : mcfe.getFadeColors()){
+			fadeColors.push(ObjectGenerator.GetGenerator().color(c, t), t);
+		}
+		fe.set("fade", fadeColors, t);
+		return fe;
+	}
+
+	public MCFireworkEffect fireworkEffect(CArray fe, Target t) {
+		MCFireworkBuilder builder = StaticLayer.GetConvertor().GetFireworkBuilder();
+		if(fe.containsKey("flicker")){
+			builder.setFlicker(Static.getBoolean(fe.get("flicker", t)));
+		}
+		if(fe.containsKey("trail")){
+			builder.setTrail(Static.getBoolean(fe.get("trail", t)));
+		}
+		if(fe.containsKey("colors")){
+			Construct colors = fe.get("colors", t);
+			if(colors instanceof CArray){
+				CArray ccolors = (CArray) colors;
+				if(ccolors.size() == 0) {
+					builder.addColor(MCColor.WHITE);
+				} else {
+					for(Construct color : ccolors.asList()) {
+						MCColor mccolor;
+						if(color instanceof CString){
+							mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
+						} else if(color instanceof CArray){
+							mccolor = color((CArray) color, t);
+						} else if(color instanceof CInt && ccolors.size() == 3){
+							// Appears to be a single color
+							builder.addColor(color(ccolors, t));
+							break;
+						} else {
+							throw new CREFormatException("Expecting individual color to be an array or string, but found "
+									+ color.typeof(), t);
+						}
+						builder.addColor(mccolor);
+					}
+				}
+			} else if(colors instanceof CString){
+				String split[] = colors.val().split("\\|");
+				if(split.length == 0){
+					builder.addColor(MCColor.WHITE);
+				} else {
+					for(String s : split) {
+						builder.addColor(StaticLayer.GetConvertor().GetColor(s, t));
+					}
+				}
+			} else {
+				throw new CREFormatException("Expecting an array or string for colors parameter, but found "
+						+ colors.typeof(), t);
+			}
+		} else {
+			builder.addColor(MCColor.WHITE);
+		}
+		if(fe.containsKey("fade")){
+			Construct colors = fe.get("fade", t);
+			if(colors instanceof CArray){
+				CArray ccolors = (CArray) colors;
+				for(Construct color : ccolors.asList()) {
+					MCColor mccolor;
+					if(color instanceof CArray){
+						mccolor = color((CArray) color, t);
+					} else if(color instanceof CString){
+						mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
+					} else if(color instanceof CInt && ccolors.size() == 3){
+						// Appears to be a single color
+						builder.addFadeColor(color(ccolors, t));
+						break;
+					} else {
+						throw new CREFormatException("Expecting individual color to be an array or string, but found "
+								+ color.typeof(), t);
+					}
+					builder.addFadeColor(mccolor);
+				}
+			} else if(colors instanceof CString){
+				String split[] = colors.val().split("\\|");
+				for(String s : split) {
+					builder.addFadeColor(StaticLayer.GetConvertor().GetColor(s, t));
+				}
+			} else {
+				throw new CREFormatException("Expecting an array or string for fade parameter, but found "
+						+ colors.typeof(), t);
+			}
+		}
+		if(fe.containsKey("type")){
+			try {
+				builder.setType(MCFireworkType.valueOf(fe.get("type", t).val().toUpperCase()));
+			} catch(IllegalArgumentException ex){
+				throw new CREFormatException(ex.getMessage(), t, ex);
+			}
+		}
+		return builder.build();
 	}
 
 	public Construct recipe(MCRecipe r, Target t) {

--- a/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
@@ -48,7 +48,9 @@ public class ItemMeta {
 			+ "<li>Leather Armor - color (color array (see Example))</li>"
 			+ "<li>Skulls - owner (string) NOTE: the visual change only applies to player skulls</li>"
 			+ "<li>Potions - potions (array of potion arrays), main(int, the id of the main effect)</li>"
-			+ "<li>Banners - basecolor (string), patterns (array of pattern arrays)"
+			+ "<li>Banners - basecolor (string), patterns (array of pattern arrays)</li>"
+			+ "<li>Fireworks - firework (array with strength (int), effects (array of effect arrays (see Example)))</li>"
+			+ "<li>Firework Charges - effect (single Firework effect array)"
 			+ "</ul>";
 	
 	@api(environments={CommandHelperEnvironment.class})
@@ -135,7 +137,12 @@ public class ItemMeta {
 							"{display: null, enchants: {}, lore: null, main: 8,"
 							+ " potions: {{ambient: true, id: 8, seconds: 180, strength: 5}}}"),
 					new ExampleScript("Demonstrates a custom banner", "msg(get_itemmeta(0))",
-							"{basecolor: WHITE, patterns: {{color: BLACK, shape: SKULL}, {color: RED, shape: CROSS}}}")
+							"{basecolor: WHITE, patterns: {{color: BLACK, shape: SKULL}, {color: RED, shape: CROSS}}}"),
+					new ExampleScript("Demonstrates a custom firework", "msg(get_itemmeta(null))",
+							"{firework: {effects: {{colors: {{b: 240, g: 240, r: 240}, {b: 44, g: 49, r: 179},"
+							+ " {b: 146, g: 49, r: 37}}, fade: {}, flicker: true, trail: false, type: STAR},"
+							+ " {colors: {{b: 255, g: 255, r: 255}}, fade: {{b: 0, g: 0, r: 255}}, flicker: false,"
+							+ " trail: true, type: BURST}}, strength: 2}}")
 			};
 		}
 		
@@ -238,7 +245,11 @@ public class ItemMeta {
 							+ " a music disc's author and name, firework meta, map meta, and stored enchantments."),
 					new ExampleScript("Demonstrates making a custom banner",
 							"set_itemmeta(0, array(basecolor: SILVER, patterns: array(array(color: BLACK, shape: SKULL))",
-							"This banner will be silver with a black skull.")
+							"This banner will be silver with a black skull."),
+					new ExampleScript("Demonstrates making a custom firework",
+							"set_itemmeta(null, array('firework': array('strength': 1, 'effects': array(array("
+							+ "'type': 'CREEPER', colors: array(array('r': 0, 'g': 255, 'b': 0)))))));",
+							"This firework will store a green creeper face effect.")
 			};
 		}
 		


### PR DESCRIPTION
This updates the firework meta so that it supports multiple effects per firework, and also adds meta for the firework charge. I made a best attempt at maintaining compatibility with old scripts. Old item array formats for setting a firework or launching a firework will continue to work! However, scripts that read or modify a firework meta array returned from a function may be unavoidably affected. I also tied in launch_firework() into the object generator for consistency and made sure some special formatting was still supported. 

Scripts can still do this, for example:
```
bind(player_interact, null, associative_array('item': 401, 'hand': 'main_hand'), @event) {
    cancel();
    launch_firework(@event['location'], pinv(player(), null)['meta']['firework']);
}
```
Or even this now with the firework charge:
```
bind(player_interact, null, associative_array('item': 402, 'hand': 'main_hand'), @event) {
    launch_firework(@event['location'], pinv(player(), null)['meta']['effect']);
}
```

The old firework meta format: (condensed for example)
```
{firework: {strength: 1, trail: true, type: CREEPER}}
```
The new firework meta format:
```
{firework: {strength: 1, effects: {{trail: true, type: CREEPER}, {type: BALL, flicker: true}}}}
```

As always, I did my best inputting various formats in testing, but I might have missed something.
