### PR TITLE
Added 'collisionrule' and 'deathmessagevisibility' options for teams & entity ai functions

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCLivingEntity.java
@@ -51,6 +51,7 @@ public interface MCLivingEntity extends MCEntity, MCProjectileSource {
     public int getRemainingAir();
     public boolean isGliding();
 	public boolean isLeashed();
+	public boolean hasAI();
 	public void resetMaxHealth();
 	public void setCanPickupItems(boolean pickup);
 	public void setRemoveWhenFarAway(boolean remove);
@@ -64,6 +65,7 @@ public interface MCLivingEntity extends MCEntity, MCProjectileSource {
     public void setRemainingAir(int ticks);
 	public void setTarget(MCLivingEntity target, Target t);
 	public void setGliding(Boolean glide);
+	public void setAI(Boolean ai);
 
 	/**
 	 * Kills the entity. In some cases, this will be equivalent to setHealth(0), but

--- a/src/main/java/com/laytonsmith/abstraction/MCTeam.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCTeam.java
@@ -1,6 +1,8 @@
 package com.laytonsmith.abstraction;
 
 import com.laytonsmith.abstraction.enums.MCNameTagVisibility;
+import com.laytonsmith.abstraction.enums.MCOption;
+import com.laytonsmith.abstraction.enums.MCOptionStatus;
 
 import java.util.Set;
 
@@ -15,6 +17,7 @@ public interface MCTeam {
 	public String getDisplayName();
 	public String getName();
 	public MCNameTagVisibility getNameTagVisibility();
+	public MCOptionStatus getOption(MCOption option);
 	public Set<String> getEntries();
 	public String getPrefix();
 	public MCScoreboard getScoreboard();
@@ -26,6 +29,7 @@ public interface MCTeam {
 	public void setCanSeeFriendlyInvisibles(boolean enabled);
 	public void setDisplayName(String displayName);
 	public void setNameTagVisibility(MCNameTagVisibility visibility);
+	public void setOption(MCOption option, MCOptionStatus status);
 	public void setPrefix(String prefix);
 	public void setSuffix(String suffix);
 	public void unregister();

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTeam.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTeam.java
@@ -7,11 +7,16 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.laytonsmith.abstraction.enums.MCNameTagVisibility;
+import com.laytonsmith.abstraction.enums.MCOption;
+import com.laytonsmith.abstraction.enums.MCOptionStatus;
+import com.laytonsmith.abstraction.enums.bukkit.BukkitMCOption;
+import com.laytonsmith.abstraction.enums.bukkit.BukkitMCOptionStatus;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCNameTagVisibility;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.bukkit.scoreboard.Team;
+import org.bukkit.scoreboard.Team.OptionStatus;
 
 public class BukkitMCTeam implements MCTeam {
 
@@ -55,6 +60,12 @@ public class BukkitMCTeam implements MCTeam {
 	public MCNameTagVisibility getNameTagVisibility() {
 		NameTagVisibility ntv = t.getNameTagVisibility();
 		return BukkitMCNameTagVisibility.getConvertor().getAbstractedEnum(ntv);
+	}
+	
+	@Override
+	public MCOptionStatus getOption(MCOption option) {
+		OptionStatus os = t.getOption(BukkitMCOption.getConvertor().getConcreteEnum(option));
+		return BukkitMCOptionStatus.getConvertor().getAbstractedEnum(os);
 	}
 
 	@Override
@@ -133,6 +144,11 @@ public class BukkitMCTeam implements MCTeam {
 	@Override
 	public void setNameTagVisibility(MCNameTagVisibility visibility) {
 		t.setNameTagVisibility(BukkitMCNameTagVisibility.getConvertor().getConcreteEnum(visibility));
+	}
+	
+	@Override
+	public void setOption(MCOption option, MCOptionStatus status) {
+		t.setOption(BukkitMCOption.getConvertor().getConcreteEnum(option), BukkitMCOptionStatus.getConvertor().getConcreteEnum(status));
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntity.java
@@ -323,17 +323,12 @@ public class BukkitMCEntity extends BukkitMCMetadatable implements MCEntity {
 	
 	@Override
 	public boolean isGlowing() {
-		if(ReflectionUtils.hasMethod(e.getClass(), "isGlowing", null)) { // Added around 1.9
-			return e.isGlowing();
-		}
-		return false;
+		return e.isGlowing();
 	}
 	
 	@Override
 	public void setGlowing(Boolean glow) {
-		if(ReflectionUtils.hasMethod(e.getClass(), "setGlowing", null)) { // Added around 1.9
-			e.setGlowing(glow);
-		}
+		e.setGlowing(glow);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEntity.java
@@ -1,6 +1,7 @@
 package com.laytonsmith.abstraction.bukkit.entities;
 
 import com.laytonsmith.PureUtilities.Vector3D;
+import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCLivingEntity;
 import com.laytonsmith.abstraction.MCLocation;
@@ -322,12 +323,17 @@ public class BukkitMCEntity extends BukkitMCMetadatable implements MCEntity {
 	
 	@Override
 	public boolean isGlowing() {
-		return e.isGlowing();
+		if(ReflectionUtils.hasMethod(e.getClass(), "isGlowing", null)) { // Added around 1.9
+			return e.isGlowing();
+		}
+		return false;
 	}
 	
 	@Override
 	public void setGlowing(Boolean glow) {
-		e.setGlowing(glow);
+		if(ReflectionUtils.hasMethod(e.getClass(), "setGlowing", null)) { // Added around 1.9
+			e.setGlowing(glow);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCLivingEntity.java
@@ -206,6 +206,14 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 		}
 		return blocks;
 	}
+	
+	@Override
+	public boolean hasAI() {
+		if(ReflectionUtils.hasMethod(le.getClass(), "hasAI", null)) { // Added in 1.9.2
+			return le.hasAI();
+		}
+		return true; // We'll assume the entity does have AI enabled
+	}
 
 	/**
 	 * @param potionID - ID of the potion
@@ -373,11 +381,23 @@ public class BukkitMCLivingEntity extends BukkitMCEntityProjectileSource impleme
 
 	@Override
 	public boolean isGliding() {
-		return le.isGliding();
+		if(ReflectionUtils.hasMethod(le.getClass(), "isGliding", null)) { // Added around 1.9
+			return le.isGliding();
+		}
+		return false;
 	}
 
 	@Override
 	public void setGliding(Boolean glide) {
-		le.setGliding(glide);
+		if(ReflectionUtils.hasMethod(le.getClass(), "setGliding", null, Boolean.class)) { // Added around 1.9
+			le.setGliding(glide);
+		}
+	}
+	
+	@Override
+	public void setAI(Boolean ai) {
+		if(ReflectionUtils.hasMethod(le.getClass(), "setAI", null, Boolean.class)) { // Added in 1.9.2
+			le.setAI(ai);
+		}
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCOption.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCOption.java
@@ -1,0 +1,10 @@
+package com.laytonsmith.abstraction.enums;
+
+import com.laytonsmith.annotations.MEnum;
+
+@MEnum("Option")
+public enum MCOption {
+	COLLISION_RULE,
+	DEATH_MESSAGE_VISIBILITY,
+	NAME_TAG_VISIBILITY
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCOptionStatus.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCOptionStatus.java
@@ -1,0 +1,11 @@
+package com.laytonsmith.abstraction.enums;
+
+import com.laytonsmith.annotations.MEnum;
+
+@MEnum("OptionStatus")
+public enum MCOptionStatus {
+	ALWAYS,
+	FOR_OTHER_TEAMS,
+	FOR_OWN_TEAM,
+	NEVER
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOption.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOption.java
@@ -28,7 +28,7 @@ public class BukkitMCOption extends EnumConvertor<MCOption, Option>{
 
 	@Override
 	protected Option getConcreteEnumCustom(MCOption abstracted) {
-		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9_4)) {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9)) {
 			return null;
 		}
 		return super.getConcreteEnumCustom(abstracted);

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOption.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOption.java
@@ -1,0 +1,36 @@
+package com.laytonsmith.abstraction.enums.bukkit;
+
+import org.bukkit.scoreboard.Team;
+import org.bukkit.scoreboard.Team.Option;
+
+import com.laytonsmith.abstraction.Implementation;
+import com.laytonsmith.abstraction.enums.EnumConvertor;
+import com.laytonsmith.abstraction.enums.MCOption;
+import com.laytonsmith.abstraction.enums.MCVersion;
+import com.laytonsmith.annotations.abstractionenum;
+import com.laytonsmith.core.Static;
+
+@abstractionenum(
+		implementation= Implementation.Type.BUKKIT,
+		forAbstractEnum=MCOption.class,
+		forConcreteEnum=Team.Option.class
+)
+public class BukkitMCOption extends EnumConvertor<MCOption, Option>{
+
+	private static BukkitMCOption instance;
+	
+	public static BukkitMCOption getConvertor() {
+		if (instance == null) {
+			instance = new BukkitMCOption();
+		}
+		return instance;
+	}
+
+	@Override
+	protected Option getConcreteEnumCustom(MCOption abstracted) {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9_4)) {
+			return null;
+		}
+		return super.getConcreteEnumCustom(abstracted);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOptionStatus.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOptionStatus.java
@@ -28,7 +28,7 @@ public class BukkitMCOptionStatus extends EnumConvertor<MCOptionStatus, OptionSt
 
 	@Override
 	protected OptionStatus getConcreteEnumCustom(MCOptionStatus abstracted) {
-		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9_4)) {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9)) {
 			return null;
 		}
 		return super.getConcreteEnumCustom(abstracted);

--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOptionStatus.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCOptionStatus.java
@@ -1,0 +1,36 @@
+package com.laytonsmith.abstraction.enums.bukkit;
+
+import org.bukkit.scoreboard.Team;
+import org.bukkit.scoreboard.Team.OptionStatus;
+
+import com.laytonsmith.abstraction.Implementation;
+import com.laytonsmith.abstraction.enums.EnumConvertor;
+import com.laytonsmith.abstraction.enums.MCOptionStatus;
+import com.laytonsmith.abstraction.enums.MCVersion;
+import com.laytonsmith.annotations.abstractionenum;
+import com.laytonsmith.core.Static;
+
+@abstractionenum(
+		implementation= Implementation.Type.BUKKIT,
+		forAbstractEnum=MCOptionStatus.class,
+		forConcreteEnum=Team.OptionStatus.class
+)
+public class BukkitMCOptionStatus extends EnumConvertor<MCOptionStatus, OptionStatus>{
+
+	private static BukkitMCOptionStatus instance;
+	
+	public static BukkitMCOptionStatus getConvertor() {
+		if (instance == null) {
+			instance = new BukkitMCOptionStatus();
+		}
+		return instance;
+	}
+
+	@Override
+	protected OptionStatus getConcreteEnumCustom(MCOptionStatus abstracted) {
+		if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_9_4)) {
+			return null;
+		}
+		return super.getConcreteEnumCustom(abstracted);
+	}
+}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -3967,4 +3967,47 @@ public class EntityManagement {
 			return CHVersion.V3_3_2;
 		}
 	}
+	
+	@api
+	public static class get_entity_ai extends EntityGetterFunction {
+		public String getName() {
+			return "get_entity_ai";
+		}
+
+		public String docs() {
+			return "boolean {Entity} Returns true if the given entity has AI";
+		}
+
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			return CBoolean.GenerateCBoolean(Static.getLivingEntity(args[0], t).hasAI(), t);
+		}
+
+		public Version since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+	
+	@api
+	public static class set_entity_ai extends EntitySetterFunction {
+		public String getName() {
+			return "set_entity_ai";
+		}
+
+		public String docs() {
+			return "void {Entity, boolean} enables or disables the entity AI";
+		}
+
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			MCLivingEntity e = Static.getLivingEntity(args[0], t);
+			boolean ai = Static.getBoolean(args[1]);
+
+			e.setAI(ai);
+
+			return CVoid.VOID;
+		}
+
+		public Version since() {
+			return CHVersion.V3_3_2;
+		}
+	}
 }

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -9,6 +9,8 @@ import com.laytonsmith.abstraction.MCTeam;
 import com.laytonsmith.abstraction.enums.MCCriteria;
 import com.laytonsmith.abstraction.enums.MCDisplaySlot;
 import com.laytonsmith.abstraction.enums.MCNameTagVisibility;
+import com.laytonsmith.abstraction.enums.MCOption;
+import com.laytonsmith.abstraction.enums.MCOptionStatus;
 import com.laytonsmith.abstraction.enums.MCVersion;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.core.CHVersion;
@@ -412,11 +414,16 @@ public class Scoreboards {
 				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_8)) {
 					ops.set("nametagvisibility", new CString(team.getNameTagVisibility().name(), t), t);
 				}
+				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_9_4)) {
+					ops.set("collisionrule", new CString(team.getOption(MCOption.COLLISION_RULE).name(), t), t);
+					ops.set("deathmessagevisibility", new CString(team.getOption(MCOption.DEATH_MESSAGE_VISIBILITY).name(), t), t);
+				}
 				to.set("options", ops, t);
 				CArray pl = new CArray(t);
 				for (String entry : team.getEntries()) {
 					pl.push(new CString(entry, t), t);
 				}
+				
 				to.set("players", pl, t);
 				ret.push(to, t);
 			}
@@ -1127,6 +1134,28 @@ public class Scoreboards {
 					}
 					team.setNameTagVisibility(visibility);
 				}
+				if (Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_9)) {
+					if(options.containsKey("collisionrule")) {
+						MCOptionStatus collision;
+						try {
+							collision = MCOptionStatus.valueOf(options.get("collisionrule", t).val().toUpperCase());
+						} catch (IllegalArgumentException iae) {
+							throw new CREFormatException("Unknown collisionrule: "
+							+ options.get("collisionrule", t).val(), t);
+						}
+						team.setOption(MCOption.COLLISION_RULE, collision);
+					}
+					if(options.containsKey("deathmessagevisibility")) {
+						MCOptionStatus visibility;
+						try {
+							visibility = MCOptionStatus.valueOf(options.get("deathmessagevisibility", t).val().toUpperCase());
+						} catch (IllegalArgumentException iae) {
+							throw new CREFormatException("Unknown deathmessagevisibility: "
+							+ options.get("deathmessagevisibility", t).val(), t);
+						}
+						team.setOption(MCOption.DEATH_MESSAGE_VISIBILITY, visibility);
+					}
+				}
 			} else {
 				throw new CREFormatException("Expected arg 2 to be an array.", t);
 			}
@@ -1146,7 +1175,7 @@ public class Scoreboards {
 		@Override
 		public String docs() {
 			return "void {teamName, array, [scoreboard]} Sets various options about the team from an array,"
-					+ " checking for keys 'friendlyfire', 'friendlyinvisibles' and 'nametagvisibility'. " + DEF_MSG;
+					+ " checking for keys 'friendlyfire', 'collisionrule', 'deathmessagevisibility', 'friendlyinvisibles' and 'nametagvisibility'. " + DEF_MSG;
 		}
 		
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -414,7 +414,7 @@ public class Scoreboards {
 				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_8)) {
 					ops.set("nametagvisibility", new CString(team.getNameTagVisibility().name(), t), t);
 				}
-				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_9_4)) {
+				if(Static.getServer().getMinecraftVersion().gte(MCVersion.MC1_9)) {
 					ops.set("collisionrule", new CString(team.getOption(MCOption.COLLISION_RULE).name(), t), t);
 					ops.set("deathmessagevisibility", new CString(team.getOption(MCOption.DEATH_MESSAGE_VISIBILITY).name(), t), t);
 				}


### PR DESCRIPTION
The NameTagVisibility *should* also use this new Option system that the new team options use, although I have no idea how to make it backwards compatible right now, so I left it out of the change for now