### PR TITLE
Reduce noise in mostly harmless ENUM mismatch warnings

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/enums/EnumConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/EnumConvertor.java
@@ -106,13 +106,10 @@ public abstract class EnumConvertor<Abstracted extends Enum, Concrete extends En
 	}
 	
 	private void doLog(Class from, Class to, Enum value){
-		String message = "When trying to convert " + from.getName() + "." + value.name() + " to a "
-				+ to.getName() + ", no match was found. This may be caused by an old plugin version, or a newer server version.";
+		String message = from.getSimpleName() + "." + value.name() + " missing a match in " + to.getName();
 		LogLevel level = LogLevel.WARNING;
 		if(useError){
 			level = LogLevel.ERROR;
-		} else {
-			message += " This may or may not cause further problems during runtime.";
 		}
 		CHLog.GetLogger().Log(CHLog.Tags.RUNTIME, level, message, Target.UNKNOWN);
 	}


### PR DESCRIPTION
The current ENUM converter checker takes an enormous amount of space per warning. This is mostly redundant information and is quite spammy on non-latest Spigot versions. I significantly reduced it by almost 200 characters, and it starts the message with the relevant ENUM type. If you still feel we need some messages about what causes this and if it can cause problems, I think that needs to be added before or after the checks.