### PR TITLE
Force BukkitGetCorrectEntity to determine a more specific entity class for UNKNOWN entity type

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCEntityType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/bukkit/BukkitMCEntityType.java
@@ -110,7 +110,7 @@ public class BukkitMCEntityType extends MCEntityType<EntityType> {
 	private void setWrapperClass() {
 		switch (getAbstracted()) {
 			case UNKNOWN:
-				wrapperClass = BukkitMCEntity.class;
+				wrapperClass = null;
 				break;
 			case DROPPED_ITEM:
 				wrapperClass = BukkitMCItem.class;


### PR DESCRIPTION
PRing this just to make sure I'm not missing something here. (@jb-aero) 

UNKNOWN entity types are sometimes handled as more specific classes than just MCEntity. For example, currently when EchoPet causes a CreatureSpawnEvent the entity type is UNKNOWN. CH wraps it as an MCEntity and causes an exception when BukkitMCCreatureSpawnEvent tries to cast it to MCLivingEntity. By setting the wrapperclass as null, it forces BukkitConvertor.BukkitGetCorrectEntity() to find the most specific entity class. 