### PR TITLE
Improve block_break when drops are modified

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
@@ -30,8 +30,6 @@ import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
-import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import org.bukkit.Bukkit;
 import org.bukkit.Note;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.*;
@@ -125,6 +123,8 @@ public class BukkitBlockEvents {
     public static class BukkitMCBlockBreakEvent implements MCBlockBreakEvent {
 
         BlockBreakEvent event;
+        boolean dropsModified = false;
+        List<MCItemStack> drops = null;
 
         public BukkitMCBlockBreakEvent(BlockBreakEvent e) {
             event = e;
@@ -153,6 +153,22 @@ public class BukkitBlockEvents {
 		@Override
 		public void setExpToDrop(int exp) {
 			event.setExpToDrop(exp);
+		}
+
+		@Override
+		public List<MCItemStack> getDrops() {
+        	return this.drops;
+		}
+
+		@Override
+		public void setDrops(List<MCItemStack> drops) {
+			dropsModified = true;
+			this.drops = drops;
+		}
+
+		@Override
+		public boolean isModified() {
+        	return dropsModified;
 		}
     }
 

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockBreakEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockBreakEvent.java
@@ -1,8 +1,11 @@
 package com.laytonsmith.abstraction.events;
 
+import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.core.events.BindableEvent;
+
+import java.util.List;
 
 /**
  *
@@ -10,11 +13,17 @@ import com.laytonsmith.core.events.BindableEvent;
  */
 public interface MCBlockBreakEvent extends BindableEvent {
 
-    public MCPlayer getPlayer();
+	public MCPlayer getPlayer();
 
-    public MCBlock getBlock();
+	public MCBlock getBlock();
 
 	public int getExpToDrop();
 
 	public void setExpToDrop(int exp);
+
+	public List<MCItemStack> getDrops();
+
+	public void setDrops(List<MCItemStack> drops);
+
+	public boolean isModified();
 }


### PR DESCRIPTION
There is no official way to modify drops from a BlockBreakEvent, so instead CH sets the block to air and spawns items. Previously protection plugins would have no say on whether CH could break a block when this was done. Also block loggers would see the block is AIR and ignore the event or record it inaccurately. This creates a new event so that other plugins can log or cancel the action accurately. It also lets lower priority binds see the modified drops.

This also fixes experience not dropping when item drops were modified.

It seemed to do well in testing. WorldGuard would cancel the break if the player didn't have permission, and everything worked as expected. It does use 2 events, but almost all plugins ignore cancelled breaks. There are some things in Spigot that I would think would cause problems (sending a packet of the block that was broken on client but not on server), but I didn't notice any issues when testing for them. Anything else I should test for? Any other concerns?