### PR TITLE
Reduce overhead when creating and modifying arrays

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -119,7 +119,7 @@ public class CArray extends Construct implements ArrayAccess{
 			}
 			this.next_index = array.size();
 		}
-		regenValue(new HashSet<CArray>());
+		regenValue();
 	}
 
 	/**
@@ -194,16 +194,23 @@ public class CArray extends Construct implements ArrayAccess{
 	 * sets the toString value to dirty, which means that the value will be regenerated
 	 * next time it is requested.
 	 */
-    private void regenValue(Set<CArray> arrays) {
+	private void regenValue() {
+		if(valueDirty){
+			return; // All parents must be dirty too
+		}
+		regenValue(new HashSet<CArray>());
+	}
+
+	private void regenValue(Set<CArray> arrays) {
 		if(arrays.contains(this)){
 			return; //Recursive, so don't continue.
 		}
-		arrays.add(this);
-        valueDirty = true;
+		valueDirty = true;
 		if(parent != null){
+			arrays.add(this);
 			parent.regenValue(arrays);
 		}
-    }
+	}
 
 	/**
 	 * Reverses the array in place, if it is a normal array, otherwise, if associative, it throws
@@ -213,7 +220,7 @@ public class CArray extends Construct implements ArrayAccess{
 	public void reverse(Target t){
 		if(!associative_mode){
 			Collections.reverse(array);
-			regenValue(new HashSet<CArray>());
+			regenValue();
 		} else {
 			throw new CRECastException("Cannot reverse an associative array.", t);
 		}
@@ -267,7 +274,7 @@ public class CArray extends Construct implements ArrayAccess{
         if(c instanceof CArray){
             ((CArray)c).parent = this;
         }
-        regenValue(new HashSet<CArray>());
+        regenValue();
     }
 
     /**
@@ -341,7 +348,7 @@ public class CArray extends Construct implements ArrayAccess{
         if(c instanceof CArray){
             ((CArray)c).parent = this;
         }
-        regenValue(new HashSet<CArray>());
+        regenValue();
     }
 
     public final void set(int index, Construct c, Target t){
@@ -455,14 +462,10 @@ public class CArray extends Construct implements ArrayAccess{
 		return ret;
 	}
 
-    @Override
-    public String val() {
-		if(valueDirty){
-			mutVal = getString(new Stack<CArray>(), this.getTarget());
-			valueDirty = false;
-		}
-        return mutVal;
-    }
+	@Override
+	public String val() {
+		return(getString(new Stack<CArray>(), this.getTarget()));
+	}
 
     @Override
     public String toString() {
@@ -479,6 +482,9 @@ public class CArray extends Construct implements ArrayAccess{
 	 * @return
 	 */
 	protected String getString(Stack<CArray> arrays, Target t){
+		if(!valueDirty) {
+			return(mutVal);
+		}
 		StringBuilder b = new StringBuilder();
 		b.append("{");
 		if (!inAssociativeMode()) {
@@ -529,8 +535,9 @@ public class CArray extends Construct implements ArrayAccess{
 			}
 		}
 		b.append("}");
-		String ret = b.toString();
-		return ret;
+		mutVal = b.toString();
+		valueDirty = false;
+		return mutVal;
 	}
 
 	@Override
@@ -560,7 +567,7 @@ public class CArray extends Construct implements ArrayAccess{
                 clone.associative_array = new TreeMap<String, Construct>(this.associative_array);
             }
         }
-        clone.regenValue(new HashSet<CArray>());
+        clone.regenValue();
         return clone;
     }
 	
@@ -652,7 +659,7 @@ public class CArray extends Construct implements ArrayAccess{
         } else {
             ret = associative_array.remove(c);
         }
-        regenValue(new HashSet<CArray>());
+        regenValue();
         return ret;
     }
 
@@ -679,7 +686,7 @@ public class CArray extends Construct implements ArrayAccess{
 				}
 			}
 		}
-		regenValue(new HashSet<CArray>());
+		regenValue();
 	}
 
 	/**
@@ -896,7 +903,7 @@ public class CArray extends Construct implements ArrayAccess{
             }
         });
         this.array = list;
-        this.regenValue(new HashSet<CArray>());
+        this.regenValue();
     }
 
 	public boolean isEmpty(){

--- a/src/test/java/com/laytonsmith/testing/ArrayTest.java
+++ b/src/test/java/com/laytonsmith/testing/ArrayTest.java
@@ -3,7 +3,6 @@
 package com.laytonsmith.testing;
 
 import com.laytonsmith.abstraction.MCPlayer;
-import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREIndexOverflowException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import static com.laytonsmith.testing.StaticTest.SRun;
@@ -453,4 +452,20 @@ public class ArrayTest {
 		verify(fakePlayer).sendMessage("{{}, {}}");
 	}
 
+	@Test
+	public void testArrayDirtyOrderToString() throws Exception {
+		SRun("@a = array(); @b = array(); @c = array(); @a[] = @b; @b[] = @c;\n"
+				+ "concat(@a); @b[] = null; @c[] = null; msg(@a);", fakePlayer);
+		verify(fakePlayer).sendMessage("{{{null}, null}}");
+	}
+
+/*
+	 This hasn't worked for years, as CArray can only have one parent CArray
+	@Test
+	public void testArrayDirtyMultiParentToString() throws Exception {
+		SRun("@a = array(); @b = array(); @c = array(); @a[] = @c; @b[] = @c;\n"
+				+ "concat(@a); @c[] = null; msg(@a);", fakePlayer);
+		verify(fakePlayer).sendMessage("{{null}}");
+	}
+*/
 }


### PR DESCRIPTION
This avoids hashing entire arrays while still preventing recursion. In most cases they weren't noticeable, but these hashes could add up when adding or setting many values in an array, even internally like with inventory events.