### PR TITLE
Fixes

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
@@ -26,47 +26,15 @@ import org.bukkit.plugin.PluginManager;
  * 
  */
 public class BukkitBlockListener implements Listener{
-	// Track piston state, because Bukkit tends to multi-fire it's piston events.
-	// HAX!
-	List<Block> pistonsOut = new ArrayList<>();
-	List<Block> pistonsIn = new ArrayList<>();
-	
+
 	@EventHandler(priority=EventPriority.LOWEST)
     public void onPistonExtend(final BlockPistonExtendEvent e){
-		pistonsIn.remove(e.getBlock());
-		if (pistonsOut.contains(e.getBlock())) {
-			return;
-		}
-		
-		Bukkit.getScheduler().runTaskLater(CommandHelperPlugin.self, new Runnable() {
-			@Override
-			public void run() {
-				pistonsOut.remove(e.getBlock());
-			}
-		}, 20);
-		
-		pistonsOut.add(e.getBlock());
-		
 		BukkitBlockEvents.BukkitMCBlockPistonExtendEvent mce = new BukkitBlockEvents.BukkitMCBlockPistonExtendEvent(e);
         EventUtils.TriggerListener(Driver.PISTON_EXTEND, "piston_extend", mce);
     }
 	
 	@EventHandler(priority=EventPriority.LOWEST)
     public void onPistonRetract(final BlockPistonRetractEvent e){
-		pistonsOut.remove(e.getBlock());
-		if (pistonsIn.contains(e.getBlock())) {
-			return;
-		}
-		
-		Bukkit.getScheduler().runTaskLater(CommandHelperPlugin.self, new Runnable() {
-			@Override
-			public void run() {
-				pistonsIn.remove(e.getBlock());
-			}
-		}, 20);
-		
-		pistonsIn.add(e.getBlock());
-		
 		BukkitBlockEvents.BukkitMCBlockPistonRetractEvent mce = new BukkitBlockEvents.BukkitMCBlockPistonRetractEvent(e);
         EventUtils.TriggerListener(Driver.PISTON_RETRACT, "piston_retract", mce);
     }

--- a/src/main/java/com/laytonsmith/core/Procedure.java
+++ b/src/main/java/com/laytonsmith/core/Procedure.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A procedure is a user defined function, essentially. Unlike a closure, however, it does not
@@ -47,7 +48,7 @@ public class Procedure implements Cloneable {
     private ParseTree tree;
 	private CClassType returnType;
     private boolean possiblyConstant = false;
-	public static final String PROCEDURE_NAME_REGEX = "^_[\\p{L}0-9]+[\\p{L}_0-9]*";
+	private static final Pattern PROCEDURE_NAME_REGEX = Pattern.compile("^_[\\p{L}0-9]+[\\p{L}_0-9]*");
 	/**
 	 * The line the procedure is defined at (for stacktraces)
 	 */
@@ -68,7 +69,7 @@ public class Procedure implements Cloneable {
             this.originals.put(var.getVariableName(), var.ival());
         }
         this.tree = tree;
-        if (!this.name.matches(PROCEDURE_NAME_REGEX)) {
+        if (!PROCEDURE_NAME_REGEX.matcher(name).matches()) {
             throw new CREFormatException("Procedure names must start with an underscore, and may only contain letters, underscores, and digits. (Found " + this.name + ")", t);
         }
         //Let's look through the tree now, and see if this is possibly constant or not.

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1666,7 +1666,12 @@ public class EntityManagement {
 			} else if (rider == null) {
 				success = horse.eject();
 			} else {
-				success = horse.setPassenger(rider);
+				try {
+					success = horse.setPassenger(rider);
+				} catch(IllegalStateException ex){
+					throw new CREFormatException("Circular entity riding!"
+							+ " One entity is already a passenger of the other.", t);
+				}
 			}
 			return CBoolean.get(success);
 		}


### PR DESCRIPTION
Making sure I'm not making a mistake with the piston workaround removal. It seems unreliable and unnecessary. Looks like it was added by @EntityReborn when the event was added in 2014. I'm guessing maybe it was a Bukkit bug that has since been fixed. I'd rather have it double fire on older versions due to an upstream bug than have it do all this unnecessary work that makes it unreliable to fire in CH or cancel.