### PR TITLE
Added useSSL to MySQLProfile

### DIFF
--- a/src/main/java/com/laytonsmith/database/MySQLProfile.java
+++ b/src/main/java/com/laytonsmith/database/MySQLProfile.java
@@ -17,6 +17,7 @@ public class MySQLProfile extends SQLProfile {
 	private final String database;
 	private final String username;
 	private final String password;
+	private final Boolean useSSL;
 
 	public MySQLProfile(String id, Map<String, String> elements) throws Profiles.InvalidProfileException {
 		super(id, elements);
@@ -48,6 +49,11 @@ public class MySQLProfile extends SQLProfile {
 		} else {
 			port = 3306;
 		}
+		if(elements.containsKey("useSSL")) {
+			useSSL = Boolean.parseBoolean(elements.get("useSSL"));
+		} else {
+			useSSL = null;
+		}
 	}
 
 	public String getDatabase() {
@@ -73,7 +79,8 @@ public class MySQLProfile extends SQLProfile {
 			return "jdbc:mysql://" + host + ":" + port + "/" + database + "?generateSimpleParameterMetadata=true"
 					+ "&jdbcCompliantTruncation=false"
 					+ (username == null ? "" : "&user=" + URLEncoder.encode(username, "UTF-8"))
-					+ (password == null ? "" : "&password=" + URLEncoder.encode(password, "UTF-8"));
+					+ (password == null ? "" : "&password=" + URLEncoder.encode(password, "UTF-8"))
+					+ (useSSL == null ? "" : "&useSSL=" + useSSL);
 		} catch (UnsupportedEncodingException ex) {
 			throw new Error();
 		}

--- a/src/main/resources/docs/SQL
+++ b/src/main/resources/docs/SQL
@@ -102,6 +102,10 @@ on the MySQL website: http://www.mysql.com/
 | port
 | The port you are connecting to. If not specified, 3306 is assumed.
 | Optional
+|-
+| useSSL
+| If set: "useSSL=false". If value "true": "useSSL=true". Default: useSSL will not be an argument.
+| Optional
 |}
 
 === PostgreSQL ===


### PR DESCRIPTION
An optional additional argument to enable/disable ssl.
Not adding the <useSSL> Tag, will default to not sending the argument.
<useSSL /> will default to false, any mix of true/TRUE will be interpreted as true.