### PR TITLE
Make uncaught exception handler plugin-wide, and pass commandsender…

### DIFF
--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -8,7 +8,6 @@ import com.laytonsmith.core.Procedure;
 import com.laytonsmith.core.Profiles;
 import com.laytonsmith.core.Script;
 import com.laytonsmith.core.Static;
-import com.laytonsmith.core.constructs.CClosure;
 import com.laytonsmith.core.constructs.IVariableList;
 import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
 import com.laytonsmith.core.events.BoundEvent;
@@ -49,7 +48,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	private final Map<String, Object> custom = new HashMap<>();
 	private Script script = null;
 	private final MutableObject<File> root;
-	private final MutableObject<CClosure> uncaughtExceptionHandler = new MutableObject<>();
 	private Map<String, Procedure> procs = null;
 	private IVariableList iVariableList = null;
 	private String label = null;
@@ -228,14 +226,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 			throw new IllegalArgumentException("File provided to SetRootFolder must be a folder, not a file. (" + file.toString() + " was found.)");
 		}
 		this.root.setObject(file);
-	}
-
-	public void SetExceptionHandler(CClosure construct) {
-		uncaughtExceptionHandler.setObject(construct);
-	}
-
-	public CClosure GetExceptionHandler() {
-		return uncaughtExceptionHandler.getObject();
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/functions/Exceptions.java
+++ b/src/main/java/com/laytonsmith/core/functions/Exceptions.java
@@ -52,8 +52,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * 
@@ -323,8 +321,8 @@ public class Exceptions {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			if(args[0] instanceof CClosure){
-				CClosure old = environment.getEnv(GlobalEnv.class).GetExceptionHandler();
-				environment.getEnv(GlobalEnv.class).SetExceptionHandler((CClosure)args[0]);
+				CClosure old = ConfigRuntimeException.GetExceptionHandler();
+				ConfigRuntimeException.SetExceptionHandler((CClosure)args[0]);
 				if(old == null){
 					return CNull.NULL;
 				} else {


### PR DESCRIPTION
…from exception env into handler.

This is what Pieter was presumably trying to solve in PR #294, however it doesn't keep it separate from /interpreter as talked about. Right now I'm setting the exception handler in auto_include.ms to get around this problem, but I'm wondering if it really makes sense to pass it around in the environment like it is.

The second part to this PR (even if the first part isn't approved) is to send the commandsender from the exception's environment to the exception handler. This way we can send error messages to the user too. This is normally not a problem in aliases, but it is in registered commands and other places where the commandsender for when the exception handler is created is not the same as the commandsender for when the code is run. This change is far more important to me at the moment.