### PR TITLE
Fixed ArrayOutOfBoundsEx in the compiler.

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -1071,7 +1071,7 @@ public final class MethodScriptCompiler {
 				int array = arrayStack.pop().get();
 				//index is the location of the first node with the index
 				int index = array + 1;
-				if (!tree.hasChildren()) {
+				if (!tree.hasChildren() || array == -1) {
 					throw new ConfigCompileException("Brackets are illegal here", t.target);
 				}
 				ParseTree myArray = tree.getChildAt(array);


### PR DESCRIPTION
When compiling "function(['bla'])" or similar code, the compiler would
attempt to convert the ['bla'] to "array_get(...)". Because the actual
array to get it from does not exist, it looks for this at index "-1",
causing an uncaught ArrayOutOfBoundsException. This commit adds a check
for this case and gives an expected compile exception instead.