### PR TITLE
Typo in foreach examples()

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -853,7 +853,7 @@ public class DataHandling {
 		+ "foreach(@key: @value in @array){\n"
 		+ "\tmsg(@key . ': ' . @value);\n"
 		+ "}"),
-		new ExampleScript("Using \"a\" keyword", "@array = array(1, 2, 3);\n"
+		new ExampleScript("Using \"as\" keyword", "@array = array(1, 2, 3);\n"
 		+ "foreach(@array as @value){\n"
 		+ "\tmsg(@value);\n"
 		+ "}"),


### PR DESCRIPTION
'a' instead of 'as'