### PR TITLE
Command block support and bugfixes.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCCommandMinecart.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCCommandMinecart.java
@@ -1,11 +1,12 @@
 package com.laytonsmith.abstraction.bukkit.entities;
 
 import com.laytonsmith.abstraction.entities.MCCommandMinecart;
+import java.util.ArrayList;
+import java.util.List;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.minecart.CommandMinecart;
 
-public class BukkitMCCommandMinecart extends BukkitMCMinecart
-		implements MCCommandMinecart {
+public class BukkitMCCommandMinecart extends BukkitMCMinecart implements MCCommandMinecart {
 
 	CommandMinecart cm;
 
@@ -32,5 +33,37 @@ public class BukkitMCCommandMinecart extends BukkitMCMinecart
 	@Override
 	public void setCommand(String cmd) {
 		cm.setCommand(cmd);
+	}
+
+	@Override
+	public void sendMessage(String string) {
+		cm.sendMessage(string);
+	}
+
+	@Override
+	public boolean isOp() {
+		return cm.isOp();
+	}
+
+	@Override
+	public boolean hasPermission(String perm) {
+		return cm.hasPermission(perm);
+	}
+
+	@Override
+	public boolean isPermissionSet(String perm) {
+		return cm.isPermissionSet(perm);
+	}
+
+	@Override
+	public List<String> getGroups() {
+		// CommandMinecarts cannot be in a group.
+		return new ArrayList<String>();
+	}
+
+	@Override
+	public boolean inGroup(String groupName) {
+		// CommandMinecarts cannot be in a group.
+		return false;
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCCommandMinecart.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCCommandMinecart.java
@@ -1,6 +1,8 @@
 package com.laytonsmith.abstraction.entities;
 
-public interface MCCommandMinecart extends MCMinecart {
+import com.laytonsmith.abstraction.MCCommandSender;
+
+public interface MCCommandMinecart extends MCMinecart, MCCommandSender {
 	public String getName();
 	public void setName(String cmd);
 	public String getCommand();

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
@@ -562,18 +562,15 @@ public class CommandHelperPlugin extends JavaPlugin {
 			if (sender instanceof Player) {
 				PlayerCommandPreprocessEvent pcpe = new PlayerCommandPreprocessEvent((Player) sender, command);
 				playerListener.onPlayerCommandPreprocess(pcpe);
-			} else if (sender instanceof ConsoleCommandSender) {
+			} else if (sender instanceof ConsoleCommandSender
+					|| sender instanceof BlockCommandSender || sender instanceof CommandMinecart) {
+				// Console commands and command blocks/minecarts all fire the same event, so pass them to the
+				// event handler that would get them if they would not have started with "/runalias".
 				if (command.startsWith("/")) {
 					command = command.substring(1);
 				}
-				ServerCommandEvent sce = new ServerCommandEvent((ConsoleCommandSender) sender, command);
+				ServerCommandEvent sce = new ServerCommandEvent(sender, command);
 				serverListener.onServerCommand(sce);
-			} else if(sender instanceof BlockCommandSender){
-				MCCommandSender s = new BukkitMCBlockCommandSender((BlockCommandSender) sender);
-				Static.getAliasCore().alias(command, s);
-			} else if(sender instanceof CommandMinecart) {
-				MCCommandSender s = new BukkitMCCommandMinecart((CommandMinecart) sender);
-				Static.getAliasCore().alias(command, s);
 			}
 			return true;
 		} else if(cmdName.equalsIgnoreCase("interpreter-on")){

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
@@ -37,6 +37,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
 import com.laytonsmith.abstraction.bukkit.BukkitMCBlockCommandSender;
 import com.laytonsmith.abstraction.bukkit.BukkitMCCommand;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCCommandMinecart;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCBiomeType;
@@ -87,6 +88,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bukkit.entity.minecart.CommandMinecart;
 
 /**
  * Entry point for the plugin.
@@ -567,7 +569,10 @@ public class CommandHelperPlugin extends JavaPlugin {
 				ServerCommandEvent sce = new ServerCommandEvent((ConsoleCommandSender) sender, command);
 				serverListener.onServerCommand(sce);
 			} else if(sender instanceof BlockCommandSender){
-				MCCommandSender s = new BukkitMCBlockCommandSender((BlockCommandSender)sender);
+				MCCommandSender s = new BukkitMCBlockCommandSender((BlockCommandSender) sender);
+				Static.getAliasCore().alias(command, s);
+			} else if(sender instanceof CommandMinecart) {
+				MCCommandSender s = new BukkitMCCommandMinecart((CommandMinecart) sender);
 				Static.getAliasCore().alias(command, s);
 			}
 			return true;
@@ -576,7 +581,7 @@ public class CommandHelperPlugin extends JavaPlugin {
 				int interpreterTimeout = Prefs.InterpreterTimeout();
 				if(interpreterTimeout != 0){
 					interpreterUnlockedUntil = (interpreterTimeout * 60 * 1000) + System.currentTimeMillis();
-					sender.sendMessage("Inpterpreter mode unlocked for " + interpreterTimeout + " minute"
+					sender.sendMessage("Interpreter mode unlocked for " + interpreterTimeout + " minute"
 							+ (interpreterTimeout==1?"":"s"));
 				}
 			} else {

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperServerListener.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperServerListener.java
@@ -3,8 +3,10 @@
 package com.laytonsmith.commandhelper;
 
 import com.laytonsmith.abstraction.MCCommandSender;
+import com.laytonsmith.abstraction.bukkit.BukkitMCBlockCommandSender;
 import com.laytonsmith.abstraction.bukkit.BukkitMCCommandSender;
 import com.laytonsmith.abstraction.bukkit.BukkitMCConsoleCommandSender;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCCommandMinecart;
 import com.laytonsmith.abstraction.bukkit.events.BukkitMiscEvents;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.core.InternalException;
@@ -12,7 +14,9 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.events.EventUtils;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import java.util.logging.Level;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -29,11 +33,18 @@ public class CommandHelperServerListener implements Listener{
 		//Run this first, so external events can intercept it.
 		BukkitMiscEvents.BukkitMCConsoleCommandEvent cce = new BukkitMiscEvents.BukkitMCConsoleCommandEvent(event);
 		EventUtils.TriggerExternal(cce);
-        MCCommandSender player = new BukkitMCCommandSender(event.getSender());
-        if(event.getSender() instanceof ConsoleCommandSender){
-            //Need the more specific subtype for player()
+		
+		// Select the proper CommandSender wrapper.
+        MCCommandSender player;
+        if(event.getSender() instanceof ConsoleCommandSender){ // Console.
             player = new BukkitMCConsoleCommandSender((ConsoleCommandSender)event.getSender());
-        }
+        } else if(event.getSender() instanceof BlockCommandSender){ // Commandblock blocks.
+            player = new BukkitMCBlockCommandSender((BlockCommandSender)event.getSender());
+        } else if(event.getSender() instanceof CommandMinecart) { // Commandblock minecarts.
+            player = new BukkitMCCommandMinecart((CommandMinecart) event.getSender());
+        } else { // Players or unknown CommandSenders.
+			player = new BukkitMCCommandSender(event.getSender());
+		}
         boolean match = false;
         try {
             match = Static.getAliasCore().alias("/" + event.getCommand(), player);

--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.MCBlockCommandSender;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.commandhelper.CommandHelperFileLocations;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
@@ -118,6 +119,8 @@ public class AliasCore {
 		Environment env = Environment.createEnvironment(gEnv, cEnv);
 		if (player instanceof MCBlockCommandSender) {
 			cEnv.SetBlockCommandSender((MCBlockCommandSender) player);
+		} else if(player instanceof MCCommandMinecart) {
+			cEnv.SetCommandMinecartSender((MCCommandMinecart) player);
 		}
 
 		if (scripts == null) {

--- a/src/main/java/com/laytonsmith/core/environments/CommandHelperEnvironment.java
+++ b/src/main/java/com/laytonsmith/core/environments/CommandHelperEnvironment.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core.environments;
 import com.laytonsmith.abstraction.MCBlockCommandSender;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 
 /**
  *
@@ -80,6 +81,18 @@ public class CommandHelperEnvironment implements Environment.EnvironmentImpl, Cl
 	public MCBlockCommandSender GetBlockCommandSender(){
 		if(this.commandSender instanceof MCBlockCommandSender){
 			return (MCBlockCommandSender)commandSender;
+		} else {
+			return null;
+		}
+	}
+
+	public void SetCommandMinecartSender(MCCommandMinecart mcs) {
+		this.commandSender = mcs;
+	}
+	
+	public MCCommandMinecart GetCommandMinecartSender() {
+		if(this.commandSender instanceof MCCommandMinecart) {
+			return (MCCommandMinecart) commandSender;
 		} else {
 			return null;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1569,6 +1569,8 @@ public class EntityManagement {
 					l = ((MCPlayer) cs).getLocation();
 				} else if (cs instanceof MCBlockCommandSender){
 					l = ((MCBlockCommandSender) cs).getBlock().getRelative(MCBlockFace.UP).getLocation();
+				} else if(cs instanceof MCCommandMinecart) {
+					l = ((MCCommandMinecart) cs).getLocation().add(0, 1, 0); // One block above the minecart.
 				} else {
 					throw new CREPlayerOfflineException("A physical commandsender must exist or location must be explicit.", t);
 				}

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.MCBlockCommandSender;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.noboilerplate;
 import com.laytonsmith.core.AliasCore;
@@ -716,12 +717,21 @@ public class Meta {
 
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
-			MCBlockCommandSender cs = environment.getEnv(CommandHelperEnvironment.class).GetBlockCommandSender();
-			if(cs != null){
-				MCLocation l = (cs.getBlock().getLocation());
-				return ObjectGenerator.GetGenerator().location(l);
+			MCCommandSender sender = environment.getEnv(CommandHelperEnvironment.class).GetCommandSender();
+			MCLocation loc;
+			String type;
+			if(sender instanceof MCBlockCommandSender) {
+				loc = ((MCBlockCommandSender) sender).getBlock().getLocation();
+				type = "block";
+			} else if(sender instanceof MCCommandMinecart) {
+				loc = ((MCCommandMinecart) sender).getLocation();
+				type = "minecart";
+			} else {
+				return CNull.NULL;
 			}
-			return CNull.NULL;
+			CArray ret = ObjectGenerator.GetGenerator().location(loc);
+			ret.set("type", new CString(type, t), t);
+			return ret;
 		}
 
 		@Override
@@ -736,8 +746,10 @@ public class Meta {
 
 		@Override
 		public String docs() {
-			return "locationArray {} If this command was being run from a command block, this will return the location of"
-					+ " the block. If a player or console ran this command, (or any other command sender) this will return null.";
+			return "locationArray {} If this command was being run from a command block block or minecart, this will"
+					+ " return the location of the block or minecart with an additional \"type\" key with value"
+					+ " \"block\" or \"minecart\" for command block blocks and command block minecarts respectively."
+					+ " If a player or console ran this command (or any other command sender), this will return null.";
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -719,18 +719,16 @@ public class Meta {
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCCommandSender sender = environment.getEnv(CommandHelperEnvironment.class).GetCommandSender();
 			MCLocation loc;
-			String type;
+			CArray ret;
 			if(sender instanceof MCBlockCommandSender) {
 				loc = ((MCBlockCommandSender) sender).getBlock().getLocation();
-				type = "block";
+				ret = ObjectGenerator.GetGenerator().location(loc, false); // Do not include pitch/yaw.
 			} else if(sender instanceof MCCommandMinecart) {
 				loc = ((MCCommandMinecart) sender).getLocation();
-				type = "minecart";
+				ret = ObjectGenerator.GetGenerator().location(loc, true); // Include pitch/yaw.
 			} else {
 				return CNull.NULL;
 			}
-			CArray ret = ObjectGenerator.GetGenerator().location(loc);
-			ret.set("type", new CString(type, t), t);
 			return ret;
 		}
 
@@ -747,8 +745,8 @@ public class Meta {
 		@Override
 		public String docs() {
 			return "locationArray {} If this command was being run from a command block block or minecart, this will"
-					+ " return the location of the block or minecart with an additional \"type\" key with value"
-					+ " \"block\" or \"minecart\" for command block blocks and command block minecarts respectively."
+					+ " return the location of the block or minecart."
+					+ " The yaw and pitch will only be included in the locationArray for minecart command blocks."
 					+ " If a player or console ran this command (or any other command sender), this will return null.";
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -15,6 +15,7 @@ import com.laytonsmith.abstraction.MCServer;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
+import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.abstraction.enums.MCGameMode;
 import com.laytonsmith.abstraction.enums.MCSound;
 import com.laytonsmith.abstraction.enums.MCSoundCategory;
@@ -111,7 +112,7 @@ public class PlayerManagement {
 				if (p instanceof MCConsoleCommandSender || "CONSOLE".equals(name)) {
 					name = Static.getConsoleName();
 				}
-				if (p instanceof MCBlockCommandSender) {
+				if (p instanceof MCBlockCommandSender || p instanceof MCCommandMinecart) {
 					name = Static.getBlockPrefix() + name;
 				}
 				return new CString(name, t);

--- a/src/main/java/com/laytonsmith/core/functions/Weather.java
+++ b/src/main/java/com/laytonsmith/core/functions/Weather.java
@@ -1,10 +1,12 @@
 package com.laytonsmith.core.functions;
 
 import com.laytonsmith.abstraction.MCBlockCommandSender;
+import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.core.CHVersion;
 import com.laytonsmith.core.ObjectGenerator;
@@ -134,12 +136,6 @@ public class Weather {
 			boolean b = Static.getBoolean(args[0]);
 			MCWorld w = null;
 			int duration = -1;
-			if (env.getEnv(CommandHelperEnvironment.class).GetCommandSender() instanceof MCPlayer) {
-				w = env.getEnv(CommandHelperEnvironment.class).GetPlayer().getWorld();
-			}
-			if (env.getEnv(CommandHelperEnvironment.class).GetCommandSender() instanceof MCBlockCommandSender) {
-				w = env.getEnv(CommandHelperEnvironment.class).GetBlockCommandSender().getBlock().getWorld();
-			}
 			if (args.length == 2) {
 				if (args[1] instanceof CString) {
 					w = Static.getServer().getWorld(args[1].val());
@@ -152,6 +148,16 @@ public class Weather {
 			if (args.length == 3) {
 				w = Static.getServer().getWorld(args[1].val());
 				duration = Static.getInt32(args[2], t);
+			}
+			if(w == null) {
+				MCCommandSender sender = env.getEnv(CommandHelperEnvironment.class).GetCommandSender();
+				if(sender instanceof MCPlayer) {
+					w = ((MCPlayer) sender).getWorld();
+				} else if(sender instanceof MCBlockCommandSender) {
+					w = ((MCBlockCommandSender) sender).getBlock().getWorld();
+				} else if(sender instanceof MCCommandMinecart) {
+					w = ((MCCommandMinecart) sender).getWorld();
+				}
 			}
 			if (w != null) {
 				w.setStorm(b);


### PR DESCRIPTION
Since CraftBukkit 1.12.1, execution of a CommandBlock fires a
ServerCommandEvent, allowing CommandHelper to listen to 'direct' aliases
(without /runalias prefix) in command blocks. This commit causes command
blocks without "/runalias" to be handled the same as the ones with
"/runalias" (effectively adding a "#" in front of the command block name
so player() will never return a valid player name for command blocks).
This commit also adds support for minecart command blocks in all places
where command block blocks are already supported.