### PR TITLE
Fix bukkit yaw in an earlier stage.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLocation.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCLocation.java
@@ -68,7 +68,15 @@ public class BukkitMCLocation implements MCLocation {
 
 	@Override
     public float getYaw() {
-        return l.getYaw();
+		// The yaw returned by Bukkit is not kept in range properly, fixing it here prevents issues with this later.
+		float yaw = l.getYaw();
+		while(yaw < 0) {
+			yaw += 360;
+		}
+		while(yaw >= 360) {
+			yaw -= 360;
+		}
+        return yaw; // In range of 0 (inclusive) to 360 (exclusive).
     }
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -87,36 +87,13 @@ public class ObjectGenerator {
     }
 
     /**
-     * Gets a Location Object, given a MCLocation
+     * Gets a Location Object with yaw and pitch, given a MCLocation
      *
      * @param l
      * @return
      */
     public CArray location(MCLocation l) {
-        CArray ca = CArray.GetAssociativeArray(Target.UNKNOWN);
-        Construct x = new CDouble(l.getX(), Target.UNKNOWN);
-        Construct y = new CDouble(l.getY(), Target.UNKNOWN);
-        Construct z = new CDouble(l.getZ(), Target.UNKNOWN);
-        Construct world = new CString(l.getWorld().getName(), Target.UNKNOWN);
-		float yawRaw = l.getYaw();
-		if (yawRaw < 0) {
-			yawRaw = (((yawRaw) % 360) + 360);
-		}
-        Construct yaw = new CDouble(yawRaw, Target.UNKNOWN);
-        Construct pitch = new CDouble(l.getPitch(), Target.UNKNOWN);
-        ca.set("0", x, Target.UNKNOWN);
-        ca.set("1", y, Target.UNKNOWN);
-        ca.set("2", z, Target.UNKNOWN);
-        ca.set("3", world, Target.UNKNOWN);
-        ca.set("4", yaw, Target.UNKNOWN);
-        ca.set("5", pitch, Target.UNKNOWN);
-        ca.set("x", x, Target.UNKNOWN);
-        ca.set("y", y, Target.UNKNOWN);
-        ca.set("z", z, Target.UNKNOWN);
-        ca.set("world", world, Target.UNKNOWN);
-        ca.set("yaw", yaw, Target.UNKNOWN);
-        ca.set("pitch", pitch, Target.UNKNOWN);
-        return ca;
+        return location(l, true);
     }
 
 	/**

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -1310,13 +1310,7 @@ public class PlayerManagement {
 					}
 				}
 				if (l != null) {
-					float yaw = l.getYaw();
-					float pitch = l.getPitch();
-					//normalize yaw
-					if (yaw < 0) {
-						yaw = (((yaw) % 360) + 360);
-					}
-					return new CArray(t, new CDouble(yaw, t), new CDouble(pitch, t));
+					return new CArray(t, new CDouble(l.getYaw(), t), new CDouble(l.getPitch(), t));
 				}
 			}
 			//Setter


### PR DESCRIPTION
Bukkit can return any yaw value, while we except a yaw to be in range of
0 to 360. This commit makes sure that any BukkitMCLocations will return
that range, rather than (partially) fixing it in a later stage.