### PR TITLE
Optimize alias permission labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,10 +145,6 @@
 			<id>maven-central</id>
 			<url>http://repo1.maven.org/maven2/</url>
 		</repository>
-		<!--repository>
-			<id>zml2008</id>
-			<url>http://files.zachsthings.com/repo/</url>
-		</repository-->
 
 		<repository>
 			<id>Plugin Metrics</id>
@@ -176,7 +172,7 @@
 			<!-- GPL -->
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.12.1-R0.1-SNAPSHOT</version>
+			<version>1.12.2-R0.1-SNAPSHOT</version>
 		</dependency>
 
 		<!-- Used for storing and retreiving Constructs in a storage transparent medium: JSONs -->
@@ -194,14 +190,6 @@
 			<artifactId>jBCrypt</artifactId>
 			<version>1.0</version>
 		</dependency>
-
-		<!-- Used for potion effects
-		<dependency>
-		 <groupId>org.bukkit</groupId>
-		 <artifactId>minecraft-server</artifactId>
-		 <version>1.8.1</version>
-		 <type>jar</type>
-		</dependency> -->
 
 		<!-- Used for IRC hooks -->
 		<!--<dependency> NOT READY YET

--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -908,7 +908,7 @@ public final class MethodScriptCompiler {
 							}
 						}
 					}
-					Script s = new Script(left, right);
+					Script s = new Script(left, right, null);
 					scripts.add(s);
 					left = new ArrayList<>();
 					right = new ArrayList<>();
@@ -1986,7 +1986,7 @@ public final class MethodScriptCompiler {
 			return CVoid.VOID;
 		}
 		if (script == null) {
-			script = new Script(null, null);
+			script = new Script(null, null, env.getEnv(GlobalEnv.class).GetLabel());
 		}
 		if (vars != null) {
 			Map<String, Variable> varMap = new HashMap<>();
@@ -2008,7 +2008,6 @@ public final class MethodScriptCompiler {
 		StringBuilder b = new StringBuilder();
 		Construct returnable = null;
 		for (ParseTree gg : root.getChildren()) {
-			script.setLabel(env.getEnv(GlobalEnv.class).GetLabel());
 			Construct retc = script.eval(gg, env);
 			if (root.numberOfChildren() == 1) {
 				returnable = retc;
@@ -2034,6 +2033,7 @@ public final class MethodScriptCompiler {
 			} catch (ProgramFlowManipulationException e) {
 				ConfigRuntimeException.HandleUncaughtException(ConfigRuntimeException.CreateUncatchableException("Cannot break program flow in auto include files.", e.getTarget()), env);
 			} catch (ConfigRuntimeException e) {
+				e.setEnv(env);
 				ConfigRuntimeException.HandleUncaughtException(e, env);
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -1077,44 +1077,9 @@ public final class Static {
 			return true;
 		}
 		MCPlayer player = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
-		MCCommandSender commandSender = env.getEnv(CommandHelperEnvironment.class).GetCommandSender();
-		String label = env.getEnv(GlobalEnv.class).GetLabel();
-		boolean perm = false;
-		if (commandSender != null) {
-			if (commandSender.isOp()) {
-				perm = true;
-			} else if (commandSender instanceof MCPlayer) {
-				perm = player.hasPermission("ch.func.use." + functionName)
-						|| player.hasPermission("commandhelper.func.use." + functionName);
-				if (label != null && label.startsWith("~")) {
-					String[] groups = label.substring(1).split("/");
-					for (String group : groups) {
-						if (player.inGroup(group)) {
-							perm = true;
-							break;
-						}
-					}
-				} else {
-					if (label != null) {
-						if (label.contains(".")) {
-                            //We are using a non-standard permission. Don't automatically
-							//add CH's prefix
-							if (player.hasPermission(label)) {
-								perm = true;
-							}
-						} else if ((player.hasPermission("ch.alias." + label))
-								|| player.hasPermission("commandhelper.alias." + label)) {
-							perm = true;
-						}
-					}
-				}
-			} else if (commandSender instanceof MCConsoleCommandSender) {
-				perm = true;
-			}
-		} else {
-			perm = true;
-		}
-		return perm;
+		return player == null || player.isOp()
+				|| player.hasPermission("ch.func.use." + functionName)
+				|| player.hasPermission("commandhelper.func.use." + functionName);
 	}
 
 	public static String Logo() {

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -554,26 +554,25 @@ public class Meta {
 	    return null;
 	}
 
-	@Override
-	public Construct execs(Target t, Environment environment, Script parent, ParseTree... nodes) throws ConfigRuntimeException {
-	    MCPlayer p = Static.GetPlayer(parent.seval(nodes[0], environment).val(), t);
-	    MCCommandSender originalPlayer = environment.getEnv(CommandHelperEnvironment.class).GetCommandSender();
-	    int offset = 0;
-	    String originalLabel = environment.getEnv(GlobalEnv.class).GetLabel();
-	    if (nodes.length == 3) {
-		offset++;
-		String label = environment.getEnv(GlobalEnv.class).GetScript().seval(nodes[1], environment).val();
-		environment.getEnv(GlobalEnv.class).SetLabel(label);
-		environment.getEnv(GlobalEnv.class).GetScript().setLabel(label);
-	    }
-	    environment.getEnv(CommandHelperEnvironment.class).SetPlayer(p);
-	    ParseTree tree = nodes[1 + offset];
-	    environment.getEnv(GlobalEnv.class).GetScript().eval(tree, environment);
-	    environment.getEnv(CommandHelperEnvironment.class).SetCommandSender(originalPlayer);
-	    environment.getEnv(GlobalEnv.class).SetLabel(originalLabel);
-	    environment.getEnv(GlobalEnv.class).GetScript().setLabel(originalLabel);
-	    return CVoid.VOID;
-	}
+		@Override
+		public Construct execs(Target t, Environment environment, Script parent, ParseTree... nodes) throws ConfigRuntimeException {
+			MCPlayer p = Static.GetPlayer(parent.seval(nodes[0], environment).val(), t);
+			MCCommandSender originalPlayer = environment.getEnv(CommandHelperEnvironment.class).GetCommandSender();
+			int offset = 0;
+			String originalLabel = environment.getEnv(GlobalEnv.class).GetLabel();
+			if (nodes.length == 3) {
+				offset++;
+				String label = environment.getEnv(GlobalEnv.class).GetScript().seval(nodes[1], environment).val();
+				environment.getEnv(GlobalEnv.class).SetLabel(label);
+			}
+			environment.getEnv(CommandHelperEnvironment.class).SetPlayer(p);
+			parent.enforceLabelPermissions();
+			ParseTree tree = nodes[1 + offset];
+			parent.eval(tree, environment);
+			environment.getEnv(CommandHelperEnvironment.class).SetCommandSender(originalPlayer);
+			environment.getEnv(GlobalEnv.class).SetLabel(originalLabel);
+			return CVoid.VOID;
+		}
 
 	@Override
 	public boolean useSpecialExec() {

--- a/src/test/java/com/laytonsmith/core/functions/MetaTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/MetaTest.java
@@ -74,23 +74,13 @@ public class MetaTest {
         SRun("assign(@e, 'msg(\\'Hello World!\\')') eval(@e)", fakePlayer);
         verify(fakePlayer).sendMessage("Hello World!");
     }
-    //:( I can't get this to work right, because AlwaysOpPlayer is different than
-    //fakePlayer, so I can't get my test to activate when the function is called.
-//    @Test(timeout=10000)
-//    public void testRunas2() throws Exception {
-//        final AtomicBoolean bool = new AtomicBoolean(false);
-//        String script =
-//                "runas(~op, '/cmd yay')";
-//        when(fakeServer.dispatchCommand(fakePlayer, "cmd yay")).thenAnswer(new Answer<Boolean>(){
-//
-//            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-//                assertTrue(((Server)invocation.getMock()).getPlayer(fakePlayer.getName()).isOp());
-//                bool.set(true);
-//                return true;
-//            }
-//
-//        });
-//        MethodScriptCompiler.execute(MethodScriptCompiler.compile(MethodScriptCompiler.lex(script, null)), fakePlayer, null, null);
-//        assertTrue(bool.get());
-//    }
-    }
+
+	@Test public void testScriptas() throws Exception{
+		String script = "scriptas('Player02', 'newlabel', msg(reflect_pull('label'))); msg(reflect_pull('label'))";
+		MCPlayer fakePlayer2 = GetOnlinePlayer("Player02", fakeServer);
+		when(fakeServer.getPlayer("Player02")).thenReturn(fakePlayer2);
+		MethodScriptCompiler.execute(MethodScriptCompiler.compile(MethodScriptCompiler.lex(script, null, true)), env, null, null);
+		verify(fakePlayer2).sendMessage("newlabel");
+		verify(fakePlayer).sendMessage("*");
+	}
+}


### PR DESCRIPTION
Script labels are now processed only once, instead of every time a function is executed. This also isolates script labels so that they're not modified after they're set, which is what the environment is for. These changes should not alter current behavior.

I don't expect any issues, but I want to do more testing before this is pulled. However, I want your impression on this approach and if you have any suggestions. I don't want to do the testing if you don't like it, and I had trouble communicating what I wanted to do here before.

So the git diff on the scriptas() function turned out pretty shitty. What I did there was removed script.setLabel() usages (as we probably shouldn't ever change the script label) and added the same script.enforceLabelPermissions() call that's at the beginning of script.run().