### PR TITLE
Updated sk89q repo in pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
 	<repositories>
 		<!-- Repository for other dependencies of SK's -->
 		<repository>
-			<id>sk89q-mvn2</id>
-			<url>http://mvn2.sk89q.com/repo</url>
+			<id>sk89q-maven</id>
+			<url>http://maven.sk89q.com/repo</url>
 		</repository>
 
 		<!-- Repository for Bukkit -->


### PR DESCRIPTION
Repository "mvn2.sk89q.com" has been replaced with "maven.sk89q.com" long ago. The mvn2 repository is currently offline and might never come back, the replacing repository is online and recommended over the deprecated one (source: wizjany).