### PR TITLE
Added blockstate data support for furnaces.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCBeaconInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCBeaconInventory.java
@@ -1,0 +1,10 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.blocks.MCBeacon;
+
+public interface MCBeaconInventory extends MCInventory {
+	MCItemStack getItem();
+	void setItem(MCItemStack stack);
+	@Override
+	MCBeacon getHolder();
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCBrewerInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCBrewerInventory.java
@@ -5,8 +5,14 @@ import com.laytonsmith.abstraction.blocks.MCBrewingStand;
 public interface MCBrewerInventory extends MCInventory {
 	MCItemStack getFuel();
 	MCItemStack getIngredient();
+	MCItemStack getLeftBottle();
+	MCItemStack getMiddleBottle();
+	MCItemStack getRightBottle();
 	void setFuel(MCItemStack stack);
 	void setIngredient(MCItemStack stack);
+	void setLeftBottle(MCItemStack stack);
+	void setMiddleBottle(MCItemStack stack);
+	void setRightBottle(MCItemStack stack);
 	@Override
 	MCBrewingStand getHolder();
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCBrewerInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCBrewerInventory.java
@@ -1,0 +1,12 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.blocks.MCBrewingStand;
+
+public interface MCBrewerInventory extends MCInventory {
+	MCItemStack getFuel();
+	MCItemStack getIngredient();
+	void setFuel(MCItemStack stack);
+	void setIngredient(MCItemStack stack);
+	@Override
+	MCBrewingStand getHolder();
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCFurnaceInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCFurnaceInventory.java
@@ -1,0 +1,14 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.blocks.MCFurnace;
+
+public interface MCFurnaceInventory extends MCInventory {
+	MCItemStack getResult();
+	MCItemStack getFuel();
+	MCItemStack getSmelting();
+	void setFuel(MCItemStack stack);
+	void setResult(MCItemStack stack);
+	void setSmelting(MCItemStack stack);
+	@Override
+	MCFurnace getHolder();
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCBeacon.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCBeacon.java
@@ -1,0 +1,18 @@
+package com.laytonsmith.abstraction.blocks;
+
+import java.util.Collection;
+
+import com.laytonsmith.abstraction.MCBeaconInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
+import com.laytonsmith.abstraction.MCLivingEntity;
+
+public interface MCBeacon extends MCBlockState, MCInventoryHolder {
+	Collection<MCLivingEntity> getEntitiesInRange();
+	@Override
+	MCBeaconInventory getInventory();
+//	MCPotionEffect getPrimaryEffect();
+//	MCPotionEffect getSecondaryEffect();
+	int getTier();
+//	void setPrimaryEffect(MCPotionEffect effect);
+//	void setSecondaryEffect(MCPotionEffect effect);
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCBrewingStand.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCBrewingStand.java
@@ -1,0 +1,13 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCBrewerInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
+
+public interface MCBrewingStand extends MCBlockState, MCInventoryHolder {
+	int getBrewingTime();
+	int getFuelLevel();
+	@Override
+	MCBrewerInventory getInventory();
+	void setBrewingTime(int brewTime);
+	void setFuelLevel(int level);
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCChest.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCChest.java
@@ -1,0 +1,6 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCInventoryHolder;
+
+public interface MCChest extends MCBlockState, MCInventoryHolder {
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCDispenser.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCDispenser.java
@@ -1,6 +1,8 @@
 package com.laytonsmith.abstraction.blocks;
 
-public interface MCDispenser extends MCBlockState {
+import com.laytonsmith.abstraction.MCInventoryHolder;
 
+public interface MCDispenser extends MCBlockState, MCInventoryHolder {
+	boolean dispense();
 	MCBlockProjectileSource getBlockProjectileSource();
 }

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCDropper.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCDropper.java
@@ -1,0 +1,7 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCInventoryHolder;
+
+public interface MCDropper extends MCBlockState, MCInventoryHolder {
+	void drop();
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCFurnace.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCFurnace.java
@@ -1,0 +1,13 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCFurnaceInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
+
+public interface MCFurnace extends MCBlockState, MCInventoryHolder {
+	short getBurnTime();
+	void setBurnTime(short burnTime);
+	short getCookTime();
+	void setCookTime(short cookTime);
+	@Override
+	MCFurnaceInventory getInventory();
+}

--- a/src/main/java/com/laytonsmith/abstraction/blocks/MCHopper.java
+++ b/src/main/java/com/laytonsmith/abstraction/blocks/MCHopper.java
@@ -1,0 +1,6 @@
+package com.laytonsmith.abstraction.blocks;
+
+import com.laytonsmith.abstraction.MCInventoryHolder;
+
+public interface MCHopper extends MCBlockState, MCInventoryHolder {
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -28,8 +28,14 @@ import com.laytonsmith.abstraction.MCWorldCreator;
 import com.laytonsmith.abstraction.blocks.MCBlockState;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBanner;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBeacon;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlockState;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBrewingStand;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCChest;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCDispenser;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCDropper;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCFurnace;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCHopper;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCMaterial;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCShulkerBox;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCAgeable;
@@ -81,11 +87,17 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Banner;
+import org.bukkit.block.Beacon;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.BrewingStand;
+import org.bukkit.block.Chest;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.Dispenser;
 import org.bukkit.block.DoubleChest;
+import org.bukkit.block.Dropper;
 import org.bukkit.block.Furnace;
+import org.bukkit.block.Hopper;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.command.BlockCommandSender;
@@ -457,8 +469,26 @@ public class BukkitConvertor extends AbstractConvertor {
 		if(bs instanceof CreatureSpawner) {
 			return new BukkitMCCreatureSpawner((CreatureSpawner) bs);
 		}
+		if(bs instanceof Beacon) {
+			return new BukkitMCBeacon((Beacon) bs);
+		}
+		if(bs instanceof BrewingStand) {
+			return new BukkitMCBrewingStand((BrewingStand) bs);
+		}
+		if(bs instanceof Chest) {
+			return new BukkitMCChest((Chest) bs);
+		}
+		if(bs instanceof Dispenser) {
+			return new BukkitMCDispenser((Dispenser) bs);
+		}
+		if(bs instanceof Dropper) {
+			return new BukkitMCDropper((Dropper) bs);
+		}
 		if(bs instanceof Furnace) {
 			return new BukkitMCFurnace((Furnace) bs);
+		}
+		if(bs instanceof Hopper) {
+			return new BukkitMCHopper((Hopper) bs);
 		}
 		return new BukkitMCBlockState(bs);
 	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -29,6 +29,7 @@ import com.laytonsmith.abstraction.blocks.MCBlockState;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBanner;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlockState;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCFurnace;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCMaterial;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCShulkerBox;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCAgeable;
@@ -84,6 +85,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.DoubleChest;
+import org.bukkit.block.Furnace;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.command.BlockCommandSender;
@@ -454,6 +456,9 @@ public class BukkitConvertor extends AbstractConvertor {
 		}
 		if(bs instanceof CreatureSpawner) {
 			return new BukkitMCCreatureSpawner((CreatureSpawner) bs);
+		}
+		if(bs instanceof Furnace) {
+			return new BukkitMCFurnace((Furnace) bs);
 		}
 		return new BukkitMCBlockState(bs);
 	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBeaconInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBeaconInventory.java
@@ -1,0 +1,35 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import org.bukkit.block.Beacon;
+import org.bukkit.inventory.BeaconInventory;
+import org.bukkit.inventory.ItemStack;
+
+import com.laytonsmith.abstraction.MCBeaconInventory;
+import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.blocks.MCBeacon;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBeacon;
+
+public class BukkitMCBeaconInventory extends BukkitMCInventory implements MCBeaconInventory {
+	
+	private BeaconInventory inv;
+	
+	public BukkitMCBeaconInventory(BeaconInventory inv) {
+		super(inv);
+		this.inv = inv;
+	}
+	
+	@Override
+	public MCItemStack getItem() {
+		return new BukkitMCItemStack(this.inv.getItem());
+	}
+	
+	@Override
+	public void setItem(MCItemStack stack) {
+		this.inv.setItem((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public MCBeacon getHolder() {
+		return new BukkitMCBeacon((Beacon) this.inv.getHolder());
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBrewerInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBrewerInventory.java
@@ -1,0 +1,45 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import org.bukkit.block.BrewingStand;
+import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.ItemStack;
+
+import com.laytonsmith.abstraction.MCBrewerInventory;
+import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.blocks.MCBrewingStand;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBrewingStand;
+
+public class BukkitMCBrewerInventory extends BukkitMCInventory implements MCBrewerInventory {
+	
+	private BrewerInventory inv;
+	
+	public BukkitMCBrewerInventory(BrewerInventory inv) {
+		super(inv);
+		this.inv = inv;
+	}
+	
+	@Override
+	public MCItemStack getFuel() {
+		return new BukkitMCItemStack(this.inv.getFuel());
+	}
+	
+	@Override
+	public MCItemStack getIngredient() {
+		return new BukkitMCItemStack(this.inv.getIngredient());
+	}
+	
+	@Override
+	public void setFuel(MCItemStack stack) {
+		this.inv.setFuel((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setIngredient(MCItemStack stack) {
+		this.inv.setIngredient((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public MCBrewingStand getHolder() {
+		return new BukkitMCBrewingStand((BrewingStand) this.inv.getHolder());
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBrewerInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCBrewerInventory.java
@@ -29,6 +29,21 @@ public class BukkitMCBrewerInventory extends BukkitMCInventory implements MCBrew
 	}
 	
 	@Override
+	public MCItemStack getLeftBottle() {
+		return new BukkitMCItemStack(this.inv.getItem(0));
+	}
+	
+	@Override
+	public MCItemStack getMiddleBottle() {
+		return new BukkitMCItemStack(this.inv.getItem(1));
+	}
+	
+	@Override
+	public MCItemStack getRightBottle() {
+		return new BukkitMCItemStack(this.inv.getItem(2));
+	}
+	
+	@Override
 	public void setFuel(MCItemStack stack) {
 		this.inv.setFuel((ItemStack) stack.getHandle());
 	}
@@ -36,6 +51,21 @@ public class BukkitMCBrewerInventory extends BukkitMCInventory implements MCBrew
 	@Override
 	public void setIngredient(MCItemStack stack) {
 		this.inv.setIngredient((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setLeftBottle(MCItemStack stack) {
+		this.inv.setItem(0, (ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setMiddleBottle(MCItemStack stack) {
+		this.inv.setItem(1, (ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setRightBottle(MCItemStack stack) {
+		this.inv.setItem(2, (ItemStack) stack.getHandle());
 	}
 	
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFurnaceInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCFurnaceInventory.java
@@ -1,0 +1,54 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import org.bukkit.inventory.FurnaceInventory;
+import org.bukkit.inventory.ItemStack;
+
+import com.laytonsmith.abstraction.MCFurnaceInventory;
+import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.blocks.MCFurnace;
+import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCFurnace;
+
+public class BukkitMCFurnaceInventory extends BukkitMCInventory implements MCFurnaceInventory {
+	
+	private FurnaceInventory inv;
+	
+	public BukkitMCFurnaceInventory(FurnaceInventory inv) {
+		super(inv);
+		this.inv = inv;
+	}
+	
+	@Override
+	public MCItemStack getResult() {
+		return new BukkitMCItemStack(this.inv.getResult());
+	}
+	
+	@Override
+	public MCItemStack getFuel() {
+		return new BukkitMCItemStack(this.inv.getFuel());
+	}
+	
+	@Override
+	public MCItemStack getSmelting() {
+		return new BukkitMCItemStack(this.inv.getSmelting());
+	}
+	
+	@Override
+	public void setFuel(MCItemStack stack) {
+		this.inv.setFuel((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setResult(MCItemStack stack) {
+		this.inv.setResult((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public void setSmelting(MCItemStack stack) {
+		this.inv.setSmelting((ItemStack) stack.getHandle());
+	}
+	
+	@Override
+	public MCFurnace getHolder() {
+		return new BukkitMCFurnace(this.inv.getHolder());
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBeacon.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBeacon.java
@@ -1,0 +1,64 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCBeaconInventory;
+import com.laytonsmith.abstraction.MCLivingEntity;
+import com.laytonsmith.abstraction.blocks.MCBeacon;
+import com.laytonsmith.abstraction.bukkit.BukkitMCBeaconInventory;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCLivingEntity;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.bukkit.block.Beacon;
+import org.bukkit.entity.LivingEntity;
+
+public class BukkitMCBeacon extends BukkitMCBlockState implements MCBeacon {
+	
+	private Beacon beacon;
+	
+	public BukkitMCBeacon(Beacon block) {
+		super(block);
+		this.beacon = block;
+	}
+	
+	@Override
+	public MCBeaconInventory getInventory() {
+		return new BukkitMCBeaconInventory(this.beacon.getInventory());
+	}
+	
+	@Override
+	public Collection<MCLivingEntity> getEntitiesInRange() {
+		HashSet<MCLivingEntity> ret = new HashSet<>();
+		for(LivingEntity entity : this.beacon.getEntitiesInRange()) {
+			ret.add(new BukkitMCLivingEntity(entity));
+		}
+		return ret;
+	}
+	
+//	@Override
+//	public MCPotionEffect getPrimaryEffect() {
+//		// TODO Implement.
+//		return null;
+//	}
+//	
+//	@Override
+//	public MCPotionEffect getSecondaryEffect() {
+//		// TODO Implement.
+//		return null;
+//	}
+	
+	@Override
+	public int getTier() {
+		return this.beacon.getTier();
+	}
+	
+//	@Override
+//	public void setPrimaryEffect(MCPotionEffect effect) {
+//		this.beacon.setPrimaryEffect(effect.getHandle());
+//	}
+//	
+//	@Override
+//	public void setSecondaryEffect(MCPotionEffect effect) {
+//		this.beacon.setSecondaryEffect(effect.getHandle());
+//	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBrewingStand.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCBrewingStand.java
@@ -1,0 +1,42 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCBrewerInventory;
+import com.laytonsmith.abstraction.blocks.MCBrewingStand;
+import com.laytonsmith.abstraction.bukkit.BukkitMCBrewerInventory;
+
+import org.bukkit.block.BrewingStand;
+
+public class BukkitMCBrewingStand extends BukkitMCBlockState implements MCBrewingStand {
+	
+	private BrewingStand bs;
+	
+	public BukkitMCBrewingStand(BrewingStand block) {
+		super(block);
+		this.bs = block;
+	}
+	
+	@Override
+	public MCBrewerInventory getInventory() {
+		return new BukkitMCBrewerInventory(this.bs.getInventory());
+	}
+	
+	@Override
+	public int getBrewingTime() {
+		return this.bs.getBrewingTime();
+	}
+	
+	@Override
+	public int getFuelLevel() {
+		return this.bs.getFuelLevel();
+	}
+	
+	@Override
+	public void setBrewingTime(int brewTime) {
+		this.bs.setBrewingTime(brewTime);
+	}
+	
+	@Override
+	public void setFuelLevel(int level) {
+		this.bs.setFuelLevel(level);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCChest.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCChest.java
@@ -1,0 +1,22 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.blocks.MCChest;
+import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
+
+import org.bukkit.block.Chest;
+
+public class BukkitMCChest extends BukkitMCBlockState implements MCChest {
+	
+	private Chest chest;
+	
+	public BukkitMCChest(Chest block) {
+		super(block);
+		this.chest = block;
+	}
+	
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(this.chest.getInventory());
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCDispenser.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCDispenser.java
@@ -1,7 +1,10 @@
 package com.laytonsmith.abstraction.bukkit.blocks;
 
+import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.blocks.MCBlockProjectileSource;
 import com.laytonsmith.abstraction.blocks.MCDispenser;
+import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
+
 import org.bukkit.block.Dispenser;
 
 public class BukkitMCDispenser extends BukkitMCBlockState implements MCDispenser {
@@ -16,5 +19,15 @@ public class BukkitMCDispenser extends BukkitMCBlockState implements MCDispenser
 	@Override
 	public MCBlockProjectileSource getBlockProjectileSource() {
 		return new BukkitMCBlockProjectileSource(d.getBlockProjectileSource());
+	}
+
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(this.d.getInventory());
+	}
+
+	@Override
+	public boolean dispense() {
+		return this.d.dispense();
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCDropper.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCDropper.java
@@ -1,0 +1,27 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.blocks.MCDropper;
+import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
+
+import org.bukkit.block.Dropper;
+
+public class BukkitMCDropper extends BukkitMCBlockState implements MCDropper {
+	
+	private Dropper dropper;
+	
+	public BukkitMCDropper(Dropper block) {
+		super(block);
+		this.dropper = block;
+	}
+	
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(this.dropper.getInventory());
+	}
+	
+	@Override
+	public void drop() {
+		this.dropper.drop();
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCFurnace.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCFurnace.java
@@ -1,0 +1,42 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCFurnaceInventory;
+import com.laytonsmith.abstraction.blocks.MCFurnace;
+import com.laytonsmith.abstraction.bukkit.BukkitMCFurnaceInventory;
+
+import org.bukkit.block.Furnace;
+
+public class BukkitMCFurnace extends BukkitMCBlockState implements MCFurnace {
+	
+	private Furnace furnace;
+	
+	public BukkitMCFurnace(Furnace block) {
+		super(block);
+		this.furnace = block;
+	}
+	
+	@Override
+	public MCFurnaceInventory getInventory() {
+		return new BukkitMCFurnaceInventory(this.furnace.getInventory());
+	}
+	
+	@Override
+	public short getBurnTime() {
+		return this.furnace.getBurnTime();
+	}
+	
+	@Override
+	public void setBurnTime(short burnTime) {
+		this.furnace.setBurnTime(burnTime);
+	}
+	
+	@Override
+	public short getCookTime() {
+		return this.furnace.getCookTime();
+	}
+	
+	@Override
+	public void setCookTime(short cookTime) {
+		this.furnace.setCookTime(cookTime);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCHopper.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCHopper.java
@@ -1,0 +1,22 @@
+package com.laytonsmith.abstraction.bukkit.blocks;
+
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.blocks.MCHopper;
+import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
+
+import org.bukkit.block.Hopper;
+
+public class BukkitMCHopper extends BukkitMCBlockState implements MCHopper {
+	
+	private Hopper hopper;
+	
+	public BukkitMCHopper(Hopper block) {
+		super(block);
+		this.hopper = block;
+	}
+	
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(this.hopper.getInventory());
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCShulkerBox.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/blocks/BukkitMCShulkerBox.java
@@ -11,16 +11,11 @@ public class BukkitMCShulkerBox extends BukkitMCBlockState implements MCShulkerB
 
 	public BukkitMCShulkerBox(ShulkerBox block) {
 		super(block);
-		sb = block;
-	}
-
-	@Override
-	public ShulkerBox getHandle() {
-		return sb;
+		this.sb = block;
 	}
 
 	@Override
 	public MCInventory getInventory() {
-		return new BukkitMCInventory(sb.getInventory());
+		return new BukkitMCInventory(this.sb.getInventory());
 	}
 }

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -406,19 +406,19 @@ public class ObjectGenerator {
 					ma.set("fuel", new CInt(brewStand.getFuelLevel(), t), t);
 					MCBrewerInventory inv = brewStand.getInventory();
 					CArray invData = CArray.GetAssociativeArray(t);
-					if(inv.getFuel() != null) {
+					if(inv.getFuel().getAmount() != 0) {
 						invData.set("fuel", ObjectGenerator.GetGenerator().item(inv.getFuel(), t), t);
 					}
-					if(inv.getIngredient() != null) {
+					if(inv.getIngredient().getAmount() != 0) {
 						invData.set("ingredient", ObjectGenerator.GetGenerator().item(inv.getIngredient(), t), t);
 					}
-					if(inv.getLeftBottle() != null) {
+					if(inv.getLeftBottle().getAmount() != 0) {
 						invData.set("leftbottle", ObjectGenerator.GetGenerator().item(inv.getLeftBottle(), t), t);
 					}
-					if(inv.getMiddleBottle() != null) {
+					if(inv.getMiddleBottle().getAmount() != 0) {
 						invData.set("middlebottle", ObjectGenerator.GetGenerator().item(inv.getMiddleBottle(), t), t);
 					}
-					if(inv.getRightBottle() != null) {
+					if(inv.getRightBottle().getAmount() != 0) {
 						invData.set("rightbottle", ObjectGenerator.GetGenerator().item(inv.getRightBottle(), t), t);
 					}
 					ma.set("inventory", invData, t);
@@ -428,13 +428,13 @@ public class ObjectGenerator {
 					ma.set("cooktime", new CInt(furnace.getCookTime(), t), t);
 					MCFurnaceInventory inv = furnace.getInventory();
 					CArray invData = CArray.GetAssociativeArray(t);
-					if(inv.getResult() != null) {
+					if(inv.getResult().getAmount() != 0) {
 						invData.set("result", ObjectGenerator.GetGenerator().item(inv.getResult(), t), t);
 					}
-					if(inv.getFuel() != null) {
+					if(inv.getFuel().getAmount() != 0) {
 						invData.set("fuel", ObjectGenerator.GetGenerator().item(inv.getFuel(), t), t);
 					}
-					if(inv.getSmelting() != null) {
+					if(inv.getSmelting().getAmount() != 0) {
 						invData.set("smelting", ObjectGenerator.GetGenerator().item(inv.getSmelting(), t), t);
 					}
 					ma.set("inventory", invData, t);

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -412,6 +412,15 @@ public class ObjectGenerator {
 					if(inv.getIngredient() != null) {
 						invData.set("ingredient", ObjectGenerator.GetGenerator().item(inv.getIngredient(), t), t);
 					}
+					if(inv.getLeftBottle() != null) {
+						invData.set("leftbottle", ObjectGenerator.GetGenerator().item(inv.getLeftBottle(), t), t);
+					}
+					if(inv.getMiddleBottle() != null) {
+						invData.set("middlebottle", ObjectGenerator.GetGenerator().item(inv.getMiddleBottle(), t), t);
+					}
+					if(inv.getRightBottle() != null) {
+						invData.set("rightbottle", ObjectGenerator.GetGenerator().item(inv.getRightBottle(), t), t);
+					}
 					ma.set("inventory", invData, t);
 				} else if(bs instanceof MCFurnace) {
 					MCFurnace furnace = (MCFurnace) bs;
@@ -692,6 +701,15 @@ public class ObjectGenerator {
 							}
 							if(invData.containsKey("ingredient")) {
 								inv.setIngredient(ObjectGenerator.GetGenerator().item(invData.get("ingredient", t), t));
+							}
+							if(invData.containsKey("leftbottle")) {
+								inv.setLeftBottle(ObjectGenerator.GetGenerator().item(invData.get("leftbottle", t), t));
+							}
+							if(invData.containsKey("middlebottle")) {
+								inv.setMiddleBottle(ObjectGenerator.GetGenerator().item(invData.get("middlebottle", t), t));
+							}
+							if(invData.containsKey("rightbottle")) {
+								inv.setRightBottle(ObjectGenerator.GetGenerator().item(invData.get("rightbottle", t), t));
 							}
 						}
 						bsm.setBlockState(bs);

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -4,6 +4,7 @@ import com.laytonsmith.PureUtilities.Vector3D;
 import com.laytonsmith.abstraction.MCBannerMeta;
 import com.laytonsmith.abstraction.MCBlockStateMeta;
 import com.laytonsmith.abstraction.MCBookMeta;
+import com.laytonsmith.abstraction.MCBrewerInventory;
 import com.laytonsmith.abstraction.MCColor;
 import com.laytonsmith.abstraction.MCCreatureSpawner;
 import com.laytonsmith.abstraction.MCEnchantment;
@@ -15,6 +16,7 @@ import com.laytonsmith.abstraction.MCFireworkMeta;
 import com.laytonsmith.abstraction.MCFurnaceInventory;
 import com.laytonsmith.abstraction.MCFurnaceRecipe;
 import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.MCItemFactory;
 import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
@@ -37,7 +39,12 @@ import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBanner;
 import com.laytonsmith.abstraction.blocks.MCBlockState;
+import com.laytonsmith.abstraction.blocks.MCBrewingStand;
+import com.laytonsmith.abstraction.blocks.MCChest;
+import com.laytonsmith.abstraction.blocks.MCDispenser;
+import com.laytonsmith.abstraction.blocks.MCDropper;
 import com.laytonsmith.abstraction.blocks.MCFurnace;
+import com.laytonsmith.abstraction.blocks.MCHopper;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.blocks.MCShulkerBox;
 import com.laytonsmith.abstraction.enums.MCDyeColor;
@@ -364,9 +371,10 @@ public class ObjectGenerator {
 			// Specific ItemMeta
 			if(meta instanceof MCBlockStateMeta) {
 				MCBlockState bs = ((MCBlockStateMeta) meta).getBlockState();
-				if(bs instanceof MCShulkerBox) {
-					MCShulkerBox mcsb = (MCShulkerBox) bs;
-					MCInventory inv = mcsb.getInventory();
+				if(bs instanceof MCShulkerBox || bs instanceof MCChest
+						|| bs instanceof MCDispenser || bs instanceof MCDropper || bs instanceof MCHopper) {
+					// Handle InventoryHolders with inventory slots that do not have a special meaning.
+					MCInventory inv = ((MCInventoryHolder) bs).getInventory();
 					CArray box = CArray.GetAssociativeArray(t);
 					for(int i = 0; i < inv.getSize(); i++) {
 						Construct item = ObjectGenerator.GetGenerator().item(inv.getItem(i), t);
@@ -392,6 +400,19 @@ public class ObjectGenerator {
 				} else if(bs instanceof MCCreatureSpawner) {
 					MCCreatureSpawner mccs = (MCCreatureSpawner) bs;
 					ma.set("spawntype", mccs.getSpawnedType().name());
+				} else if(bs instanceof MCBrewingStand) {
+					MCBrewingStand brewStand = (MCBrewingStand) bs;
+					ma.set("brewtime", new CString(Integer.toString(brewStand.getBrewingTime()), t), t);
+					ma.set("fuel", new CString(Integer.toString(brewStand.getFuelLevel()), t), t);
+					MCBrewerInventory inv = brewStand.getInventory();
+					CArray invData = CArray.GetAssociativeArray(t);
+					if(inv.getFuel() != null) {
+						invData.set("fuel", ObjectGenerator.GetGenerator().item(inv.getFuel(), t), t);
+					}
+					if(inv.getIngredient() != null) {
+						invData.set("ingredient", ObjectGenerator.GetGenerator().item(inv.getIngredient(), t), t);
+					}
+					ma.set("inventory", invData, t);
 				} else if(bs instanceof MCFurnace) {
 					MCFurnace furnace = (MCFurnace) bs;
 					ma.set("burntime", new CString(Short.toString(furnace.getBurnTime()), t), t);
@@ -603,30 +624,33 @@ public class ObjectGenerator {
 				if(meta instanceof MCBlockStateMeta) {
 					MCBlockStateMeta bsm = (MCBlockStateMeta) meta;
 					MCBlockState bs = bsm.getBlockState();
-					if(bs instanceof MCShulkerBox) {
+					if(bs instanceof MCShulkerBox || bs instanceof MCChest
+							|| bs instanceof MCDispenser || bs instanceof MCDropper || bs instanceof MCHopper) {
 						if(ma.containsKey("inventory")) {
-							MCShulkerBox box = (MCShulkerBox) bs;
-							MCInventory inv = box.getInventory();
-							Construct csbm = ma.get("inventory", t);
-							if(csbm instanceof CArray) {
-								CArray cinv = (CArray) csbm;
+							MCInventory inv = ((MCInventoryHolder) bs).getInventory();
+							Construct cInvRaw = ma.get("inventory", t);
+							if(cInvRaw instanceof CArray) {
+								CArray cinv = (CArray) cInvRaw;
 								for(String key : cinv.stringKeySet()) {
 									try {
 										int index = Integer.parseInt(key);
 										if(index < 0 || index >= inv.getSize()) {
 											ConfigRuntimeException.DoWarning("Out of range value (" + index + ") found"
-													+ " in ShulkerBox inventory array, so ignoring.");
+													+ " in " + bs.getClass().getSimpleName().replaceFirst("MC", "")
+													+ " inventory array, so ignoring.");
 										}
 										MCItemStack is = ObjectGenerator.GetGenerator().item(cinv.get(key, t), t);
 										inv.setItem(index, is);
 									} catch(NumberFormatException ex) {
-										ConfigRuntimeException.DoWarning("Expecting integer value for key in ShulkerBox"
+										ConfigRuntimeException.DoWarning("Expecting integer value for key in "
+												+ bs.getClass().getSimpleName().replaceFirst("MC", "")
 												+ " inventory array, but \"" + key + "\" was found. Ignoring.");
 									}
 								}
 								bsm.setBlockState(bs);
-							} else if(!(csbm instanceof CNull)) {
-								throw new CREFormatException("ShulkerBox inventory expected to be an array or null.", t);
+							} else if(!(cInvRaw instanceof CNull)) {
+								throw new CREFormatException(bs.getClass().getSimpleName().replaceFirst("MC", "")
+										+ " inventory expected to be an array or null.", t);
 							}
 						}
 					} else if(bs instanceof MCBanner) {
@@ -652,6 +676,25 @@ public class ObjectGenerator {
 							mccs.setSpawnedType(type);
 							bsm.setBlockState(bs);
 						}
+					} else if(bs instanceof MCBrewingStand) {
+						MCBrewingStand brewStand = (MCBrewingStand) bs;
+						if(ma.containsKey("brewtime")) {
+							brewStand.setBrewingTime(ArgumentValidation.getInt32(ma.get("brewtime", t), t));
+						}
+						if(ma.containsKey("fuel")) {
+							brewStand.setFuelLevel(ArgumentValidation.getInt32(ma.get("fuel", t), t));
+						}
+						if(ma.containsKey("inventory")) {
+							CArray invData = ArgumentValidation.getArray(ma.get("inventory", t), t);
+							MCBrewerInventory inv = brewStand.getInventory();
+							if(invData.containsKey("fuel")) {
+								inv.setFuel(ObjectGenerator.GetGenerator().item(invData.get("fuel", t), t));
+							}
+							if(invData.containsKey("ingredient")) {
+								inv.setIngredient(ObjectGenerator.GetGenerator().item(invData.get("ingredient", t), t));
+							}
+						}
+						bsm.setBlockState(bs);
 					} else if(bs instanceof MCFurnace) {
 						MCFurnace furnace = (MCFurnace) bs;
 						if(ma.containsKey("burntime")) {

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -12,6 +12,7 @@ import com.laytonsmith.abstraction.MCFireworkBuilder;
 import com.laytonsmith.abstraction.MCFireworkEffect;
 import com.laytonsmith.abstraction.MCFireworkEffectMeta;
 import com.laytonsmith.abstraction.MCFireworkMeta;
+import com.laytonsmith.abstraction.MCFurnaceInventory;
 import com.laytonsmith.abstraction.MCFurnaceRecipe;
 import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCItemFactory;
@@ -36,6 +37,7 @@ import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBanner;
 import com.laytonsmith.abstraction.blocks.MCBlockState;
+import com.laytonsmith.abstraction.blocks.MCFurnace;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.blocks.MCShulkerBox;
 import com.laytonsmith.abstraction.enums.MCDyeColor;
@@ -390,6 +392,22 @@ public class ObjectGenerator {
 				} else if(bs instanceof MCCreatureSpawner) {
 					MCCreatureSpawner mccs = (MCCreatureSpawner) bs;
 					ma.set("spawntype", mccs.getSpawnedType().name());
+				} else if(bs instanceof MCFurnace) {
+					MCFurnace furnace = (MCFurnace) bs;
+					ma.set("burntime", new CString(Short.toString(furnace.getBurnTime()), t), t);
+					ma.set("cooktime", new CString(Short.toString(furnace.getCookTime()), t), t);
+					MCFurnaceInventory inv = furnace.getInventory();
+					CArray invData = CArray.GetAssociativeArray(t);
+					if(inv.getResult() != null) {
+						invData.set("result", ObjectGenerator.GetGenerator().item(inv.getResult(), t), t);
+					}
+					if(inv.getFuel() != null) {
+						invData.set("fuel", ObjectGenerator.GetGenerator().item(inv.getFuel(), t), t);
+					}
+					if(inv.getSmelting() != null) {
+						invData.set("smelting", ObjectGenerator.GetGenerator().item(inv.getSmelting(), t), t);
+					}
+					ma.set("inventory", invData, t);
 				}
 			} else if(meta instanceof MCFireworkEffectMeta) {
 				MCFireworkEffectMeta mcfem = (MCFireworkEffectMeta) meta;
@@ -634,6 +652,28 @@ public class ObjectGenerator {
 							mccs.setSpawnedType(type);
 							bsm.setBlockState(bs);
 						}
+					} else if(bs instanceof MCFurnace) {
+						MCFurnace furnace = (MCFurnace) bs;
+						if(ma.containsKey("burntime")) {
+							furnace.setBurnTime(ArgumentValidation.getInt16(ma.get("burntime", t), t));
+						}
+						if(ma.containsKey("cooktime")) {
+							furnace.setCookTime(ArgumentValidation.getInt16(ma.get("cooktime", t), t));
+						}
+						if(ma.containsKey("inventory")) {
+							CArray invData = ArgumentValidation.getArray(ma.get("inventory", t), t);
+							MCFurnaceInventory inv = furnace.getInventory();
+							if(invData.containsKey("result")) {
+								inv.setResult(ObjectGenerator.GetGenerator().item(invData.get("result", t), t));
+							}
+							if(invData.containsKey("fuel")) {
+								inv.setFuel(ObjectGenerator.GetGenerator().item(invData.get("fuel", t), t));
+							}
+							if(invData.containsKey("smelting")) {
+								inv.setSmelting(ObjectGenerator.GetGenerator().item(invData.get("smelting", t), t));
+							}
+						}
+						bsm.setBlockState(bs);
 					}
 				} else if(meta instanceof MCFireworkEffectMeta) {
 					MCFireworkEffectMeta femeta = (MCFireworkEffectMeta) meta;

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -402,8 +402,8 @@ public class ObjectGenerator {
 					ma.set("spawntype", mccs.getSpawnedType().name());
 				} else if(bs instanceof MCBrewingStand) {
 					MCBrewingStand brewStand = (MCBrewingStand) bs;
-					ma.set("brewtime", new CString(Integer.toString(brewStand.getBrewingTime()), t), t);
-					ma.set("fuel", new CString(Integer.toString(brewStand.getFuelLevel()), t), t);
+					ma.set("brewtime", new CInt(brewStand.getBrewingTime(), t), t);
+					ma.set("fuel", new CInt(brewStand.getFuelLevel(), t), t);
 					MCBrewerInventory inv = brewStand.getInventory();
 					CArray invData = CArray.GetAssociativeArray(t);
 					if(inv.getFuel() != null) {
@@ -415,8 +415,8 @@ public class ObjectGenerator {
 					ma.set("inventory", invData, t);
 				} else if(bs instanceof MCFurnace) {
 					MCFurnace furnace = (MCFurnace) bs;
-					ma.set("burntime", new CString(Short.toString(furnace.getBurnTime()), t), t);
-					ma.set("cooktime", new CString(Short.toString(furnace.getCookTime()), t), t);
+					ma.set("burntime", new CInt(furnace.getBurnTime(), t), t);
+					ma.set("cooktime", new CInt(furnace.getCookTime(), t), t);
 					MCFurnaceInventory inv = furnace.getInventory();
 					CArray invData = CArray.GetAssociativeArray(t);
 					if(inv.getResult() != null) {


### PR DESCRIPTION
Furnaces will now have a "burntime", "cooktime" and "inventory" metadata tag. "inventory" is an array with 3 possible keys: "result", "fuel" and "smelting".
This PR prevents set_pinv(pinv()) to erase furnace metadata and adds the ability to get/modify it.