### PR TITLE
Added broadcast_message event.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitMiscEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitMiscEvents.java
@@ -6,53 +6,12 @@ import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.bukkit.BukkitMCCommand;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import com.laytonsmith.abstraction.events.MCCommandTabCompleteEvent;
-import com.laytonsmith.abstraction.events.MCServerCommandEvent;
 import com.laytonsmith.abstraction.events.MCPluginIncomingMessageEvent;
-import com.laytonsmith.abstraction.events.MCServerPingEvent;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
-import org.bukkit.event.server.ServerCommandEvent;
-import org.bukkit.event.server.ServerListPingEvent;
-
-import java.net.InetAddress;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 public class BukkitMiscEvents {
-
-	public static class BukkitMCServerCommandEvent implements MCServerCommandEvent {
-
-		ServerCommandEvent sce;
-		MCCommandSender sender;
-
-		public BukkitMCServerCommandEvent(ServerCommandEvent sce, MCCommandSender sender) {
-			this.sce = sce;
-			this.sender = sender;
-		}
-
-		@Override
-		public Object _GetObject() {
-			return sce;
-		}
-
-		@Override
-		public String getCommand() {
-			return sce.getCommand();
-		}
-
-		@Override
-		public void setCommand(String command) {
-			sce.setCommand(command);
-		}
-
-		@Override
-		public MCCommandSender getCommandSender() {
-			return sender;
-		}
-	}
 
 	/*
 	 * Not an actual event, but making it one.
@@ -87,82 +46,6 @@ public class BukkitMiscEvents {
 		@Override
 		public Object _GetObject() {
 			return null;
-		}
-	}
-
-	public static class BukkitMCServerPingEvent implements MCServerPingEvent {
-
-		private final ServerListPingEvent slp;
-
-		public BukkitMCServerPingEvent(ServerListPingEvent event) {
-			slp = event;
-		}
-
-		@Override
-		public Object _GetObject() {
-			return slp;
-		}
-
-		@Override
-		public InetAddress getAddress() {
-			return slp.getAddress();
-		}
-
-		@Override
-		public int getMaxPlayers() {
-			return slp.getMaxPlayers();
-		}
-
-		@Override
-		public String getMOTD() {
-			return slp.getMotd();
-		}
-
-		@Override
-		public int getNumPlayers() {
-			return slp.getNumPlayers();
-		}
-
-		@Override
-		public void setMaxPlayers(int max) {
-			slp.setMaxPlayers(max);
-		}
-
-		@Override
-		public void setMOTD(String motd) {
-			slp.setMotd(motd);
-		}
-
-		@Override
-		public Set<MCPlayer> getPlayers() {
-			Set<MCPlayer> players = new HashSet<>();
-			try {
-				Iterator<Player> iterator = slp.iterator();
-				while(iterator.hasNext()) {
-					players.add(new BukkitMCPlayer(iterator.next()));
-				}
-			} catch(UnsupportedOperationException ex) {
-				// not implemented, ignore
-			}
-			return players;
-		}
-
-		@Override
-		public void setPlayers(Collection<MCPlayer> players) {
-			Set<Player> ps = new HashSet<>();
-			for(MCPlayer player : players) {
-				ps.add((Player) player.getHandle());
-			}
-			try {
-				Iterator<Player> iterator = slp.iterator();
-				while(iterator.hasNext()) {
-					if(!ps.contains(iterator.next())) {
-						iterator.remove();
-					}
-				}
-			} catch(UnsupportedOperationException ex) {
-				// not implemented, ignore
-			}
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitServerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitServerEvents.java
@@ -2,10 +2,15 @@ package com.laytonsmith.abstraction.bukkit.events;
 
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.bukkit.BukkitMCCommandSender;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
+import com.laytonsmith.abstraction.events.MCBroadcastMessageEvent;
 import com.laytonsmith.abstraction.events.MCServerCommandEvent;
 import com.laytonsmith.abstraction.events.MCServerPingEvent;
+
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.event.server.BroadcastMessageEvent;
 import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 
@@ -124,5 +129,72 @@ public class BukkitServerEvents {
 		}
 	}
 
-	
+	public static class BukkitMCBroadcastMessageEvent implements MCBroadcastMessageEvent {
+
+		private final BroadcastMessageEvent bme;
+
+		public BukkitMCBroadcastMessageEvent(BroadcastMessageEvent event) {
+			this.bme = event;
+		}
+		
+		@Override
+		public Object _GetObject() {
+			return this.bme;
+		}
+
+		@Override
+		public void cancel(boolean state) {
+			this.bme.setCancelled(state);
+		}
+
+		@Override
+		public String getMessage() {
+			return this.bme.getMessage();
+		}
+
+		@Override
+		public void setMessage(String message) {
+			this.bme.setMessage(message);
+		}
+
+		/**
+		 * Gets the recipients of this message.
+		 * Modifications made to the returned set do not have influence on the event itself.
+		 * This set can contain command senders like players, command blocks, command block functions and console.
+		 * To only receive the player recipients, use the {@link #getPlayerRecipients()} method.
+		 * @return The recipients of this message.
+		 */
+		@Override
+		public Set<MCCommandSender> getRecipients() {
+			Set<MCCommandSender> ret = new HashSet<MCCommandSender>();
+			for(CommandSender sender : this.bme.getRecipients()) {
+				ret.add(new BukkitMCCommandSender(sender));
+			}
+			return ret;
+		}
+
+		/**
+		 * Gets the player recipients of this message.
+		 * Modifications made to the returned set do not have influence on the event itself.
+		 * This set can contain command senders like players, command blocks, command block functions and console.
+		 * To receive player and non-player recipients, use the {@link #getRecipients()} method.
+		 * @return The player recipients of this message.
+		 */
+		@Override
+		public Set<MCPlayer> getPlayerRecipients() {
+			Set<MCPlayer> ret = new HashSet<MCPlayer>();
+			for(CommandSender sender : this.bme.getRecipients()) {
+				if(sender instanceof Player) {
+					ret.add(new BukkitMCPlayer((Player) sender));
+				}
+			}
+			return ret;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return this.bme.isCancelled();
+		}
+		
+	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitServerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitServerEvents.java
@@ -1,0 +1,128 @@
+package com.laytonsmith.abstraction.bukkit.events;
+
+import com.laytonsmith.abstraction.MCCommandSender;
+import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
+import com.laytonsmith.abstraction.events.MCServerCommandEvent;
+import com.laytonsmith.abstraction.events.MCServerPingEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.event.server.ServerListPingEvent;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public class BukkitServerEvents {
+
+	public static class BukkitMCServerCommandEvent implements MCServerCommandEvent {
+
+		ServerCommandEvent sce;
+		MCCommandSender sender;
+
+		public BukkitMCServerCommandEvent(ServerCommandEvent sce, MCCommandSender sender) {
+			this.sce = sce;
+			this.sender = sender;
+		}
+
+		@Override
+		public Object _GetObject() {
+			return sce;
+		}
+
+		@Override
+		public String getCommand() {
+			return sce.getCommand();
+		}
+
+		@Override
+		public void setCommand(String command) {
+			sce.setCommand(command);
+		}
+
+		@Override
+		public MCCommandSender getCommandSender() {
+			return sender;
+		}
+	}
+
+	public static class BukkitMCServerPingEvent implements MCServerPingEvent {
+
+		private final ServerListPingEvent slp;
+
+		public BukkitMCServerPingEvent(ServerListPingEvent event) {
+			slp = event;
+		}
+
+		@Override
+		public Object _GetObject() {
+			return slp;
+		}
+
+		@Override
+		public InetAddress getAddress() {
+			return slp.getAddress();
+		}
+
+		@Override
+		public int getMaxPlayers() {
+			return slp.getMaxPlayers();
+		}
+
+		@Override
+		public String getMOTD() {
+			return slp.getMotd();
+		}
+
+		@Override
+		public int getNumPlayers() {
+			return slp.getNumPlayers();
+		}
+
+		@Override
+		public void setMaxPlayers(int max) {
+			slp.setMaxPlayers(max);
+		}
+
+		@Override
+		public void setMOTD(String motd) {
+			slp.setMotd(motd);
+		}
+
+		@Override
+		public Set<MCPlayer> getPlayers() {
+			Set<MCPlayer> players = new HashSet<>();
+			try {
+				Iterator<Player> iterator = slp.iterator();
+				while(iterator.hasNext()) {
+					players.add(new BukkitMCPlayer(iterator.next()));
+				}
+			} catch(UnsupportedOperationException ex) {
+				// not implemented, ignore
+			}
+			return players;
+		}
+
+		@Override
+		public void setPlayers(Collection<MCPlayer> players) {
+			Set<Player> ps = new HashSet<>();
+			for(MCPlayer player : players) {
+				ps.add((Player) player.getHandle());
+			}
+			try {
+				Iterator<Player> iterator = slp.iterator();
+				while(iterator.hasNext()) {
+					if(!ps.contains(iterator.next())) {
+						iterator.remove();
+					}
+				}
+			} catch(UnsupportedOperationException ex) {
+				// not implemented, ignore
+			}
+		}
+	}
+
+	
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitWorldEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitWorldEvents.java
@@ -93,31 +93,22 @@ public final class BukkitWorldEvents {
 
 	public static class BukkitMCWorldSaveEvent extends BukkitMCWorldEvent implements MCWorldSaveEvent {
 
-		private final WorldSaveEvent _event;
-
 		public BukkitMCWorldSaveEvent(WorldSaveEvent event) {
 			super(event);
-			_event = event;
 		}
 	}
 
 	public static class BukkitMCWorldUnloadEvent extends BukkitMCWorldEvent implements MCWorldUnloadEvent {
 
-		private final WorldUnloadEvent _event;
-
 		public BukkitMCWorldUnloadEvent(WorldUnloadEvent event) {
 			super(event);
-			_event = event;
 		}
 	}
 
 	public static class BukkitMCWorldLoadEvent extends BukkitMCWorldEvent implements MCWorldLoadEvent {
 
-		private final WorldLoadEvent _event;
-
 		public BukkitMCWorldLoadEvent(WorldLoadEvent event) {
 			super(event);
-			_event = event;
 		}
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPhysicsEvent;
+import org.bukkit.event.server.BroadcastMessageEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 
 public class BukkitServerListener implements Listener {
@@ -56,5 +57,11 @@ public class BukkitServerListener implements Listener {
 				});
 			}
 		}
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onBroadcast(BroadcastMessageEvent event) {
+		EventUtils.TriggerListener(Driver.BROADCAST_MESSAGE, "broadcast_message",
+				new BukkitServerEvents.BukkitMCBroadcastMessageEvent(event));
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
@@ -2,7 +2,7 @@ package com.laytonsmith.abstraction.bukkit.events.drivers;
 
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.bukkit.BukkitMCLocation;
-import com.laytonsmith.abstraction.bukkit.events.BukkitMiscEvents;
+import com.laytonsmith.abstraction.bukkit.events.BukkitServerEvents;
 import com.laytonsmith.abstraction.events.MCRedstoneChangedEvent;
 import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
@@ -18,7 +18,7 @@ public class BukkitServerListener implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPing(ServerListPingEvent event) {
-		BukkitMiscEvents.BukkitMCServerPingEvent pe = new BukkitMiscEvents.BukkitMCServerPingEvent(event);
+		BukkitServerEvents.BukkitMCServerPingEvent pe = new BukkitServerEvents.BukkitMCServerPingEvent(event);
 		EventUtils.TriggerListener(Driver.SERVER_PING, "server_ping", pe);
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBroadcastMessageEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBroadcastMessageEvent.java
@@ -1,0 +1,16 @@
+package com.laytonsmith.abstraction.events;
+
+import java.util.Set;
+
+import com.laytonsmith.abstraction.MCCommandSender;
+import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.core.events.BindableEvent;
+import com.laytonsmith.core.events.CancellableEvent;
+
+public interface MCBroadcastMessageEvent extends BindableEvent, CancellableEvent {
+	String getMessage();
+	void setMessage(String message);
+	Set<MCCommandSender> getRecipients();
+	Set<MCPlayer> getPlayerRecipients();
+	boolean isCancelled();
+}

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperServerListener.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperServerListener.java
@@ -5,7 +5,7 @@ import com.laytonsmith.abstraction.bukkit.BukkitMCBlockCommandSender;
 import com.laytonsmith.abstraction.bukkit.BukkitMCCommandSender;
 import com.laytonsmith.abstraction.bukkit.BukkitMCConsoleCommandSender;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCCommandMinecart;
-import com.laytonsmith.abstraction.bukkit.events.BukkitMiscEvents;
+import com.laytonsmith.abstraction.bukkit.events.BukkitServerEvents;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.core.InternalException;
 import com.laytonsmith.core.Static;
@@ -37,7 +37,7 @@ public class CommandHelperServerListener implements Listener {
 			sender = new BukkitMCCommandSender(event.getSender());
 		}
 
-		BukkitMiscEvents.BukkitMCServerCommandEvent cce = new BukkitMiscEvents.BukkitMCServerCommandEvent(event, sender);
+		BukkitServerEvents.BukkitMCServerCommandEvent cce = new BukkitServerEvents.BukkitMCServerCommandEvent(event, sender);
 		EventUtils.TriggerListener(Driver.SERVER_COMMAND, "server_command", cce);
 		try {
 			if(event.isCancelled()) {

--- a/src/main/java/com/laytonsmith/core/events/Driver.java
+++ b/src/main/java/com/laytonsmith/core/events/Driver.java
@@ -101,6 +101,7 @@ public enum Driver {
 	 */
 	SERVER_COMMAND,
 	SERVER_PING,
+	BROADCAST_MESSAGE,
 	/**
 	 * Vehicle events
 	 */

--- a/src/main/java/com/laytonsmith/core/events/drivers/ServerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/ServerEvents.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core.events.drivers;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.events.MCBroadcastMessageEvent;
 import com.laytonsmith.abstraction.events.MCCommandTabCompleteEvent;
 import com.laytonsmith.abstraction.events.MCServerCommandEvent;
 import com.laytonsmith.abstraction.events.MCRedstoneChangedEvent;
@@ -408,4 +409,70 @@ public class ServerEvents {
 
 	}
 
+	@api
+	public static class broadcast_message extends AbstractEvent {
+
+		@Override
+		public String getName() {
+			return "broadcast_message";
+		}
+
+		@Override
+		public String docs() {
+			return "{message: <string match>}"
+					+ " Fired when a message is broadcasted on the server."
+					+ " {message: The message that will be broadcasted"
+					+ " | player_recipients: An array of players who will receive the message.}"
+					+ " {message}"
+					+ " {}";
+		}
+
+		@Override
+		public boolean matches(Map<String, Construct> prefilter, BindableEvent e) throws PrefilterNonMatchException {
+			if(e instanceof MCBroadcastMessageEvent) {
+				MCBroadcastMessageEvent event = (MCBroadcastMessageEvent) e;
+				Prefilters.match(prefilter, "message", event.getMessage(), PrefilterType.STRING_MATCH);
+				return true;
+			}
+			return false;
+		}
+
+		@Override
+		public BindableEvent convert(CArray manualObject, Target t) {
+			throw new UnsupportedOperationException("Not supported yet.");
+		}
+
+		@Override
+		public Map<String, Construct> evaluate(BindableEvent e) throws EventException {
+			MCBroadcastMessageEvent event = (MCBroadcastMessageEvent) e;
+			Map<String, Construct> map = evaluate_helper(e);
+			map.put("message", new CString(event.getMessage(), Target.UNKNOWN));
+			CArray cRecipients = new CArray(Target.UNKNOWN);
+			for(MCPlayer player : event.getPlayerRecipients()) {
+				cRecipients.push(new CString(player.getName(), Target.UNKNOWN), Target.UNKNOWN);
+			}
+			map.put("player_recipients", cRecipients);
+			return map;
+		}
+
+		@Override
+		public Driver driver() {
+			return Driver.BROADCAST_MESSAGE;
+		}
+
+		@Override
+		public boolean modifyEvent(String key, Construct value, BindableEvent e) {
+			if(key.equals("message")) {
+				MCBroadcastMessageEvent event = (MCBroadcastMessageEvent) e;
+				event.setMessage(value.nval());
+				return true;
+			}
+			return false;
+		}
+
+		@Override
+		public Version since() {
+			return CHVersion.V3_3_2;
+		}
+	}
 }


### PR DESCRIPTION
Added support for Bukkit's BroadcastMessageEvent.
The recipients of the Bukkit event cannot be changed and only the player recipients are passed to CH. The other CommandSenders can be console, normal command blocks, command block functions and probably more depending on the server software used. Except for the console sender, these other non-player senders do not have a unique name and/or location and seem therefore useless to include.