### PR TITLE
fix pre browser inheritance behavior

### DIFF
--- a/src/main/resources/siteDeploy/resources/css/styles.css
+++ b/src/main/resources/siteDeploy/resources/css/styles.css
@@ -27,7 +27,8 @@ table td p {
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
     box-shadow: 0 .3em .3em rgba(0, 0, 0, 0.1);
-    color: #555
+    color: #555;
+    white-space: pre-line;
 }
 
 .hidden {


### PR DESCRIPTION
Per Pieter12345's suggestion, text will wrap when necessary and/or on line-breaks.