### PR TITLE
Checkstyle update

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -8,33 +8,40 @@
 -->
 <module name="Checker">
     <property name="severity" value="error"/>
+    
+    <!-- Supression filter to disable specified modules/checks for specified files -->
+    <module name="SuppressionFilter">
+        <property name="file" value="checkstyle_suppressions.xml"/>
+        <property name="optional" value="false"/>
+    </module>
+    
     <module name="TreeWalker">
         
-        <!-- Line length <= 120 characters. -->
+        <!-- Line length <= 120 characters -->
         <module name="LineLength">
-            <property name="severity" value="ignore"/> <!-- TODO: Change to "error" once the >7000 violations have been resolved. -->
+            <property name="severity" value="ignore"/> <!-- TODO: Change to "error" once the >7000 violations have been resolved -->
             <property name="max" value="120"/>
         </module>
         
-        <!-- Indent must use tab characters. -->
+        <!-- Indent must use tab characters -->
         <module name="RegexpSinglelineJava">
-            <property name="format" value="^\t* ([^\*]|$)"/> <!-- Javadoc and multiline comments have a single leading whitespace, so allow " *". -->
+            <property name="format" value="^\t* ([^\*]|$)"/> <!-- Javadoc and multiline comments have a single leading whitespace, so allow " *" -->
             <property name="message" value="Indent must use tab characters"/>
             <property name="ignoreComments" value="false"/>
         </module>
         
-        <!-- Disallow package.* imports. -->
+        <!-- Disallow package.* imports -->
         <module name="AvoidStarImport"/>
         
-        <!-- Disallow whitespaces after '(' and before ')'. -->
+        <!-- Disallow whitespaces after '(' and before ')' -->
         <module name="ParenPad"/>
         
     </module>
     
-    <!-- Disallow trailing whitespaces/tabs. -->
+    <!-- Disallow trailing whitespaces/tabs -->
     <module name="RegexpSingleline">
         <property name="severity" value="error"/>
-        <property name="format" value="(?&lt;! \*)\s+$"/> <!-- Empty javadoc and multiline comment lines have a single trailing whitespace, so allow " * ". -->
+        <property name="format" value="(?&lt;! \*)\s+$"/> <!-- Empty javadoc and multiline comment lines have a single trailing whitespace, so allow " * " -->
         <property name="message" value="Line has trailing whitespaces/tabs."/>
         <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>

--- a/checkstyle_suppressions.xml
+++ b/checkstyle_suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    
+    <!-- Allow star imports in "...Test.java" files -->
+    <suppress checks="AvoidStarImport" files=".*Test\.java$"/>
+    
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 
 		<repository>
 			<id>Plugin Metrics</id>
-			<url>http://repo.mcstats.org/content/repositories/public</url>
+			<url>http://repo.mcstats.org/content/repositories/public/</url>
 		</repository>
 
 		<!-- Java Mail -->
@@ -922,8 +922,8 @@
 				<version>3.0.0</version>
 				<executions>
 					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
+						<id>checkstyle</id>
+						<phase>test</phase>
 						<configuration>
 							<sourceDirectories>${project.compileSourceRoots}</sourceDirectories>
 							<testSourceDirectories>${project.testCompileSourceRoots}</testSourceDirectories>


### PR DESCRIPTION
- Allow star imports in "...Test.java" classes.
- Move checkstyle execution from "validate" to "test" phase (allow compile to happen before checking syntax and don't run checkstyle when not running tests).