### PR TITLE
RandomTest optimization

### DIFF
--- a/src/main/java/com/laytonsmith/annotations/api.java
+++ b/src/main/java/com/laytonsmith/annotations/api.java
@@ -47,9 +47,9 @@ public @interface api {
 	}
 
 	/**
-	 * Returns the platform this is implemented for. The default is {
+	 * Returns the platform this is implemented for. The default is {@link api.Platforms#INTERPRETER_JAVA}.
 	 *
-	 * @see api.Platforms#INTERPRETER_JAVA}.
+	 * @see {@link api.Platforms#INTERPRETER_JAVA}.
 	 * @return
 	 */
 	Platforms[] platform() default {api.Platforms.INTERPRETER_JAVA};

--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -16,6 +16,7 @@ import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.FunctionReturnException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,7 +55,12 @@ public abstract class CompositeFunction extends AbstractFunction {
 		env.SetVarList(newVariables);
 		Construct ret = CVoid.VOID;
 		try {
-			env.GetScript().eval(tree, environment);
+			if(env.GetScript() != null) {
+				env.GetScript().eval(tree, environment);
+			} else {
+				// This can happen when the environment is not fully setup during tests.
+				Script.GenerateScript(null, null).eval(tree, environment);
+			}
 		} catch (FunctionReturnException ex) {
 			ret = ex.getReturn();
 		}


### PR DESCRIPTION
- Optimize `testFunctionsAreOnlyDefinedOnce` test to run in O(n) instead of O(n^2) where n = 743 (and n^2 = 552049). Locally, this reduces the test time of te RandomTests class (being 12±2 seconds on my system) by roughly 3 or 4 seconds on my system.
- Fixed javadoc comment.
- Fixed case where not setting up the global environment makes the `testFunctionsAreOnlyDefinedOnce` test fail when executed on itself in an IDE.