### PR TITLE
Disable secure_string and get_locales boilerplate test

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -929,6 +929,7 @@ public class Meta {
 	}
 
 	@api
+	@noboilerplate // A boilerplate test on this function is relatively expensive and not necessary.
 	public static class get_locales extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/StringHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/StringHandling.java
@@ -6,6 +6,7 @@ import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
+import com.laytonsmith.annotations.noboilerplate;
 import com.laytonsmith.annotations.noprofile;
 import com.laytonsmith.annotations.seealso;
 import com.laytonsmith.core.ArgumentValidation;
@@ -2295,6 +2296,7 @@ public class StringHandling {
 
 	@api
 	@seealso(decrypt_secure_string.class)
+	@noboilerplate // A boilerplate test on this function is very hard on Travis CI, sometimes resulting in a timeout.
 	public static class secure_string extends AbstractFunction {
 
 		@Override


### PR DESCRIPTION
Disable secure_string and get_locales boilerplate test because these slow down the build time by Travis CI significantly. secure_string's boilerplate test can easily take 6 minutes and even cause Travis CI to time out (>10 minutes combined).