### PR TITLE
Fix broadcast() function event consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ true
 /test-backend/
 /nbproject/
 /dependency-reduced-pom.xml
+.checkstyle

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,7 +11,7 @@
 	
 	<!-- Supression filter to disable specified modules/checks for specified files -->
 	<module name="SuppressionFilter">
-		<property name="file" value="checkstyle_suppressions.xml"/>
+		<property name="file" value="${config_loc}/checkstyle_suppressions.xml"/>
 		<property name="optional" value="false"/>
 	</module>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -929,6 +929,7 @@
 							<testSourceDirectories>${project.testCompileSourceRoots}</testSourceDirectories>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
 							<configLocation>${basedir}/checkstyle.xml</configLocation>
+							<propertyExpansion>config_loc=${basedir}</propertyExpansion>
 							<encoding>UTF-8</encoding>
 							<consoleOutput>true</consoleOutput>
 							<failsOnError>true</failsOnError>

--- a/src/main/java/com/laytonsmith/abstraction/MCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCServer.java
@@ -33,6 +33,8 @@ public interface MCServer extends AbstractionObject {
 
 	void broadcastMessage(String message, String permission);
 
+	void broadcastMessage(String message, Set<MCCommandSender> recipients);
+
 	MCConsoleCommandSender getConsole();
 
 	MCItemFactory getItemFactory();

--- a/src/main/java/com/laytonsmith/abstraction/MCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCServer.java
@@ -29,10 +29,25 @@ public interface MCServer extends AbstractionObject {
 
 	List<MCWorld> getWorlds();
 
+	/**
+	 * Broadcasts a message to all online players and console.
+	 * @param message - The message to broadcast.
+	 */
 	void broadcastMessage(String message);
 
+	/**
+	 * Broadcasts a message to all online players with a given permission and console.
+	 * @param message - The message to broadcast.
+	 * @param permission - The required permission to receive the message.
+	 */
 	void broadcastMessage(String message, String permission);
 
+	/**
+	 * Broadcasts a message to a list of recipients.
+	 * {@link MCConsoleCommandSender Console} has to be included in this list to receive the broadcast.
+	 * @param message - The message to broadcast.
+	 * @param recipients - A list of {@link MCCommandSender command senders} to send the message to.
+	 */
 	void broadcastMessage(String message, Set<MCCommandSender> recipients);
 
 	MCConsoleCommandSender getConsole();

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -30,6 +30,7 @@ import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -625,7 +626,10 @@ public class Echoes {
 		public String docs() {
 			return "void {message, [permission] | message, [players]} Broadcasts a message to all or some players."
 					+ " If permission is given, only players with that permission will see the broadcast."
-					+ " If an array is given, only players in the list will see the broadcast.";
+					+ " If an array is given, only online players in the list will see the broadcast."
+					+ " Offline players in the list will be ignored."
+					+ " If permission/players is null, all players will see the broadcast."
+					+ " Throws a CREFormatException when the given players array is associative.";
 		}
 
 		@Override
@@ -646,29 +650,41 @@ public class Echoes {
 		@Override
 		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
 			final MCServer server = Static.getServer();
-			String permission = null;
-			if(args.length == 2) {
-				if(args[1] instanceof CArray) {
-					CArray array = (CArray) args[1];
-					if(!array.isAssociative()) {
-						for(Construct p : array.asList()) {
-							try {
-								Static.GetPlayer(p, t).sendMessage(args[0].val());
-							} catch (CREPlayerOfflineException cre) {
-								// ignore offline players
-							}
-						}
-						return CVoid.VOID;
-					}
-					throw new CREFormatException("Expected a normal array or permission as the second parameter.", t);
-				}
-				permission = args[1].nval();
-			}
-			if(permission == null) {
+
+			// Handle "broadcast(message, [null])".
+			if(args.length == 1 || args[1].nval() == null) { // args.length can only be 1 or 2 due to the numArgs().
 				server.broadcastMessage(args[0].val());
-			} else {
-				server.broadcastMessage(args[0].val(), permission);
+				return CVoid.VOID;
 			}
+
+			// Handle "broadcast(message, playerArray)".
+			if(args[1] instanceof CArray) {
+
+				// Get the CArray and validate that it is non-associative.
+				CArray array = (CArray) args[1];
+				if(array.isAssociative()) {
+					throw new CREFormatException(
+							"Expected a non-associative array or permission as the second parameter.", t);
+				}
+
+				// Get the player recipients from the array.
+				Set<MCCommandSender> recipients = new HashSet<>();
+				for(Construct p : array.asList()) {
+					try {
+						recipients.add(Static.GetPlayer(p, t));
+					} catch (CREPlayerOfflineException cre) {
+						// Ignore offline players.
+					}
+				}
+
+				// Perform the broadcast and return cvoid.
+				server.broadcastMessage(args[0].val(), recipients);
+				return CVoid.VOID;
+			}
+
+			// Handle "broadcast(message, permission)".
+			String permission = args[1].nval();
+			server.broadcastMessage(args[0].val(), permission);
 			return CVoid.VOID;
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -624,15 +624,14 @@ public class Echoes {
 
 		@Override
 		public String docs() {
-			return "void {message, [permission] | message, [players]} Broadcasts a message to all or some players"
+			return "void {message, [permission] | message, [recipients]} Broadcasts a message to all or some players"
 					+ " and/or console."
-					+ " If permission is given, only players with that permission will see the broadcast. On Bukkit"
-					+ " servers, console will only receive the broadcast when permission is 'bukkit.broadcast'."
-					+ " If an array is given, only online players in the list will see the broadcast."
+					+ " If permission is given, only players with that permission and console will see the broadcast."
+					+ " If an array of recipients is given, only online players in the list will see the broadcast."
 					+ " Console will receive the broadcast only when the array contains case-insensitive '~console'."
-					+ " Offline players in the list will be ignored."
-					+ " If permission/players is null, all players and console will see the broadcast."
-					+ " Throws CREFormatException when the given players array is associative.";
+					+ " Offline players and duplicate recipients in the list will be ignored."
+					+ " If permission/recipients is null, all players and console will see the broadcast."
+					+ " Throws FormatException when the given recipients array is associative.";
 		}
 
 		@Override
@@ -660,7 +659,7 @@ public class Echoes {
 				return CVoid.VOID;
 			}
 
-			// Handle "broadcast(message, playerArray)".
+			// Handle "broadcast(message, recipientsArray)".
 			if(args[1] instanceof CArray) {
 
 				// Get the CArray and validate that it is non-associative.
@@ -670,7 +669,7 @@ public class Echoes {
 							"Expected a non-associative array or permission as the second parameter.", t);
 				}
 
-				// Get the player recipients from the array.
+				// Get the recipients from the array.
 				Set<MCCommandSender> recipients = new HashSet<>();
 				for(Construct p : array.asList()) {
 					if(p.val().equalsIgnoreCase("~console")) {

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -624,12 +624,15 @@ public class Echoes {
 
 		@Override
 		public String docs() {
-			return "void {message, [permission] | message, [players]} Broadcasts a message to all or some players."
-					+ " If permission is given, only players with that permission will see the broadcast."
+			return "void {message, [permission] | message, [players]} Broadcasts a message to all or some players"
+					+ " and/or console."
+					+ " If permission is given, only players with that permission will see the broadcast. On Bukkit"
+					+ " servers, console will only receive the broadcast when permission is 'bukkit.broadcast'."
 					+ " If an array is given, only online players in the list will see the broadcast."
+					+ " Console will receive the broadcast only when the array contains case-insensitive '~console'."
 					+ " Offline players in the list will be ignored."
-					+ " If permission/players is null, all players will see the broadcast."
-					+ " Throws a CREFormatException when the given players array is associative.";
+					+ " If permission/players is null, all players and console will see the broadcast."
+					+ " Throws CREFormatException when the given players array is associative.";
 		}
 
 		@Override
@@ -670,10 +673,14 @@ public class Echoes {
 				// Get the player recipients from the array.
 				Set<MCCommandSender> recipients = new HashSet<>();
 				for(Construct p : array.asList()) {
-					try {
-						recipients.add(Static.GetPlayer(p, t));
-					} catch (CREPlayerOfflineException cre) {
-						// Ignore offline players.
+					if(p.val().equalsIgnoreCase("~console")) {
+						recipients.add(server.getConsole());
+					} else {
+						try {
+							recipients.add(Static.GetPlayer(p, t));
+						} catch (CREPlayerOfflineException cre) {
+							// Ignore offline players.
+						}
 					}
 				}
 


### PR DESCRIPTION
- Make broadcast(message, players) fire an event through its Bukkit implementation so that it matches the broadcast(message) and broadcast(message, permission) behaviour.
- Extend broadcast() documentation to include all behaviour.