### PR TITLE
Add new inventory functions and virtual inventories.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/Convertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/Convertor.java
@@ -128,6 +128,8 @@ public interface Convertor {
 	 */
 	MCInventory GetLocationInventory(MCLocation location);
 
+	MCInventoryHolder CreateInventoryHolder(String id);
+
 	/**
 	 * Run whenever the server is shutting down (or restarting). There is no guarantee provided as to what thread the
 	 * runnables actually run on, so you should ensure that the runnable executes it's actions on the appropriate thread

--- a/src/main/java/com/laytonsmith/abstraction/MCDoubleChest.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCDoubleChest.java
@@ -1,0 +1,5 @@
+package com.laytonsmith.abstraction;
+
+public interface MCDoubleChest extends MCInventoryHolder {
+	MCLocation getLocation();
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCServer.java
@@ -56,11 +56,9 @@ public interface MCServer extends AbstractionObject {
 
 	MCCommandMap getCommandMap();
 
-	MCInventory createInventory(MCInventoryHolder owner, MCInventoryType type);
+	MCInventory createInventory(MCInventoryHolder owner, MCInventoryType type, String title);
 
 	MCInventory createInventory(MCInventoryHolder owner, int size, String title);
-
-	MCInventory createInventory(MCInventoryHolder owner, int size);
 
 	/**
 	 * Provides access to local user data associated with a name. Depending on the implementation, a web lookup with the

--- a/src/main/java/com/laytonsmith/abstraction/MCVirtualInventoryHolder.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCVirtualInventoryHolder.java
@@ -1,0 +1,5 @@
+package com.laytonsmith.abstraction;
+
+public interface MCVirtualInventoryHolder extends MCInventoryHolder {
+	String getID();
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -12,6 +12,7 @@ import com.laytonsmith.abstraction.MCEnchantment;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCFireworkBuilder;
 import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
@@ -89,13 +90,11 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Banner;
 import org.bukkit.block.Beacon;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.BrewingStand;
 import org.bukkit.block.Chest;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.Dispenser;
-import org.bukkit.block.DoubleChest;
 import org.bukkit.block.Dropper;
 import org.bukkit.block.Furnace;
 import org.bukkit.block.Hopper;
@@ -556,27 +555,24 @@ public class BukkitConvertor extends AbstractConvertor {
 		if(entity instanceof InventoryHolder) {
 			if(entity instanceof Player) {
 				return new BukkitMCPlayerInventory(((Player) entity).getInventory());
-			} else {
-				return new BukkitMCInventory(((InventoryHolder) entity).getInventory());
 			}
-		} else {
-			return null;
+			return new BukkitMCInventory(((InventoryHolder) entity).getInventory());
 		}
+		return null;
 	}
 
 	@Override
 	public MCInventory GetLocationInventory(MCLocation location) {
-		Block b = ((Location) location.getHandle()).getBlock();
-		if(b.getState() instanceof InventoryHolder) {
-			if(b.getState() instanceof DoubleChest) {
-				DoubleChest dc = (DoubleChest) b.getState();
-				return new BukkitMCDoubleChest(dc.getLeftSide().getInventory(), dc.getRightSide().getInventory());
-			} else {
-				return new BukkitMCInventory(((InventoryHolder) b.getState()).getInventory());
-			}
-		} else {
-			return null;
+		BlockState bs = ((Location) location.getHandle()).getBlock().getState();
+		if(bs instanceof InventoryHolder) {
+			return new BukkitMCInventory(((InventoryHolder) bs).getInventory());
 		}
+		return null;
+	}
+
+	@Override
+	public MCInventoryHolder CreateInventoryHolder(String id) {
+		return new BukkitMCVirtualInventoryHolder(id);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCDoubleChest.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCDoubleChest.java
@@ -1,72 +1,30 @@
 package com.laytonsmith.abstraction.bukkit;
 
-import com.laytonsmith.abstraction.MCItemStack;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
+import com.laytonsmith.abstraction.MCDoubleChest;
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCLocation;
+import org.bukkit.block.DoubleChest;
 
-public class BukkitMCDoubleChest extends BukkitMCInventory {
+public class BukkitMCDoubleChest implements MCDoubleChest {
 
-	Inventory left;
-	Inventory right;
+	DoubleChest dc;
 
-	public BukkitMCDoubleChest(Inventory left, Inventory right) {
-		super(left);
+	public BukkitMCDoubleChest(DoubleChest chest) {
+		this.dc = chest;
 	}
 
 	@Override
-	public int getSize() {
-		return left.getSize() + right.getSize();
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(this.dc.getInventory());
 	}
 
 	@Override
-	public MCItemStack getItem(int slot) {
-		ItemStack is;
-		if(slot < left.getSize()) {
-			is = left.getItem(slot);
-		} else {
-			is = right.getItem(slot - left.getSize());
-		}
-		return new BukkitMCItemStack(is);
+	public MCLocation getLocation() {
+		return new BukkitMCLocation(this.dc.getLocation());
 	}
 
 	@Override
-	public void setItem(int slot, MCItemStack stack) {
-		ItemStack is = (ItemStack) stack.getHandle();
-		if(slot < left.getSize()) {
-			left.setItem(slot, is);
-		} else {
-			right.setItem(slot - left.getSize(), is);
-		}
-	}
-
-	@Override
-	public String toString() {
-		return left.toString() + ":" + right.toString();
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if(obj == null) {
-			return false;
-		}
-		if(getClass() != obj.getClass()) {
-			return false;
-		}
-		final BukkitMCDoubleChest other = (BukkitMCDoubleChest) obj;
-		if(this.left != other.left && (this.left == null || !this.left.equals(other.left))) {
-			return false;
-		}
-		if(this.right != other.right && (this.right == null || !this.right.equals(other.right))) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		int hash = 7;
-		hash = 59 * hash + (this.left != null ? this.left.hashCode() : 0);
-		hash = 59 * hash + (this.right != null ? this.right.hashCode() : 0);
-		return hash;
+	public Object getHandle() {
+		return this.dc;
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCInventory.java
@@ -12,9 +12,13 @@ import com.laytonsmith.core.CHLog.Tags;
 import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.CRE.CRERangeException;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -135,7 +139,17 @@ public class BukkitMCInventory implements MCInventory {
 
 	@Override
 	public MCInventoryHolder getHolder() {
-		return new BukkitMCInventoryHolder(i.getHolder());
+		InventoryHolder ih = i.getHolder();
+		if(ih instanceof BlockState) {
+			return (MCInventoryHolder) BukkitConvertor.BukkitGetCorrectBlockState((BlockState) ih);
+		} else if(ih instanceof Entity) {
+			return (MCInventoryHolder) BukkitConvertor.BukkitGetCorrectEntity((Entity) ih);
+		} else if(ih instanceof BukkitMCVirtualInventoryHolder.VirtualHolder) {
+			return new BukkitMCVirtualInventoryHolder(ih);
+		} else if(ih instanceof DoubleChest) {
+			return new BukkitMCDoubleChest((DoubleChest) ih);
+		}
+		return new BukkitMCInventoryHolder(ih);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
@@ -5,7 +5,6 @@ import com.laytonsmith.abstraction.MCBossBar;
 import com.laytonsmith.abstraction.MCCommandMap;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCConsoleCommandSender;
-import com.laytonsmith.abstraction.MCHumanEntity;
 import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.MCItemFactory;
@@ -17,7 +16,6 @@ import com.laytonsmith.abstraction.MCRecipe;
 import com.laytonsmith.abstraction.MCScoreboard;
 import com.laytonsmith.abstraction.MCServer;
 import com.laytonsmith.abstraction.MCWorld;
-import com.laytonsmith.abstraction.bukkit.entities.BukkitMCHumanEntity;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import com.laytonsmith.abstraction.bukkit.pluginmessages.BukkitMCMessenger;
 import com.laytonsmith.abstraction.enums.MCBarColor;
@@ -437,47 +435,30 @@ public class BukkitMCServer implements MCServer {
 	}
 
 	@Override
-	public MCInventory createInventory(MCInventoryHolder holder, MCInventoryType type) {
-		InventoryHolder ih = null;
-
-		if(holder instanceof MCPlayer) {
-			ih = ((BukkitMCPlayer) holder)._Player();
-		} else if(holder instanceof MCHumanEntity) {
-			ih = ((BukkitMCHumanEntity) holder).asHumanEntity();
-		} else if(holder.getHandle() instanceof InventoryHolder) {
+	public MCInventory createInventory(MCInventoryHolder holder, MCInventoryType type, String title) {
+		InventoryHolder ih;
+		if(holder == null) {
+			ih = null;
+		} else {
 			ih = (InventoryHolder) holder.getHandle();
 		}
-
-		return new BukkitMCInventory(Bukkit.createInventory(ih, InventoryType.valueOf(type.name())));
-	}
-
-	@Override
-	public MCInventory createInventory(MCInventoryHolder holder, int size) {
-		InventoryHolder ih = null;
-
-		if(holder instanceof MCPlayer) {
-			ih = ((BukkitMCPlayer) holder)._Player();
-		} else if(holder instanceof MCHumanEntity) {
-			ih = ((BukkitMCHumanEntity) holder).asHumanEntity();
-		} else if(holder.getHandle() instanceof InventoryHolder) {
-			ih = (InventoryHolder) holder.getHandle();
+		if(title == null) {
+			return new BukkitMCInventory(Bukkit.createInventory(ih, InventoryType.valueOf(type.name())));
 		}
-
-		return new BukkitMCInventory(Bukkit.createInventory(ih, size));
+		return new BukkitMCInventory(Bukkit.createInventory(ih, InventoryType.valueOf(type.name()), title));
 	}
 
 	@Override
 	public MCInventory createInventory(MCInventoryHolder holder, int size, String title) {
-		InventoryHolder ih = null;
-
-		if(holder instanceof MCPlayer) {
-			ih = ((BukkitMCPlayer) holder)._Player();
-		} else if(holder instanceof MCHumanEntity) {
-			ih = ((BukkitMCHumanEntity) holder).asHumanEntity();
-		} else if(holder.getHandle() instanceof InventoryHolder) {
+		InventoryHolder ih;
+		if(holder == null) {
+			ih = null;
+		} else {
 			ih = (InventoryHolder) holder.getHandle();
 		}
-
+		if(title == null) {
+			return new BukkitMCInventory(Bukkit.createInventory(ih, size));
+		}
 		return new BukkitMCInventory(Bukkit.createInventory(ih, size, title));
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCVirtualInventoryHolder.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCVirtualInventoryHolder.java
@@ -1,0 +1,48 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCVirtualInventoryHolder;
+import com.laytonsmith.core.functions.InventoryManagement;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class BukkitMCVirtualInventoryHolder implements MCVirtualInventoryHolder {
+
+	private VirtualHolder vholder;
+
+	public BukkitMCVirtualInventoryHolder(String id) {
+		this.vholder = new VirtualHolder(id);
+	}
+
+	public BukkitMCVirtualInventoryHolder(InventoryHolder ih) {
+		this.vholder = (VirtualHolder) ih;
+	}
+
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(vholder.getInventory());
+	}
+
+	@Override
+	public String getID() {
+		return vholder.id;
+	}
+
+	@Override
+	public Object getHandle() {
+		return this.vholder;
+	}
+
+	public class VirtualHolder implements InventoryHolder {
+		private String id;
+
+		VirtualHolder(String id) {
+			this.id = id;
+		}
+
+		@Override
+		public Inventory getInventory() {
+			return (Inventory) InventoryManagement.VIRTUAL_INVENTORIES.get(this.id).getHandle();
+		}
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCVillager.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCVillager.java
@@ -1,6 +1,8 @@
 package com.laytonsmith.abstraction.bukkit.entities;
 
 import com.laytonsmith.abstraction.AbstractionObject;
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
 import com.laytonsmith.abstraction.entities.MCVillager;
 import com.laytonsmith.abstraction.enums.MCProfession;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCProfession;
@@ -30,5 +32,10 @@ public class BukkitMCVillager extends BukkitMCAgeable implements MCVillager {
 	@Override
 	public void setProfession(MCProfession profession) {
 		getHandle().setProfession(BukkitMCProfession.getConvertor().getConcreteEnum(profession));
+	}
+
+	@Override
+	public MCInventory getInventory() {
+		return new BukkitMCInventory(getHandle().getInventory());
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCVillager.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCVillager.java
@@ -1,11 +1,10 @@
 package com.laytonsmith.abstraction.entities;
 
 import com.laytonsmith.abstraction.MCAgeable;
+import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.enums.MCProfession;
 
-public interface MCVillager extends MCAgeable {
-
+public interface MCVillager extends MCAgeable, MCInventoryHolder {
 	MCProfession getProfession();
-
 	void setProfession(MCProfession profession);
 }

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCInventoryType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCInventoryType.java
@@ -6,18 +6,33 @@ import com.laytonsmith.annotations.MEnum;
 public enum MCInventoryType {
 	BREWING,
 	CHEST,
-	CRAFTING,
-	CREATIVE,
+	CRAFTING(false), // bukkit doesn't allow opening
+	CREATIVE(false), // bukkit doesn't allow opening
 	DISPENSER,
 	DROPPER,
-	ENCHANTING,
+	ENCHANTING(false), // non-functional
 	ENDER_CHEST,
 	FURNACE,
 	HOPPER,
-	MERCHANT,
+	MERCHANT(false), // doesn't open
 	PLAYER,
 	WORKBENCH,
 	ANVIL,
 	BEACON,
-	SHULKER_BOX
+	SHULKER_BOX;
+
+	// Whether or not this inventory type can be created and used virtually
+	private final boolean canVirtualize;
+
+	MCInventoryType() {
+		this.canVirtualize = true;
+	}
+
+	MCInventoryType(boolean virtual) {
+		this.canVirtualize = virtual;
+	}
+
+	public boolean canVirtualize() {
+		return this.canVirtualize;
+	}
 }

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -47,7 +47,6 @@ import com.laytonsmith.core.exceptions.CRE.CREBadEntityException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
-import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
 import com.laytonsmith.core.exceptions.CRE.CREInvalidPluginException;
 import com.laytonsmith.core.exceptions.CRE.CREInvalidWorldException;
 import com.laytonsmith.core.exceptions.CRE.CRELengthException;
@@ -703,7 +702,7 @@ public final class Static {
 						+ " but the given string was " + subject.length() + " characters.", t);
 			}
 		} catch (IllegalArgumentException iae) {
-			throw new CREIllegalArgumentException("A UUID length string was given, but was not a valid UUID.", t);
+			throw new CREFormatException("A UUID length string was given, but was not a valid UUID.", t);
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -5,6 +5,7 @@ import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.abstraction.MCHumanEntity;
 import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCItemStack;
+import com.laytonsmith.abstraction.MCVirtualInventoryHolder;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.enums.MCClickType;
 import com.laytonsmith.abstraction.enums.MCDragType;
@@ -39,6 +40,8 @@ import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.EventException;
 import com.laytonsmith.core.exceptions.PrefilterNonMatchException;
+import com.laytonsmith.core.functions.InventoryManagement;
+
 import java.util.Map;
 
 public class InventoryEvents {
@@ -57,29 +60,37 @@ public class InventoryEvents {
 
 		@Override
 		public String docs() {
-			return "{slottype: <macro> The type of slot being clicked, can be "
+			return "{virtual: <boolean> Whether or not this inventory is virtually stored in CH"
+					+ " | slottype: <macro> The type of slot being clicked, can be "
 					+ StringUtils.Join(MCSlotType.values(), ", ", ", or ")
 					+ " | clicktype: <macro> One of " + StringUtils.Join(MCClickType.values(), ", ", ", or ")
 					+ " | action: <macro> One of " + StringUtils.Join(MCInventoryAction.values(), ", ", ", or ")
 					+ " | slotitem: <item match> | player: <macro>}"
 					+ " Fired when a player clicks a slot in any inventory. "
 					+ " {player: The player who clicked | viewers: everyone looking in this inventory"
-					+ " | leftclick: true/false if this was a left click | keyboardclick: true/false if a key was pressed"
-					+ " | rightclick: true/false if this was a right click | shiftclick: true/false if shift was being held"
+					+ " | leftclick: if this was a left click | keyboardclick: true/false if a key was pressed"
+					+ " | rightclick: if this was a right click | shiftclick: true/false if shift was being held"
 					+ " | creativeclick: true/false if this action could only be performed in creative mode"
-					+ " | slot: the number of the slot | rawslot: the number of the slot in whole inventory window | slottype"
+					+ " | slot: the slot number | rawslot: the slot number in whole inventory window | slottype"
 					+ " | slotitem | inventorytype | inventorysize: number of slots in opened inventory | cursoritem"
 					+ " | inventory: all the items in the (top) inventory | clicktype | action}"
-					+ " {slotitem: the item currently in the clicked slot | cursoritem: the item on the cursor (may cause"
-					+ " unexpected behavior)}"
+					+ " {slotitem: the item currently in the clicked slot | cursoritem: the item on the cursor"
+					+ " (may cause unexpected behavior)}"
 					+ " {}";
 		}
+
 
 		@Override
 		public boolean matches(Map<String, Construct> prefilter, BindableEvent event) throws PrefilterNonMatchException {
 			if(event instanceof MCInventoryClickEvent) {
 				MCInventoryClickEvent e = (MCInventoryClickEvent) event;
 
+				if(prefilter.containsKey("virtual")) {
+					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
+					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+						return false;
+					}
+				}
 				Prefilters.match(prefilter, "action", e.getAction().name(), PrefilterType.MACRO);
 				Prefilters.match(prefilter, "player", e.getWhoClicked().getName(), PrefilterType.MACRO);
 				Prefilters.match(prefilter, "clicktype", e.getClickType().name(), PrefilterType.MACRO);
@@ -101,38 +112,39 @@ public class InventoryEvents {
 			if(event instanceof MCInventoryClickEvent) {
 				MCInventoryClickEvent e = (MCInventoryClickEvent) event;
 				Map<String, Construct> map = evaluate_helper(event);
+				Target t = Target.UNKNOWN;
 
-				map.put("player", new CString(e.getWhoClicked().getName(), Target.UNKNOWN));
-				CArray viewers = new CArray(Target.UNKNOWN);
+				map.put("player", new CString(e.getWhoClicked().getName(), t));
+				CArray viewers = new CArray(t);
 				for(MCHumanEntity viewer : e.getViewers()) {
-					viewers.push(new CString(viewer.getName(), Target.UNKNOWN), Target.UNKNOWN);
+					viewers.push(new CString(viewer.getName(), t), t);
 				}
 				map.put("viewers", viewers);
 
-				map.put("action", new CString(e.getAction().name(), Target.UNKNOWN));
-				map.put("clicktype", new CString(e.getClickType().name(), Target.UNKNOWN));
+				map.put("action", new CString(e.getAction().name(), t));
+				map.put("clicktype", new CString(e.getClickType().name(), t));
 
 				map.put("leftclick", CBoolean.get(e.isLeftClick()));
 				map.put("rightclick", CBoolean.get(e.isRightClick()));
 				map.put("shiftclick", CBoolean.get(e.isShiftClick()));
 				map.put("creativeclick", CBoolean.get(e.isCreativeClick()));
 				map.put("keyboardclick", CBoolean.get(e.isKeyboardClick()));
-				map.put("cursoritem", ObjectGenerator.GetGenerator().item(e.getCursor(), Target.UNKNOWN));
+				map.put("cursoritem", ObjectGenerator.GetGenerator().item(e.getCursor(), t));
 
-				map.put("slot", new CInt(e.getSlot(), Target.UNKNOWN));
-				map.put("rawslot", new CInt(e.getRawSlot(), Target.UNKNOWN));
-				map.put("hotbarbutton", new CInt(e.getHotbarButton(), Target.UNKNOWN));
-				map.put("slottype", new CString(e.getSlotType().name(), Target.UNKNOWN));
-				map.put("slotitem", ObjectGenerator.GetGenerator().item(e.getCurrentItem(), Target.UNKNOWN));
+				map.put("slot", new CInt(e.getSlot(), t));
+				map.put("rawslot", new CInt(e.getRawSlot(), t));
+				map.put("hotbarbutton", new CInt(e.getHotbarButton(), t));
+				map.put("slottype", new CString(e.getSlotType().name(), t));
+				map.put("slotitem", ObjectGenerator.GetGenerator().item(e.getCurrentItem(), t));
 
-				CArray items = CArray.GetAssociativeArray(Target.UNKNOWN);
+				CArray items = CArray.GetAssociativeArray(t);
 				MCInventory inv = e.getInventory();
 				for(int i = 0; i < inv.getSize(); i++) {
-					items.set(i, ObjectGenerator.GetGenerator().item(inv.getItem(i), Target.UNKNOWN), Target.UNKNOWN);
+					items.set(i, ObjectGenerator.GetGenerator().item(inv.getItem(i), t), t);
 				}
 				map.put("inventory", items);
-				map.put("inventorytype", new CString(inv.getType().name(), Target.UNKNOWN));
-				map.put("inventorysize", new CInt(inv.getSize(), Target.UNKNOWN));
+				map.put("inventorytype", new CString(inv.getType().name(), t));
+				map.put("inventorysize", new CInt(inv.getSize(), t));
 
 				return map;
 			} else {
@@ -186,13 +198,18 @@ public class InventoryEvents {
 
 		@Override
 		public String docs() {
-			return "{world: <macro> World name | type: <string match> Can be " + StringUtils.Join(MCDragType.values(), ", ", ", or ")
+			return "{virtual: <boolean> Whether or not this inventory is virtually stored in CH"
+					+ " | world: <macro> World name"
+					+ " | type: <string match> Can be " + StringUtils.Join(MCDragType.values(), ", ", ", or ")
 					+ " | cursoritem: <item match> item in hand, before event starts}"
-					+ "Fired when a player clicks (by left or right mouse button) a slot in inventory and drag mouse across slots. "
-					+ "{player: The player who clicked | newcursoritem: item on cursor, after event | oldcursoritem: item on cursor,"
-					+ " before event | slots: used slots | rawslots: used slots, as the numbers of the slots in whole inventory window"
-					+ " | newitems: array of items which are dropped in selected slots | inventorytype | inventorysize: number of slots in"
-					+ " opened inventory} {cursoritem: the item on the cursor, after event} "
+					+ "Fired when a player clicks (by left or right mouse button) a slot in an inventory and then drags"
+					+ " the mouse across slots. "
+					+ "{player: The player who clicked | newcursoritem: item on cursor, after event"
+					+ " | oldcursoritem: item on cursor, before event | slots: used slots"
+					+ " | rawslots: used slots, as the numbers of the slots in whole inventory window"
+					+ " | newitems: array of items which are dropped in selected slots | inventorytype"
+					+ " | inventorysize: number of slots in opened inventory}"
+					+ "{cursoritem: the item on the cursor, after event} "
 					+ "{} ";
 		}
 
@@ -201,6 +218,12 @@ public class InventoryEvents {
 			if(event instanceof MCInventoryDragEvent) {
 				MCInventoryDragEvent e = (MCInventoryDragEvent) event;
 
+				if(prefilter.containsKey("virtual")) {
+					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
+					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+						return false;
+					}
+				}
 				Prefilters.match(prefilter, "world", e.getWhoClicked().getWorld().getName(), PrefilterType.MACRO);
 				Prefilters.match(prefilter, "type", e.getType().name(), PrefilterType.STRING_MATCH);
 				Prefilters.match(prefilter, "cursoritem", Static.ParseItemNotation(e.getOldCursor()), PrefilterType.ITEM_MATCH);
@@ -304,17 +327,26 @@ public class InventoryEvents {
 
 		@Override
 		public String docs() {
-			return "{} "
+			return "{virtual: <boolean> Whether or not this inventory is virtually stored in CH} "
 					+ "Fired when a player opens an inventory. "
-					+ "{player: The player | " /*"{player: The player who clicked | viewers: everyone looking in this inventory | "*/
-					+ "inventory: the inventory items in this inventory | "
-					+ "inventorytype: type of inventory} "
+					+ "{player: The player | inventory: the inventory items in this inventory"
+					+ " | inventorytype: type of inventory | virtual"
+					+ " | holder: block location array, entity UUID, or virtual id for this inventory (can be null)}"
 					+ "{} "
 					+ "{} ";
 		}
 
 		@Override
 		public boolean matches(Map<String, Construct> prefilter, BindableEvent event) throws PrefilterNonMatchException {
+			if(event instanceof MCInventoryOpenEvent) {
+				MCInventoryOpenEvent e = (MCInventoryOpenEvent) event;
+				if(prefilter.containsKey("virtual")) {
+					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
+					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+						return false;
+					}
+				}
+			}
 			return true;
 		}
 
@@ -328,20 +360,21 @@ public class InventoryEvents {
 			if(event instanceof MCInventoryOpenEvent) {
 				MCInventoryOpenEvent e = (MCInventoryOpenEvent) event;
 				Map<String, Construct> map = evaluate_helper(event);
+				Target t = Target.UNKNOWN;
 
-				map.put("player", new CString(e.getPlayer().getName(), Target.UNKNOWN));
+				map.put("player", new CString(e.getPlayer().getName(), t));
 
-				CArray items = CArray.GetAssociativeArray(Target.UNKNOWN);
+				CArray items = CArray.GetAssociativeArray(t);
 				MCInventory inv = e.getInventory();
-
 				for(int i = 0; i < inv.getSize(); i++) {
-					Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), Target.UNKNOWN);
-					items.set(i, c, Target.UNKNOWN);
+					Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), t);
+					items.set(i, c, t);
 				}
-
 				map.put("inventory", items);
 
-				map.put("inventorytype", new CString(e.getInventory().getType().name(), Target.UNKNOWN));
+				map.put("inventorytype", new CString(e.getInventory().getType().name(), t));
+				map.put("holder", InventoryManagement.GetInventoryHolder(e.getInventory(), t));
+				map.put("virtual", CBoolean.get(e.getInventory().getHolder() instanceof MCVirtualInventoryHolder));
 
 				return map;
 			} else {
@@ -376,17 +409,26 @@ public class InventoryEvents {
 
 		@Override
 		public String docs() {
-			return "{} "
+			return "{virtual: <boolean> Whether or not this inventory is virtually stored in CH} "
 					+ "Fired when a player closes an inventory. "
-					+ "{player: The player | " /*"{player: The player who clicked | viewers: everyone looking in this inventory | "*/
-					+ "inventory: the inventory items in this inventory | "
-					+ "inventorytype: type of inventory} "
+					+ "{player: The player | inventory: the inventory items in this inventory"
+					+ " | inventorytype: type of inventory | virtual"
+					+ " | holder: block location array, entity UUID, or virtual id for this inventory (can be null)}"
 					+ "{} "
 					+ "{} ";
 		}
 
 		@Override
 		public boolean matches(Map<String, Construct> prefilter, BindableEvent event) throws PrefilterNonMatchException {
+			if(event instanceof MCInventoryCloseEvent) {
+				MCInventoryCloseEvent e = (MCInventoryCloseEvent) event;
+				if(prefilter.containsKey("virtual")) {
+					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
+					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+						return false;
+					}
+				}
+			}
 			return true;
 		}
 
@@ -400,20 +442,21 @@ public class InventoryEvents {
 			if(event instanceof MCInventoryCloseEvent) {
 				MCInventoryCloseEvent e = (MCInventoryCloseEvent) event;
 				Map<String, Construct> map = evaluate_helper(event);
+				Target t = Target.UNKNOWN;
 
-				map.put("player", new CString(e.getPlayer().getName(), Target.UNKNOWN));
+				map.put("player", new CString(e.getPlayer().getName(), t));
 
-				CArray items = CArray.GetAssociativeArray(Target.UNKNOWN);
+				CArray items = CArray.GetAssociativeArray(t);
 				MCInventory inv = e.getInventory();
-
 				for(int i = 0; i < inv.getSize(); i++) {
-					Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), Target.UNKNOWN);
-					items.set(i, c, Target.UNKNOWN);
+					Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), t);
+					items.set(i, c, t);
 				}
-
 				map.put("inventory", items);
 
-				map.put("inventorytype", new CString(e.getInventory().getType().name(), Target.UNKNOWN));
+				map.put("inventorytype", new CString(e.getInventory().getType().name(), t));
+				map.put("holder", InventoryManagement.GetInventoryHolder(e.getInventory(), t));
+				map.put("virtual", CBoolean.get(e.getInventory().getHolder() instanceof MCVirtualInventoryHolder));
 
 				return map;
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -2,15 +2,21 @@ package com.laytonsmith.core.functions;
 
 import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.abstraction.MCCommandSender;
+import com.laytonsmith.abstraction.MCDoubleChest;
 import com.laytonsmith.abstraction.MCEntity;
+import com.laytonsmith.abstraction.MCHumanEntity;
 import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
+import com.laytonsmith.abstraction.MCInventoryView;
 import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCPlayerInventory;
+import com.laytonsmith.abstraction.MCVirtualInventoryHolder;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.laytonsmith.abstraction.blocks.MCBlockState;
 import com.laytonsmith.abstraction.enums.MCInventoryType;
 import com.laytonsmith.abstraction.enums.MCVersion;
 import com.laytonsmith.annotations.api;
@@ -18,8 +24,10 @@ import com.laytonsmith.core.CHVersion;
 import com.laytonsmith.core.ObjectGenerator;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
+import com.laytonsmith.core.constructs.CBoolean;
 import com.laytonsmith.core.constructs.CInt;
 import com.laytonsmith.core.constructs.CNull;
+import com.laytonsmith.core.constructs.CNumber;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Construct;
@@ -39,6 +47,9 @@ import com.laytonsmith.core.exceptions.CRE.CRERangeException;
 import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class InventoryManagement {
@@ -53,6 +64,7 @@ public class InventoryManagement {
 			+ " data: The data value of the item, or the damage if a damageable item,"
 			+ " qty: The number of items in their inventory,"
 			+ " meta: An array of item meta or null if none exists (see {{function|get_itemmeta}} for details).";
+
 	@api(environments = {CommandHelperEnvironment.class})
 	public static class pinv extends AbstractFunction {
 
@@ -81,9 +93,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class,
-				CRECastException.class, CRERangeException.class,
-				CRENotFoundException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class, CRECastException.class,
+					CRERangeException.class, CRENotFoundException.class};
 		}
 
 		@Override
@@ -186,7 +197,7 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -227,8 +238,7 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "void {[player]} Closes the inventory of the current player, "
-					+ "or of the specified player.";
+			return "void {[player]} Closes the inventory of the current player, or of the specified player.";
 		}
 
 		@Override
@@ -242,8 +252,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class,
-				CREInsufficientArgumentsException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class,
+					CREInsufficientArgumentsException.class};
 		}
 
 		@Override
@@ -302,7 +312,7 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -366,7 +376,7 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -450,7 +460,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class, CRECastException.class, CREFormatException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRECastException.class, CREFormatException.class,
+					CRELengthException.class};
 		}
 
 		@Override
@@ -625,7 +636,7 @@ public class InventoryManagement {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CREPlayerOfflineException.class, CREFormatException.class, CRERangeException.class,
-				CRECastException.class, CRENotFoundException.class};
+					CRECastException.class, CRENotFoundException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -716,8 +727,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREFormatException.class,
-				CREPlayerOfflineException.class, CRENotFoundException.class};
+			return new Class[]{CRECastException.class, CREFormatException.class, CRELengthException.class,
+					CREPlayerOfflineException.class, CRENotFoundException.class};
 		}
 
 		@Override
@@ -814,7 +825,7 @@ public class InventoryManagement {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CRECastException.class, CREFormatException.class, CREPlayerOfflineException.class,
-				CRENotFoundException.class, CREIllegalArgumentException.class};
+					CRENotFoundException.class, CREIllegalArgumentException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -906,7 +917,7 @@ public class InventoryManagement {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CRECastException.class, CREPlayerOfflineException.class, CRERangeException.class,
-				CREFormatException.class, CRENotFoundException.class};
+					CREFormatException.class, CRENotFoundException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -1012,7 +1023,8 @@ public class InventoryManagement {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CREFormatException.class, CRECastException.class, CRERangeException.class,
-				CREPlayerOfflineException.class, CRENotFoundException.class, CREIllegalArgumentException.class};
+					CREPlayerOfflineException.class, CRENotFoundException.class, CREIllegalArgumentException.class,
+					CRELengthException.class};
 		}
 
 		@Override
@@ -1101,8 +1113,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREPlayerOfflineException.class,
-				CREFormatException.class, CRENotFoundException.class, CRERangeException.class};
+			return new Class[]{CRECastException.class, CREPlayerOfflineException.class, CRELengthException.class,
+					CREFormatException.class, CRENotFoundException.class, CRERangeException.class};
 		}
 
 		@Override
@@ -1195,7 +1207,7 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "void {[player], pinvArray} Sets a player's enderchest's inventory to the specified inventory object."
+			return "void {[player], invArray} Sets a player's enderchest's inventory to the specified inventory object."
 					+ " An inventory object is one that matches what is returned by penderchest(), so set_penderchest(penderchest()),"
 					+ " while pointless, would be a correct call. ---- The array must be associative, "
 					+ " however, it may skip items, in which case, only the specified values will be changed. If"
@@ -1210,7 +1222,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class, CRECastException.class, CREFormatException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRECastException.class, CREFormatException.class,
+					CRELengthException.class};
 		}
 
 		@Override
@@ -1310,9 +1323,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class,
-				CRECastException.class, CRERangeException.class,
-				CRENotFoundException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class, CRECastException.class,
+					CRERangeException.class, CRENotFoundException.class};
 		}
 
 		@Override
@@ -1393,8 +1405,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREFormatException.class, CRECastException.class,
-				CRELengthException.class};
+			return new Class[]{CREFormatException.class, CREBadEntityException.class, CREInvalidWorldException.class,
+					CRECastException.class, CRERangeException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1437,7 +1449,7 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "array {entityID, slotNumber | locationArray, slotNumber} If a number is provided, it is assumed to be an entity, and if the entity supports"
+			return "array {specifier, slot} If a number is provided, it is assumed to be an entity, and if the entity supports"
 					+ " inventories, it will be valid. Otherwise, if a location array is provided, it is assumed to be a block (chest, brewer, etc)"
 					+ " and interpreted thusly. Depending on the inventory type, the max index will vary. If the index is too large, a RangeException is thrown,"
 					+ " otherwise, the item at that location is returned as an item array, or null, if no item is there. You can determine the inventory type"
@@ -1456,8 +1468,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREFormatException.class, CRECastException.class,
-				CRELengthException.class};
+			return new Class[]{CREFormatException.class, CREBadEntityException.class, CREInvalidWorldException.class,
+					CRECastException.class, CRERangeException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1502,8 +1514,9 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "void {entityID, index, itemArray | locationArray, index, itemArray} Sets the specified item in the specified slot given either an entityID or a location array of a container"
-					+ " object. See get_inventory_type for more information. The itemArray is an array in the same format as pinv/set_pinv takes.";
+			return "void {specifier, index, itemArray} Sets the specified item in the specified inventory slot."
+					+ " The specifier can be an entity UUID, block location array or virtual inventory id. ---- "
+					+ ITEM_OBJECT;
 		}
 
 		@Override
@@ -1518,8 +1531,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREFormatException.class,
-				CRELengthException.class};
+			return new Class[]{CRECastException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1556,10 +1569,10 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "string {entityID | locationArray} Returns the inventory type at the location specified, or of the entity specified. If the"
-					+ " entity or location specified is not capable of having an inventory, a FormatException is thrown."
-					+ " ---- Note that not all valid inventory types are actually returnable at this time, due to lack of support in the server, but"
-					+ " the valid return types are: " + StringUtils.Join(MCInventoryType.values(), ", ");
+			return "string {specifier} Returns the inventory type at the location specified, or of the entity specified."
+					+ " If the entity or location specified is not capable of having an inventory, a FormatException is thrown."
+					+ " ---- Note that not all valid inventory types may actually be returnable, due to lack of support"
+					+ " in the server, but the valid return types are: " + StringUtils.Join(MCInventoryType.values(), ", ");
 		}
 
 		@Override
@@ -1574,8 +1587,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREFormatException.class, CRECastException.class,
-				CRELengthException.class};
+			return new Class[]{CREFormatException.class, CREBadEntityException.class, CREInvalidWorldException.class,
+					CRECastException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1610,8 +1623,8 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "int {entityID | locationArray} Returns the max size of the inventory specified. If the block or entity can't have an inventory,"
-					+ " a FormatException is thrown.";
+			return "int {specifier} Returns the max size of the inventory specified."
+					+ " If the block or entity can't have an inventory, a FormatException is thrown.";
 		}
 
 		@Override
@@ -1627,7 +1640,7 @@ public class InventoryManagement {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CREBadEntityException.class, CRECastException.class, CREFormatException.class,
-				CREIllegalArgumentException.class, CREInvalidWorldException.class, CRELengthException.class};
+					CREInvalidWorldException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1663,7 +1676,7 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "string {entityID | locationArray} Returns the name of the inventory specified. If the block or entity"
+			return "string {specifier} Returns the name of the inventory specified. If the block or entity"
 					+ " can't have an inventory, a FormatException is thrown.";
 		}
 
@@ -1679,7 +1692,7 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -1744,7 +1757,7 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "array {entityID, [index] | locationArray, [index]} Gets the inventory for the specified block or entity."
+			return "array {specifier, [index]} Gets an array of the specified inventory."
 					+ " If the block or entity can't have an inventory, a FormatException is thrown. If the index is specified,"
 					+ " only the slot given will be returned. The max index of the array in the array is different for"
 					+ " different types of inventories. If there is no item at the slot specified, null is returned."
@@ -1754,8 +1767,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CRERangeException.class,
-				CREFormatException.class, CRELengthException.class};
+			return new Class[]{CRECastException.class, CRERangeException.class, CREFormatException.class,
+					CREBadEntityException.class, CREInvalidWorldException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1817,9 +1830,10 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "void {entityID, pinvArray | locationArray, pinvArray} Sets a block or entity inventory to the specified"
-					+ " inventory object. If the block or entity can't have an inventory, a FormatException is thrown."
-					+ " An inventory object pinvArray is one that matches what is returned by get_inventory(), so"
+			return "void {specifier, invArray} Sets a block or entity inventory to the specified inventory object."
+					+ " The specifier can be an entity UUID, location array, or virtual inventory ID."
+					+ " If the block or entity can't have an inventory, a FormatException is thrown."
+					+ " An inventory object invArray is one that matches what is returned by get_inventory(), so"
 					+ " set_inventory(123, get_inventory(123)) while pointless, would be a correct call."
 					+ " ---- The array must be associative, however, it may skip items, in which case, only the specified"
 					+ " values will be changed. If a key is out of range, or otherwise improper, a warning is emitted,"
@@ -1832,8 +1846,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREFormatException.class,
-				CRELengthException.class};
+			return new Class[]{CRECastException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CRERangeException.class, CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -1865,12 +1879,7 @@ public class InventoryManagement {
 
 			for(String key : array.stringKeySet()) {
 				try {
-					int index;
-					try {
-						index = Integer.parseInt(key);
-					} catch (NumberFormatException e) {
-						throw e;
-					}
+					int index = Integer.parseInt(key);
 					if(index < 0 || index >= size) {
 						ConfigRuntimeException.DoWarning("Out of range value (" + index + ") found in array passed to set_inventory(), so ignoring.");
 					} else {
@@ -1901,19 +1910,19 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "int {target, itemArray | target, itemID, qty, [metaArray]} Add to block or entity inventory the"
-					+ " specified item. The target must be a location array or entity UUID. Unlike set_inventory(),"
-					+ " this does not specify a slot. The items are distributed in the inventory, first filling up"
-					+ " slots that have the same item type, up to the max stack size, then fills up empty slots, until"
-					+ " either the entire inventory is filled, or the entire amount has been given. If the inventory is"
-					+ " full, number of items that were not added is returned, which will be less than or equal to the"
-					+ " quantity provided. Otherwise, returns 0.";
+			return "int {specifier, itemArray | specifier, itemID, qty, [metaArray]} Add to inventory the specified item."
+					+ " The specifier must be a location array, entity UUID, or virtual inventory id."
+					+ " The items are distributed in the inventory, first filling up slots that have the same item type,"
+					+ " up to the max stack size, then fills up empty slots, until either the entire inventory is filled,"
+					+ " or the entire amount has been given. If the inventory is full, number of items that were not"
+					+ " added is returned, which will be less than or equal to the quantity provided. Otherwise, returns 0.";
 		}
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREFormatException.class, CRELengthException.class,
-				CREIllegalArgumentException.class, CRENotFoundException.class, CRERangeException.class};
+			return new Class[]{CRECastException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CREIllegalArgumentException.class, CRENotFoundException.class,
+					CRERangeException.class};
 		}
 
 		@Override
@@ -1974,15 +1983,16 @@ public class InventoryManagement {
 
 		@Override
 		public String docs() {
-			return "int {target, itemArray | target, itemID, qty} Works in reverse of add_to_inventory(), but"
+			return "int {specifier, itemArray | specifier, itemID, qty} Works in reverse of add_to_inventory(), but"
 					+ " returns the number of items actually taken, which will be from 0 to qty. Target must be a"
 					+ " location array or entity UUID." + ITEM_MATCHING;
 		}
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRECastException.class, CREFormatException.class, CRERangeException.class,
-				CRELengthException.class, CRENotFoundException.class};
+			return new Class[]{CRECastException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CRERangeException.class, CRENotFoundException.class,
+					CREIllegalArgumentException.class};
 		}
 
 		@Override
@@ -2060,8 +2070,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CRERangeException.class, CREPlayerOfflineException.class,
-				CREFormatException.class, CRENotFoundException.class};
+			return new Class[]{CRERangeException.class, CREPlayerOfflineException.class, CREFormatException.class,
+					CRENotFoundException.class, CRELengthException.class};
 		}
 
 		@Override
@@ -2142,8 +2152,8 @@ public class InventoryManagement {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREPlayerOfflineException.class,
-				CREFormatException.class, CRENotFoundException.class};
+			return new Class[]{CREPlayerOfflineException.class, CRELengthException.class, CREFormatException.class,
+					CRENotFoundException.class};
 		}
 
 		@Override
@@ -2193,75 +2203,455 @@ public class InventoryManagement {
 		}
 	}
 
-//	@api
-//	public static class pinv_consolidate extends AbstractFunction {
-//
-//		public String getName() {
-//			return "pinv_consolidate";
-//		}
-//
-//		public Integer[] numArgs() {
-//			return new Integer[]{0, 1};
-//		}
-//
-//		public String docs() {
-//			return "void {[player]} Consolidates a player's inventory as much as possible."
-//					+ " There is no guarantee anything will happen after this function"
-//					+ " is called, and there is no way to specify details about how"
-//					+ " consolidation occurs, however, the following heuristics are followed:"
-//					+ " The hotbar items will not be moved from the hotbar, unless there are"
-//					+ " two+ slots that have the same item. Items in the main inventory area"
-//					+ " will be moved closer to the bottom of the main inventory. No empty slots"
-//					+ " will be filled in the hotbar.";
-//		}
-//
-//		public Class<? extends CREThrowable>[] thrown() {
-//			return new Class[]{};
-//		}
-//
-//		public boolean isRestricted() {
-//			return true;
-//		}
-//
-//		public boolean preResolveVariables() {
-//			return true;
-//		}
-//
-//		public Boolean runAsync() {
-//			return false;
-//		}
-//
-//		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
-//			MCPlayer p = environment.GetPlayer();
-//			if(args.length == 1){
-//				p = Static.GetPlayer(args[0], t);
-//			}
-//			//First, we need to address the hotbar
-//			for(int i = 0; i < 10; i++){
-//				//If the stack size is maxed out, we're done.
-//			}
-//
-//			return CVoid.VOID;
-//		}
-//
-//		public CHVersion since() {
-//			return CHVersion.V3_3_1;
-//		}
-//	}
+	@api(environments = {CommandHelperEnvironment.class})
+	public static class popen_inventory extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "popen_inventory";
+		}
+
+		@Override
+		public String docs() {
+			return "void {[player], specifier} Opens an inventory for a player. The specifier must be an entity UUID,"
+					+ " location array of a container block, or a virtual inventory id.";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1, 2};
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			MCPlayer p;
+			MCInventory inv;
+			if(args.length == 2) {
+				p = Static.GetPlayer(args[0], t);
+				inv = GetInventory(args[1], p.getWorld(), t);
+			} else {
+				p = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
+				Static.AssertPlayerNonNull(p, t);
+				inv = GetInventory(args[0], p.getWorld(), t);
+			}
+			p.openInventory(inv);
+			return CVoid.VOID;
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CREPlayerOfflineException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CRECastException.class, CRELengthException.class,
+					CREIllegalArgumentException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	@api(environments = {CommandHelperEnvironment.class})
+	public static class pinventory_holder extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "pinventory_holder";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{0, 1};
+		}
+
+		@Override
+		public String docs() {
+			return "mixed {[player]} Returns the block location, entity UUID, or virtual id of the inventory the player"
+					+ " is currently viewing. If the player is viewing their own inventory or no inventory, the"
+					+ " player's UUID is returned. When the inventory is virtual but has no id, it will return null."
+					+ " The returned value can be used in other inventory functions unless it is null.";
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			MCPlayer p;
+			if(args.length == 1) {
+				p = Static.GetPlayer(args[0], t);
+			} else {
+				p = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
+				Static.AssertPlayerNonNull(p, t);
+			}
+			MCInventoryView view = p.getOpenInventory();
+			if(view == null) {
+				// probably tests
+				return CNull.NULL;
+			}
+			return GetInventoryHolder(view.getTopInventory(), t);
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CREPlayerOfflineException.class, CREFormatException.class, CREBadEntityException.class,
+					CREInvalidWorldException.class, CRECastException.class, CRELengthException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	@api
+	public static class get_inventory_viewers extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "get_inventory_viewers";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1};
+		}
+
+		@Override
+		public String docs() {
+			return "array {specifier} Gets all players currently viewing this inventory."
+					+ " The specifier can be an entity UUID, block location array, or virtual inventory id.";
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			MCInventory inv = GetInventory(args[0], null, t);
+			CArray list = new CArray(t);
+			for(MCHumanEntity viewer : inv.getViewers()) {
+				list.push(new CString(viewer.getName(), t), t);
+			}
+			return list;
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CREFormatException.class, CREBadEntityException.class, CREInvalidWorldException.class,
+					CRECastException.class, CREIllegalArgumentException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	@api
+	public static class get_virtual_inventories extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "get_virtual_inventories";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{0};
+		}
+
+		@Override
+		public String docs() {
+			return "array {} Returns an array of virtual inventory ids.";
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			CArray list = new CArray(t);
+			for(String id : VIRTUAL_INVENTORIES.keySet()) {
+				list.push(new CString(id, t), t);
+			}
+			return list;
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	@api
+	public static class create_virtual_inventory extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "create_virtual_inventory";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1, 2, 3, 4};
+		}
+
+		@Override
+		public String docs() {
+			List<String> virtual = new ArrayList<>();
+			for(MCInventoryType type : MCInventoryType.values()) {
+				if(type.canVirtualize()) {
+					virtual.add(type.name());
+				}
+			}
+			return "void {id, [type/size], [title], [inventory]} Creates a virtual inventory and holds it under the"
+					+ " specified id. The string id should not be a UUID."
+					+ " If the id is already in use, an IllegalArgumentException will be thrown."
+					+ " You can use this id in other inventory functions to modify the contents, among other things."
+					+ " If a size is specified instead of a type, it is rounded up to the nearest multiple of 9."
+					+ " Size may be higher than 54, but the slots on the inventory background texture will not line up."
+					+ " A title for the top of the inventory may be given, but it will use the default for that"
+					+ " that inventory type if null is specified."
+					+ " An optional inventory array may be specified, otherwise the inventory will start empty."
+					+ " Available inventory types: " + StringUtils.Join(virtual, ", ", " or ", ", or ");
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			String id = args[0].val();
+			if(VIRTUAL_INVENTORIES.get(id) != null) {
+				throw new CREIllegalArgumentException("An inventory using the id \"" + id + "\" already exists.", t);
+			}
+
+			MCInventoryType type = null;
+			int size = 54;
+			String title = null;
+			if(args.length > 1) {
+				if(args[1] instanceof CNumber) {
+					size = Static.getInt32(args[1], t);
+					if(size < 9) {
+						size = 9; // minimum
+					} else {
+						size = (size + 8) / 9 * 9; // must be a multiple of 9
+					}
+				} else {
+					try {
+						type = MCInventoryType.valueOf(args[1].val().toUpperCase());
+					} catch (IllegalArgumentException iae) {
+						throw new CREIllegalArgumentException("Invalid inventory type: " + args[1].val().toUpperCase(), t);
+					}
+					if(!type.canVirtualize()) {
+						throw new CREIllegalArgumentException("Unable to create a virtual " + args[1].val().toUpperCase(), t);
+					}
+				}
+				if(args.length > 2) {
+					title = args[2].nval();
+				}
+			}
+
+			MCInventoryHolder holder = StaticLayer.GetConvertor().CreateInventoryHolder(id);
+			MCInventory inv;
+			if(type == null) {
+				inv = Static.getServer().createInventory(holder, size, title);
+			} else {
+				inv = Static.getServer().createInventory(holder, type, title);
+			}
+
+			if(args.length == 4) {
+				if(!(args[3] instanceof CArray)) {
+					throw new CRECastException("Inventory argument not an array in " + getName(), t);
+				}
+				CArray array = (CArray) args[3];
+				for(String key : array.stringKeySet()) {
+					try {
+						int index = Integer.parseInt(key);
+						if(index < 0 || index >= size) {
+							ConfigRuntimeException.DoWarning("Out of range value (" + index + ") found in array passed to "
+									+ getName() + "(), so ignoring.");
+						} else {
+							MCItemStack is = ObjectGenerator.GetGenerator().item(array.get(index, t), t);
+							inv.setItem(index, is);
+						}
+					} catch (NumberFormatException e) {
+						ConfigRuntimeException.DoWarning("Expecting integer value for key in array passed to "
+								+ getName() + "(), but \"" + key + "\" was found. Ignoring.");
+					}
+				}
+			}
+
+			VIRTUAL_INVENTORIES.put(id, inv);
+			return CVoid.VOID;
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CRERangeException.class, CRECastException.class, CREFormatException.class,
+					CREIllegalArgumentException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	@api
+	public static class delete_virtual_inventory extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "delete_virtual_inventory";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1};
+		}
+
+		@Override
+		public String docs() {
+			return "boolean {id} Deletes a virtual inventory. The inventory will be closed for all viewers."
+					+ " Returns whether or not an inventory with that id existed and was removed.";
+		}
+
+		@Override
+		public Construct exec(Target t, Environment env, Construct... args) throws ConfigRuntimeException {
+			String id = args[0].val();
+			MCInventory inv = VIRTUAL_INVENTORIES.get(id);
+			if(inv != null) {
+				for(MCHumanEntity viewer : inv.getViewers()) {
+					viewer.closeInventory();
+				}
+				VIRTUAL_INVENTORIES.remove(id);
+				return CBoolean.TRUE;
+			}
+			return CBoolean.FALSE;
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public CHVersion since() {
+			return CHVersion.V3_3_2;
+		}
+	}
+
+	public static final HashMap<String, MCInventory> VIRTUAL_INVENTORIES = new HashMap<>();
+
+	/**
+	 * Returns the inventory that this construct specifies.
+	 * @param specifier The construct representing the inventory holder, whether entity UUID, location array or virtual id.
+	 * @param t
+	 * @return
+	 */
 	private static MCInventory GetInventory(Construct specifier, MCWorld w, Target t) {
 		MCInventory inv;
 		if(specifier instanceof CArray) {
 			MCLocation l = ObjectGenerator.GetGenerator().location(specifier, w, t);
 			inv = StaticLayer.GetConvertor().GetLocationInventory(l);
-		} else {
-			MCEntity entity = Static.getEntity(specifier, t);
-			inv = StaticLayer.GetConvertor().GetEntityInventory(entity);
-		}
-		if(inv == null) {
-			throw new CREFormatException("The entity or location specified is not capable of having an inventory.", t);
-		} else {
+			if(inv == null) {
+				throw new CREIllegalArgumentException("The location specified is not capable of having an inventory.", t);
+			}
 			return inv;
 		}
+		if(specifier.val().length() == 36 || specifier.val().length() == 32) {
+			try {
+				MCEntity entity = Static.getEntity(specifier, t);
+				inv = StaticLayer.GetConvertor().GetEntityInventory(entity);
+				if(inv == null) {
+					throw new CREIllegalArgumentException("The entity specified is not capable of having an inventory.", t);
+				}
+				return inv;
+			} catch (CREFormatException iae) {
+				// not a UUID
+			}
+		}
+		inv = VIRTUAL_INVENTORIES.get(specifier.val());
+		if(inv == null) {
+			throw new CREIllegalArgumentException("An inventory for \"" + specifier.val() + "\" does not exist.", t);
+		}
+		return inv;
+	}
+
+	/**
+	 * Returns a construct representing an inventory's holder that can be used in inventory functions.
+	 * This returns CNull if this inventory does not have a holder or if it's a virtual inventory from another plugin.
+	 * @param inv
+	 * @param t
+	 * @return The construct representation of the inventory holder
+	 */
+	public static Construct GetInventoryHolder(MCInventory inv, Target t) {
+		MCInventoryHolder h = inv.getHolder();
+		if(h instanceof MCEntity) {
+			return new CString(((MCEntity) h).getUniqueId().toString(), t);
+		} else if(h instanceof MCBlockState) {
+			return ObjectGenerator.GetGenerator().location(((MCBlockState) h).getLocation(), false);
+		} else if(h instanceof MCDoubleChest) {
+			return ObjectGenerator.GetGenerator().location(((MCDoubleChest) h).getLocation(), false);
+		} else if(h instanceof MCVirtualInventoryHolder) {
+			return new CString(((MCVirtualInventoryHolder) h).getID(), t);
+		}
+		return CNull.NULL;
 	}
 
 	private static final String ITEM_MATCHING = " ---- The item array also serves as a map for what to compare."

--- a/src/main/java/com/laytonsmith/tools/Interpreter.java
+++ b/src/main/java/com/laytonsmith/tools/Interpreter.java
@@ -17,6 +17,7 @@ import com.laytonsmith.abstraction.MCEnchantment;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCFireworkBuilder;
 import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
@@ -990,6 +991,11 @@ public final class Interpreter {
 
 		@Override
 		public MCInventory GetLocationInventory(MCLocation location) {
+			throw new UnsupportedOperationException("This method is not supported from a shell.");
+		}
+
+		@Override
+		public MCInventoryHolder CreateInventoryHolder(String id) {
 			throw new UnsupportedOperationException("This method is not supported from a shell.");
 		}
 

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -15,6 +15,7 @@ import com.laytonsmith.abstraction.MCEnchantment;
 import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.abstraction.MCFireworkBuilder;
 import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCInventoryHolder;
 import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
@@ -777,6 +778,11 @@ public class StaticTest {
 
 		@Override
 		public MCInventory GetLocationInventory(MCLocation location) {
+			throw new UnsupportedOperationException("Not supported yet.");
+		}
+
+		@Override
+		public MCInventoryHolder CreateInventoryHolder(String id) {
 			throw new UnsupportedOperationException("Not supported yet.");
 		}
 


### PR DESCRIPTION
New functions: popen_inventory(), pviewing(), get_inventory_viewers(), get_virtual_inventories(), create_virtual_inventory(), and delete_virtual_inventory().
New "virtual" prefilter for inventory_click, inventory_drag, inventory_open, and inventory_close events.
New inventory "holder" data for inventory_open and inventory_close events.

So this is my attempt to bring virtual inventories to CommandHelper proper instead of having to rely on CHVirtualChests (and without breaking the extension). This allows us to use the same inventory functions and events for virtual inventories as we do for in-world inventories held by entities and blocks. I also used this opportunity to add some other useful functions: popen_inventory(), pviewing() and get_inventory_viewers(). This addresses a few tickets on the issue tracker. As always, I'm not entirely confident on the implementation and naming, so I'd love some feedback. 

I stuck with the "virtual" naming scheme used in CHVirtualChests since it's familiar to CommandHelper scripters, but deviated in other ways. For example, virtual inventories are no longer represented by a one dimensional array, but are instead created by a few function parameters. This makes persistence storing a little more verbose, but makes the overall functionality simpler and consistent.

Here's an example script that opens up a simple temporary inventory menu that runs the name of the item as a command:

```
@menu = array(
	1: array('name': 'STONE', 'meta': array('display': '/warp x')),
	2: array('name': 'SAND', 'meta': array('display': '/warp y')),
	3: array('name': 'DIRT', 'meta': array('display': '/warp z')),
);
create_virtual_inventory(player().'_warp_menu', 'HOPPER', 'Select a Warp:', @menu);
popen_inventory(player().'_warp_menu');

@clickBind = bind('inventory_click', null, array('virtual': true, 'player': player()), @event) {
	if(pviewing() == player().'_warp_menu') {
		cancel();
		run(@event['slotitem']['meta']['display']);
		play_sound(ploc(), array('sound': 'UI_BUTTON_CLICK'), player());
		close_pinv();
	}
}

bind('inventory_close', null, array('virtual': true), @event, @clickBind, @player = player()) {
	if(@player == player()) {
		unbind();
		unbind(@clickBind);
		delete_virtual_inventory(player().'_warp_menu');
		console('Debug: '.player().' closed '.@event['holder'], false);
	}
}
```
Here's some potential talking points:
- pviewing() returns null when it's a virtual inventory from another plugin (or if we were to create a virtual inventory without an id).
- You can't name a virtual id in the same format as an entity UUID since they're both strings when fetching an inventory by construct specifier.
- Unlike CHVirtualChests, when you create an inventory by the same id, it throws an exception instead of replacing it.
- The function and event key names are still up to debate.
- I could add an optional inventory array to popen_inventory(), but it wouldn't have an id, so you couldn't differentiate it from other virtual menus from other plugins.
- I filtered inventory types by those that can be opened and modified when virtual. However, I left redundant inventory types (eg. shulker box, which is essentially a chest). I could also filter those to make the list simpler.

Have any thoughts on these or anything else?