### PR TITLE
Fix non include file encoding to UTF-8

### DIFF
--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -34,7 +34,7 @@ import com.laytonsmith.persistence.io.ConnectionMixinFactory;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,6 +43,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -536,14 +537,14 @@ public class AliasCore {
 	 * @throws Exception if the file cannot be found
 	 */
 	public static String file_get_contents(String fileLocation) throws IOException {
-		BufferedReader in = new BufferedReader(new FileReader(fileLocation));
-		String ret = "";
-		String str;
-		while((str = in.readLine()) != null) {
-			ret += str + "\n";
+		StringBuilder ret = new StringBuilder();
+		try(BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(fileLocation), Charset.forName("UTF-8")))) {
+			String str;
+			while((str = in.readLine()) != null) {
+				ret.append(str).append('\n');
+			}
 		}
-		in.close();
-		return ret;
+		return ret.toString();
 	}
 
 	/**


### PR DESCRIPTION
CommandHelper reads auto_include.ms to UTF-8 but others not. (Maybe use OS default encoding)
That makes problem when using non english characters for example "한글".

In addition, `StreamUtils.GetSystemOut().println("Non english character")` prints broken character.
I reproduced that problems in my default OS encoding(x-windows-949)
