### PR TITLE
Add a Booleanish interface.

### DIFF
--- a/src/main/java/com/laytonsmith/core/CHLog.java
+++ b/src/main/java/com/laytonsmith/core/CHLog.java
@@ -254,7 +254,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void e(Tags modules, Throwable throwable, Target t) {
-		Log(modules, LogLevel.ERROR, StackTraceUtils.GetStacktrace(throwable), t);
+		Log(modules, LogLevel.ERROR, StackTraceUtils.GetStacktrace(throwable), t, true);
 	}
 
 	/**
@@ -265,7 +265,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void e(Tags modules, String message, Target t) {
-		Log(modules, LogLevel.ERROR, message, t);
+		Log(modules, LogLevel.ERROR, message, t, true);
 	}
 
 	/**
@@ -276,7 +276,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void w(Tags modules, String message, Target t) {
-		Log(modules, LogLevel.WARNING, message, t);
+		Log(modules, LogLevel.WARNING, message, t, true);
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void i(Tags modules, String message, Target t) {
-		Log(modules, LogLevel.INFO, message, t);
+		Log(modules, LogLevel.INFO, message, t, true);
 	}
 
 	/**
@@ -298,7 +298,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void d(Tags modules, String message, Target t) {
-		Log(modules, LogLevel.DEBUG, message, t);
+		Log(modules, LogLevel.DEBUG, message, t, true);
 	}
 
 	/**
@@ -309,7 +309,7 @@ public class CHLog {
 	 * @param t
 	 */
 	public void v(Tags modules, String message, Target t) {
-		Log(modules, LogLevel.VERBOSE, message, t);
+		Log(modules, LogLevel.VERBOSE, message, t, true);
 	}
 
 	public static class MsgBundle {

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -675,7 +675,7 @@ public class ObjectGenerator {
 						meta.setDamage(Static.getInt32(ma.get("damage", t), t));
 					}
 					if(ma.containsKey("unbreakable")) {
-						meta.setUnbreakable(Static.getBoolean(ma.get("unbreakable", t), t));
+						meta.setUnbreakable(ArgumentValidation.getBoolean(ma.get("unbreakable", t), t));
 					}
 				}
 
@@ -1256,13 +1256,13 @@ public class ObjectGenerator {
 					}
 				}
 				if(effect.containsKey("ambient")) {
-					ambient = Static.getBoolean(effect.get("ambient", t), t);
+					ambient = ArgumentValidation.getBoolean(effect.get("ambient", t), t);
 				}
 				if(effect.containsKey("particles")) {
-					particles = Static.getBoolean(effect.get("particles", t), t);
+					particles = ArgumentValidation.getBoolean(effect.get("particles", t), t);
 				}
 				if(effect.containsKey("icon")) {
-					icon = Static.getBoolean(effect.get("icon", t), t);
+					icon = ArgumentValidation.getBoolean(effect.get("icon", t), t);
 				}
 				ret.add(new MCLivingEntity.MCEffect(type, strength, (int) (seconds * 20), ambient, particles, icon));
 			} else {
@@ -1340,10 +1340,10 @@ public class ObjectGenerator {
 	public MCFireworkEffect fireworkEffect(CArray fe, Target t) {
 		MCFireworkBuilder builder = StaticLayer.GetConvertor().GetFireworkBuilder();
 		if(fe.containsKey("flicker")) {
-			builder.setFlicker(Static.getBoolean(fe.get("flicker", t), t));
+			builder.setFlicker(ArgumentValidation.getBoolean(fe.get("flicker", t), t));
 		}
 		if(fe.containsKey("trail")) {
-			builder.setTrail(Static.getBoolean(fe.get("trail", t), t));
+			builder.setTrail(ArgumentValidation.getBoolean(fe.get("trail", t), t));
 		}
 		if(fe.containsKey("colors")) {
 			Mixed colors = fe.get("colors", t);

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -245,16 +245,23 @@ public final class Static {
 	}
 
 	/**
-	 * Returns a boolean from any given construct. Depending on the type of the construct being converted, it follows
-	 * the following rules: If it is an integer or a double, it is false if 0, true otherwise. If it is a string, if it
-	 * is empty, it is false, otherwise it is true.
-	 *
+	 * Currently forwards the call to
+	 * {@link ArgumentValidation#getBooleanish},
+	 * to keep backwards compatible behavior, but will be removed in a future release. Explicitely use either
+	 * {@link ArgumentValidation#getBooleanish} or {@link ArgumentValidation#getBooleanObject}.
 	 * @param c
 	 * @param t
 	 * @return
+	 * @deprecated Use {@link ArgumentValidation#getBooleanish} for current behavior, or
+	 * {@link ArgumentValidation#getBooleanObject} for strict behavior. Note: While this is deprecated, and will be
+	 * removed from Static, it will not be removed until all the other methods that are duplicated here and in
+	 * {@link ArgumentValidation} are officially deprecated and removed, so there is no immediate need to backport older
+	 * code, as it will probably be easier to do it all at once later. However, new code should no longer use this
+	 * method. (Or any of the other methods that are duplicated.)
 	 */
+	@Deprecated
 	public static boolean getBoolean(Mixed c, Target t) {
-		return ArgumentValidation.getBoolean(c, t);
+		return ArgumentValidation.getBooleanish(c, t);
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.MEnum;
 import com.laytonsmith.annotations.typeof;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.LogLevel;
@@ -15,7 +16,7 @@ import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.ArrayHandling;
 import com.laytonsmith.core.functions.BasicLogic;
 import com.laytonsmith.core.functions.DataHandling;
-import com.laytonsmith.core.natives.interfaces.ArrayAccess;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -39,7 +40,8 @@ import java.util.TreeMap;
  * methods in this class, you need only to override the non-final ones for the same effect.
  */
 @typeof("ms.lang.array")
-public class CArray extends Construct implements ArrayAccess, Iterable<Mixed> {
+public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
+		com.laytonsmith.core.natives.interfaces.Iterable {
 
 	public static final CClassType TYPE = CClassType.get("ms.lang.array");
 	private boolean associativeMode = false;
@@ -887,11 +889,11 @@ public class CArray extends Construct implements ArrayAccess, Iterable<Mixed> {
 					}
 				}
 				if(o1 instanceof CBoolean || o2 instanceof CBoolean) {
-					if(Static.getBoolean(o1, Target.UNKNOWN) == Static.getBoolean(o2, Target.UNKNOWN)) {
+					if(ArgumentValidation.getBoolean(o1, Target.UNKNOWN) == ArgumentValidation.getBoolean(o2, Target.UNKNOWN)) {
 						return 0;
 					} else {
-						int oo1 = Static.getBoolean(o1, Target.UNKNOWN) ? 1 : 0;
-						int oo2 = Static.getBoolean(o2, Target.UNKNOWN) ? 1 : 0;
+						int oo1 = ArgumentValidation.getBoolean(o1, Target.UNKNOWN) ? 1 : 0;
+						int oo2 = ArgumentValidation.getBoolean(o2, Target.UNKNOWN) ? 1 : 0;
 						return (oo1 < oo2) ? -1 : 1;
 					}
 				}
@@ -910,13 +912,13 @@ public class CArray extends Construct implements ArrayAccess, Iterable<Mixed> {
 			}
 
 			public int compareRegular(Mixed o1, Mixed o2) {
-				if(Static.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o1), Target.UNKNOWN)
-						&& Static.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o2), Target.UNKNOWN)) {
+				if(ArgumentValidation.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o1), Target.UNKNOWN)
+						&& ArgumentValidation.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o2), Target.UNKNOWN)) {
 					return compareNumeric(o1, o2);
-				} else if(Static.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o1), Target.UNKNOWN)) {
+				} else if(ArgumentValidation.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o1), Target.UNKNOWN)) {
 					//The first is a number, the second is a string
 					return -1;
-				} else if(Static.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o2), Target.UNKNOWN)) {
+				} else if(ArgumentValidation.getBoolean(new DataHandling.is_numeric().exec(Target.UNKNOWN, null, o2), Target.UNKNOWN)) {
 					//The second is a number, the first is a string
 					return 1;
 				} else {
@@ -964,7 +966,12 @@ public class CArray extends Construct implements ArrayAccess, Iterable<Mixed> {
 
 	@Override
 	public CClassType[] getInterfaces() {
-		return new CClassType[]{ArrayAccess.TYPE};
+		return new CClassType[]{Booleanish.TYPE, com.laytonsmith.core.natives.interfaces.Iterable.TYPE};
+	}
+
+	@Override
+	public boolean getBooleanValue(Target t) {
+		return size() > 0;
 	}
 
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.ObjectModifier;
 import java.util.EnumSet;
 import java.util.Set;
@@ -11,7 +12,7 @@ import java.util.Set;
  * Represents a MethodScript boolean.
  */
 @typeof("ms.lang.boolean")
-public final class CBoolean extends CPrimitive implements Cloneable {
+public final class CBoolean extends CPrimitive implements Cloneable, Booleanish {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("ms.lang.boolean");
@@ -88,6 +89,13 @@ public final class CBoolean extends CPrimitive implements Cloneable {
 	public boolean getBoolean() {
 		return val;
 	}
+
+	@Override
+	public boolean getBooleanValue(Target t) {
+		return val;
+	}
+
+
 
 	/**
 	 * Negates this CBoolean.

--- a/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
@@ -3,7 +3,6 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.MSVersion;
-import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.ObjectModifier;
 import java.util.EnumSet;
 import java.util.Set;
@@ -12,7 +11,7 @@ import java.util.Set;
  * Represents a MethodScript boolean.
  */
 @typeof("ms.lang.boolean")
-public final class CBoolean extends CPrimitive implements Cloneable, Booleanish {
+public final class CBoolean extends CPrimitive implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("ms.lang.boolean");

--- a/src/main/java/com/laytonsmith/core/constructs/CClassType.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClassType.java
@@ -8,7 +8,6 @@ import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.exceptions.CRE.CREUnsupportedOperationException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import com.laytonsmith.core.natives.interfaces.ArrayAccess;
 import com.laytonsmith.core.natives.interfaces.MEnumType;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import java.util.Arrays;
@@ -27,7 +26,7 @@ import java.util.stream.Stream;
  */
 @typeof("ms.lang.ClassType")
 @SuppressWarnings("checkstyle:overloadmethodsdeclarationorder")
-public final class CClassType extends Construct implements ArrayAccess {
+public final class CClassType extends Construct implements com.laytonsmith.core.natives.interfaces.Iterable {
 
 	public static final String PATH_SEPARATOR = FullyQualifiedClassName.PATH_SEPARATOR;
 

--- a/src/main/java/com/laytonsmith/core/constructs/CDecimal.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CDecimal.java
@@ -83,4 +83,9 @@ public class CDecimal extends CPrimitive implements Cloneable {
 		return new CDecimal(val, getTarget());
 	}
 
+	@Override
+	public boolean getBooleanValue(Target t) {
+		return val.compareTo(new BigDecimal(0)) != 0;
+	}
+
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CDouble.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CDouble.java
@@ -72,4 +72,9 @@ public class CDouble extends CNumber implements Cloneable {
 		return new CDouble(val, getTarget());
 	}
 
+	@Override
+	public double getNumber() {
+		return val;
+	}
+
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CInt.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CInt.java
@@ -70,4 +70,10 @@ public class CInt extends CNumber implements Cloneable {
 	public CInt duplicate() {
 		return new CInt(val, getTarget());
 	}
+
+	@Override
+	public double getNumber() {
+		return (double) val;
+	}
+
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CNull.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CNull.java
@@ -3,12 +3,13 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 
 /**
  * Represents a MethodScript null value.
  */
 @typeof("null")
-public final class CNull extends Construct implements Cloneable {
+public final class CNull extends Construct implements Cloneable, Booleanish {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("null");
@@ -104,4 +105,11 @@ public final class CNull extends Construct implements Cloneable {
 	public CClassType[] getInterfaces() {
 		throw new RuntimeException("Cannot call getInterfaces on null");
 	}
+
+	@Override
+	public boolean getBooleanValue(Target t) {
+		return false;
+	}
+
+
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CNumber.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CNumber.java
@@ -39,4 +39,10 @@ public abstract class CNumber extends CPrimitive {
 		return MSVersion.V3_0_1;
 	}
 
+	public abstract double getNumber();
+
+	@Override
+	public boolean getBooleanValue(Target t) {
+		return getNumber() != 0.0;
+	}
 }

--- a/src/main/java/com/laytonsmith/core/constructs/CPrimitive.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CPrimitive.java
@@ -3,13 +3,14 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.ValueType;
 
 /**
  *
  */
 @typeof("ms.lang.primitive")
-public abstract class CPrimitive extends Construct implements ValueType {
+public abstract class CPrimitive extends Construct implements ValueType, Booleanish {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("ms.lang.primitive");

--- a/src/main/java/com/laytonsmith/core/constructs/CPrimitiveRunner.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CPrimitiveRunner.java
@@ -4,6 +4,7 @@ import com.laytonsmith.PureUtilities.Common.Annotations.InterfaceRunnerFor;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.natives.interfaces.AbstractMixedInterfaceRunner;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.natives.interfaces.ObjectType;
 import com.laytonsmith.core.natives.interfaces.ValueType;
@@ -17,7 +18,8 @@ public class CPrimitiveRunner extends AbstractMixedInterfaceRunner {
 
 	@Override
 	public String docs() {
-		return "A primitive is any non-object and non-array data type. All primitives are pass by value.";
+		return "A primitive is any non-object and non-array data type. All primitives are pass by value and"
+				+ " Booleanish.";
 	}
 
 	@Override
@@ -32,7 +34,7 @@ public class CPrimitiveRunner extends AbstractMixedInterfaceRunner {
 
 	@Override
 	public CClassType[] getInterfaces() {
-		return new CClassType[]{ValueType.TYPE};
+		return new CClassType[]{ValueType.TYPE, Booleanish.TYPE};
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/constructs/CString.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CString.java
@@ -2,12 +2,12 @@ package com.laytonsmith.core.constructs;
 
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
+import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CRERangeException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import com.laytonsmith.core.natives.interfaces.ArrayAccess;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.natives.interfaces.ObjectType;
 import java.util.AbstractSet;
@@ -19,7 +19,8 @@ import java.util.Set;
  *
  */
 @typeof("ms.lang.string")
-public class CString extends CPrimitive implements Cloneable, ArrayAccess {
+public class CString extends CPrimitive implements Cloneable,
+		com.laytonsmith.core.natives.interfaces.Iterable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("ms.lang.string");
@@ -156,7 +157,7 @@ public class CString extends CPrimitive implements Cloneable, ArrayAccess {
 
 	@Override
 	public CClassType[] getInterfaces() {
-		return new CClassType[]{ArrayAccess.TYPE};
+		return new CClassType[]{com.laytonsmith.core.natives.interfaces.Iterable.TYPE};
 	}
 
 	@Override
@@ -167,5 +168,15 @@ public class CString extends CPrimitive implements Cloneable, ArrayAccess {
 	@Override
 	public CString duplicate() {
 		return new CString(val(), getTarget());
+	}
+
+	@Override
+	public boolean getBooleanValue(Target t) {
+		if(val().equals("false")) {
+			CHLog.GetLogger().e(CHLog.Tags.FALSESTRING, "String \"false\" evaluates as true (non-empty strings are"
+					+ " true). This is most likely not what you meant to do. This warning can globally be disabled"
+					+ " with the logger-preferences.ini file.", t);
+		}
+		return val().length() > 0;
 	}
 }

--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -14,6 +14,7 @@ import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
 import com.laytonsmith.core.events.BoundEvent;
 import com.laytonsmith.core.exceptions.StackTraceManager;
 import com.laytonsmith.core.natives.interfaces.ArrayAccess;
+import com.laytonsmith.core.natives.interfaces.Iterator;
 import com.laytonsmith.core.profiler.Profiler;
 import com.laytonsmith.core.taskmanager.TaskManager;
 import com.laytonsmith.persistence.PersistenceNetwork;
@@ -56,7 +57,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	private final Profiles profiles;
 	private BoundEvent.ActiveEvent event = null;
 	private boolean interrupt = false;
-	private final List<ArrayAccess.ArrayAccessIterator> arrayAccessList = Collections.synchronizedList(new ArrayList<ArrayAccess.ArrayAccessIterator>());
+	private final List<Iterator> arrayAccessList = Collections.synchronizedList(new ArrayList<Iterator>());
 	private final MutableObject<TaskManager> taskManager = new MutableObject<>();
 	private final WeakHashMap<Thread, StackTraceManager> stackTraceManagers = new WeakHashMap<>();
 
@@ -344,7 +345,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	 *
 	 * @return
 	 */
-	public List<ArrayAccess.ArrayAccessIterator> GetArrayAccessIterators() {
+	public List<Iterator> GetArrayAccessIterators() {
 		return arrayAccessList;
 	}
 
@@ -354,10 +355,10 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	 * @param array
 	 * @return
 	 */
-	public List<ArrayAccess.ArrayAccessIterator> GetArrayAccessIteratorsFor(ArrayAccess array) {
-		List<ArrayAccess.ArrayAccessIterator> list = new ArrayList<>();
+	public List<Iterator> GetArrayAccessIteratorsFor(ArrayAccess array) {
+		List<Iterator> list = new ArrayList<>();
 		synchronized(arrayAccessList) {
-			for(ArrayAccess.ArrayAccessIterator value : arrayAccessList) {
+			for(Iterator value : arrayAccessList) {
 				if(value.underlyingArray() == array) {
 					list.add(value);
 				}

--- a/src/main/java/com/laytonsmith/core/events/Prefilters.java
+++ b/src/main/java/com/laytonsmith/core/events/Prefilters.java
@@ -2,6 +2,7 @@ package com.laytonsmith.core.events;
 
 import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
 import com.laytonsmith.abstraction.MCLocation;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.ObjectGenerator;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CBoolean;
@@ -152,7 +153,7 @@ public final class Prefilters {
 	}
 
 	private static void BooleanMatch(Mixed bool1, Mixed bool2) throws PrefilterNonMatchException {
-		if(Static.getBoolean(bool1, Target.UNKNOWN) != Static.getBoolean(bool2, Target.UNKNOWN)) {
+		if(ArgumentValidation.getBoolean(bool1, Target.UNKNOWN) != ArgumentValidation.getBoolean(bool2, Target.UNKNOWN)) {
 			throw new PrefilterNonMatchException();
 		}
 	}

--- a/src/main/java/com/laytonsmith/core/events/drivers/CmdlineEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/CmdlineEvents.java
@@ -5,8 +5,8 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.hide;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
-import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
 import com.laytonsmith.core.constructs.CInt;
@@ -155,7 +155,7 @@ public class CmdlineEvents {
 		@Override
 		public BindableEvent convert(CArray manualObject, Target t) {
 			CmdlinePromptInput cpi = new CmdlinePromptInput(manualObject.get("command", t).val(),
-					Static.getBoolean(manualObject.get("shellMode", t), t));
+					ArgumentValidation.getBoolean(manualObject.get("shellMode", t), t));
 			return cpi;
 		}
 

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -104,7 +104,7 @@ public class InventoryEvents {
 
 				if(prefilter.containsKey("virtual")) {
 					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
-					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+					if(isVirtual != ArgumentValidation.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
 						return false;
 					}
 				}
@@ -246,7 +246,7 @@ public class InventoryEvents {
 
 				if(prefilter.containsKey("virtual")) {
 					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
-					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+					if(isVirtual != ArgumentValidation.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
 						return false;
 					}
 				}
@@ -361,7 +361,7 @@ public class InventoryEvents {
 				MCInventoryOpenEvent e = (MCInventoryOpenEvent) event;
 				if(prefilter.containsKey("virtual")) {
 					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
-					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+					if(isVirtual != ArgumentValidation.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
 						return false;
 					}
 				}
@@ -443,7 +443,7 @@ public class InventoryEvents {
 				MCInventoryCloseEvent e = (MCInventoryCloseEvent) event;
 				if(prefilter.containsKey("virtual")) {
 					boolean isVirtual = e.getInventory().getHolder() instanceof MCVirtualInventoryHolder;
-					if(isVirtual != Static.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
+					if(isVirtual != ArgumentValidation.getBoolean(prefilter.get("virtual"), Target.UNKNOWN)) {
 						return false;
 					}
 				}

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -1318,10 +1318,10 @@ public class PlayerEvents {
 						e.setDeathMessage(Construct.nval(value));
 						return true;
 					case "keep_inventory":
-						e.setKeepInventory(Static.getBoolean(value, Target.UNKNOWN));
+						e.setKeepInventory(ArgumentValidation.getBoolean(value, Target.UNKNOWN));
 						return true;
 					case "keep_level":
-						e.setKeepLevel(Static.getBoolean(value, Target.UNKNOWN));
+						e.setKeepLevel(ArgumentValidation.getBoolean(value, Target.UNKNOWN));
 						return true;
 					case "new_exp":
 						e.setNewExp(Static.getInt32(value, Target.UNKNOWN));
@@ -2372,7 +2372,7 @@ public class PlayerEvents {
 						return true;
 					}
 				} else if(key.equalsIgnoreCase("signing")) {
-					((MCPlayerEditBookEvent) event).setSigning(Static.getBoolean(value, Target.UNKNOWN));
+					((MCPlayerEditBookEvent) event).setSigning(ArgumentValidation.getBoolean(value, Target.UNKNOWN));
 					return true;
 				} else {
 					return false;

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -322,11 +322,11 @@ public class VehicleEvents {
 			if(event instanceof MCVehicleEntityCollideEvent) {
 				MCVehicleEntityCollideEvent e = (MCVehicleEntityCollideEvent) event;
 				if(key.equals("collide")) {
-					e.setCollisionCancelled(!Static.getBoolean(value, Target.UNKNOWN));
+					e.setCollisionCancelled(!ArgumentValidation.getBoolean(value, Target.UNKNOWN));
 					return true;
 				}
 				if(key.equals("pickup")) {
-					e.setPickupCancelled(!Static.getBoolean(value, Target.UNKNOWN));
+					e.setPickupCancelled(!ArgumentValidation.getBoolean(value, Target.UNKNOWN));
 					return true;
 				}
 			}

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
@@ -196,11 +196,6 @@ public abstract class AbstractCREException extends ConfigRuntimeException implem
 	}
 
 	@Override
-	public long size() {
-		return exceptionObject.size();
-	}
-
-	@Override
 	public boolean isAssociative() {
 		return exceptionObject.isAssociative();
 	}

--- a/src/main/java/com/laytonsmith/core/exceptions/ConfigRuntimeException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/ConfigRuntimeException.java
@@ -6,6 +6,7 @@ import com.laytonsmith.PureUtilities.TermColors;
 import com.laytonsmith.abstraction.MCCommandSender;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.enums.MCChatColor;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.ObjectGenerator;
@@ -104,7 +105,7 @@ public class ConfigRuntimeException extends RuntimeException {
 					return Reaction.REPORT; // Closure returned null or scream-errors was set in the config.
 				} else {
 					// Closure returned a boolean. TRUE -> IGNORE and FALSE -> FATAL.
-					return (Static.getBoolean(ret, Target.UNKNOWN) ? Reaction.IGNORE : Reaction.FATAL);
+					return (ArgumentValidation.getBoolean(ret, Target.UNKNOWN) ? Reaction.IGNORE : Reaction.FATAL);
 				}
 			} catch (ConfigRuntimeException cre) {
 

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -82,7 +82,7 @@ public class BasicLogic {
 				__else = nodes[2];
 			}
 
-			if(Static.getBoolean(parent.seval(condition, env), t)) {
+			if(ArgumentValidation.getBoolean(parent.seval(condition, env), t)) {
 				return parent.seval(__if, env);
 			} else {
 				if(__else == null) {
@@ -155,7 +155,7 @@ public class BasicLogic {
 			}
 			if(args.get(0).isConst()) {
 				// We can optimize this one way or the other, since the condition is const
-				if(Static.getBoolean(args.get(0).getData(), t)) {
+				if(ArgumentValidation.getBoolean(args.get(0).getData(), t)) {
 					// It's true, return the true condition
 					return args.get(1);
 				} else // If there are three args, return the else condition, otherwise,
@@ -271,7 +271,7 @@ public class BasicLogic {
 				if(evalStatement instanceof CIdentifier) {
 					evalStatement = parent.seval(((CIdentifier) evalStatement).contained(), env);
 				}
-				if(Static.getBoolean(evalStatement, t)) {
+				if(ArgumentValidation.getBoolean(evalStatement, t)) {
 					Mixed ret = env.getEnv(GlobalEnv.class).GetScript().eval(code, env);
 					return ret;
 				}
@@ -796,8 +796,8 @@ public class BasicLogic {
 			if(Static.anyBooleans(args)) {
 				boolean equals = true;
 				for(int i = 1; i < args.length; i++) {
-					boolean arg1 = Static.getBoolean(args[i - 1], t);
-					boolean arg2 = Static.getBoolean(args[i], t);
+					boolean arg1 = ArgumentValidation.getBoolean(args[i - 1], t);
+					boolean arg2 = ArgumentValidation.getBoolean(args[i], t);
 					if(arg1 != arg2) {
 						equals = false;
 						break;
@@ -1136,8 +1136,8 @@ public class BasicLogic {
 			if(Static.anyBooleans(args)) {
 				boolean equals = true;
 				for(int i = 1; i < args.length; i++) {
-					boolean arg1 = Static.getBoolean(args[i - 1], t);
-					boolean arg2 = Static.getBoolean(args[i], t);
+					boolean arg1 = ArgumentValidation.getBoolean(args[i - 1], t);
+					boolean arg2 = ArgumentValidation.getBoolean(args[i], t);
 					if(arg1 != arg2) {
 						equals = false;
 						break;
@@ -1681,7 +1681,7 @@ public class BasicLogic {
 			//This will only happen if they hardcode true/false in, but we still
 			//need to handle it appropriately.
 			for(Mixed c : args) {
-				if(!Static.getBoolean(c, t)) {
+				if(!ArgumentValidation.getBoolean(c, t)) {
 					return CBoolean.FALSE;
 				}
 			}
@@ -1692,7 +1692,7 @@ public class BasicLogic {
 		public CBoolean execs(Target t, Environment env, Script parent, ParseTree... nodes) {
 			for(ParseTree tree : nodes) {
 				Mixed c = env.getEnv(GlobalEnv.class).GetScript().seval(tree, env);
-				boolean b = Static.getBoolean(c, t);
+				boolean b = ArgumentValidation.getBoolean(c, t);
 				if(b == false) {
 					return CBoolean.FALSE;
 				}
@@ -1749,7 +1749,7 @@ public class BasicLogic {
 					continue;
 				}
 				if(child.isConst()) {
-					if(Static.getBoolean(child.getData(), t) == true) {
+					if(ArgumentValidation.getBoolean(child.getData(), t) == true) {
 						it.remove();
 					} else {
 						foundFalse = true;
@@ -1773,7 +1773,7 @@ public class BasicLogic {
 //			}
 			// At this point, it could be that there are some conditions with side effects, followed by a final false. However,
 			// if false is the only remaining condition (which could be) then we can simply return false here.
-			if(children.size() == 1 && children.get(0).isConst() && Static.getBoolean(children.get(0).getData(), t) == false) {
+			if(children.size() == 1 && children.get(0).isConst() && ArgumentValidation.getBoolean(children.get(0).getData(), t) == false) {
 				return new ParseTree(CBoolean.FALSE, fileOptions);
 			}
 			if(children.isEmpty()) {
@@ -1830,7 +1830,7 @@ public class BasicLogic {
 		public Mixed execs(Target t, Environment env, Script parent, ParseTree... nodes) {
 			for(ParseTree tree : nodes) {
 				Mixed c = env.getEnv(GlobalEnv.class).GetScript().seval(tree, env);
-				if(!Static.getBoolean(c, t)) {
+				if(!ArgumentValidation.getBoolean(c, t)) {
 					return c;
 				}
 			}
@@ -1854,7 +1854,7 @@ public class BasicLogic {
 					continue;
 				}
 				if(child.isConst()) {
-					if(Static.getBoolean(child.getData(), t) == true) {
+					if(ArgumentValidation.getBoolean(child.getData(), t) == true) {
 						it.remove();
 					} else {
 						foundFalse = true;
@@ -1878,7 +1878,7 @@ public class BasicLogic {
 //			}
 			// At this point, it could be that there are some conditions with side effects, followed by a final false. However,
 			// if false is the only remaining condition (which could be) then we can simply return false here.
-			if(children.size() == 1 && children.get(0).isConst() && Static.getBoolean(children.get(0).getData(), t) == false) {
+			if(children.size() == 1 && children.get(0).isConst() && ArgumentValidation.getBoolean(children.get(0).getData(), t) == false) {
 				return new ParseTree(children.get(0).getData(), fileOptions);
 			}
 			if(children.isEmpty()) {
@@ -1937,7 +1937,7 @@ public class BasicLogic {
 			//This will only happen if they hardcode true/false in, but we still
 			//need to handle it appropriately.
 			for(Mixed c : args) {
-				if(Static.getBoolean(c, t)) {
+				if(ArgumentValidation.getBoolean(c, t)) {
 					return CBoolean.TRUE;
 				}
 			}
@@ -1948,7 +1948,7 @@ public class BasicLogic {
 		public CBoolean execs(Target t, Environment env, Script parent, ParseTree... nodes) {
 			for(ParseTree tree : nodes) {
 				Mixed c = env.getEnv(GlobalEnv.class).GetScript().seval(tree, env);
-				if(Static.getBoolean(c, t)) {
+				if(ArgumentValidation.getBoolean(c, t)) {
 					return CBoolean.TRUE;
 				}
 			}
@@ -2004,7 +2004,7 @@ public class BasicLogic {
 					continue;
 				}
 				if(child.isConst()) {
-					if(Static.getBoolean(child.getData(), t) == false) {
+					if(ArgumentValidation.getBoolean(child.getData(), t) == false) {
 						it.remove();
 					} else {
 						foundTrue = true;
@@ -2028,7 +2028,7 @@ public class BasicLogic {
 //			}
 			// At this point, it could be that there are some conditions with side effects, followed by a final true. However,
 			// if true is the only remaining condition (which could be) then we can simply return true here.
-			if(children.size() == 1 && children.get(0).isConst() && Static.getBoolean(children.get(0).getData(), t) == true) {
+			if(children.size() == 1 && children.get(0).isConst() && ArgumentValidation.getBoolean(children.get(0).getData(), t) == true) {
 				return new ParseTree(CBoolean.TRUE, fileOptions);
 			}
 			if(children.isEmpty()) {
@@ -2085,7 +2085,7 @@ public class BasicLogic {
 		public Mixed execs(Target t, Environment env, Script parent, ParseTree... nodes) {
 			for(ParseTree tree : nodes) {
 				Mixed c = env.getEnv(GlobalEnv.class).GetScript().seval(tree, env);
-				if(Static.getBoolean(c, t)) {
+				if(ArgumentValidation.getBoolean(c, t)) {
 					return c;
 				}
 			}
@@ -2109,7 +2109,7 @@ public class BasicLogic {
 					continue;
 				}
 				if(child.isConst()) {
-					if(Static.getBoolean(child.getData(), t) == false) {
+					if(ArgumentValidation.getBoolean(child.getData(), t) == false) {
 						it.remove();
 					} else {
 						foundTrue = true;
@@ -2133,7 +2133,7 @@ public class BasicLogic {
 //			}
 			// At this point, it could be that there are some conditions with side effects, followed by a final true. However,
 			// if true is the only remaining condition (which could be) then we can simply return true here.
-			if(children.size() == 1 && children.get(0).isConst() && Static.getBoolean(children.get(0).getData(), t) == true) {
+			if(children.size() == 1 && children.get(0).isConst() && ArgumentValidation.getBoolean(children.get(0).getData(), t) == true) {
 				return new ParseTree(children.get(0).getData(), fileOptions);
 			}
 			if(children.isEmpty()) {
@@ -2199,7 +2199,7 @@ public class BasicLogic {
 			if(args.length != 1) {
 				throw new CREFormatException(this.getName() + " expects 1 argument.", t);
 			}
-			return CBoolean.get(!Static.getBoolean(args[0], t));
+			return CBoolean.get(!ArgumentValidation.getBoolean(args[0], t));
 		}
 
 		@Override
@@ -2288,8 +2288,8 @@ public class BasicLogic {
 			if(args.length != 2) {
 				throw new CREFormatException(this.getName() + " expects 2 arguments.", t);
 			}
-			boolean val1 = Static.getBoolean(args[0], t);
-			boolean val2 = Static.getBoolean(args[1], t);
+			boolean val1 = ArgumentValidation.getBoolean(args[0], t);
+			boolean val2 = ArgumentValidation.getBoolean(args[1], t);
 			return CBoolean.get(val1 ^ val2);
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/BossBar.java
+++ b/src/main/java/com/laytonsmith/core/functions/BossBar.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.enums.MCBarColor;
 import com.laytonsmith.abstraction.enums.MCBarStyle;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
@@ -150,7 +151,7 @@ public class BossBar {
 					}
 				}
 				if(ca.containsKey("visible")) {
-					visible = Static.getBoolean(ca.get("visible", t), t);
+					visible = ArgumentValidation.getBoolean(ca.get("visible", t), t);
 				}
 				if(ca.containsKey("percent")) {
 					try {
@@ -233,7 +234,7 @@ public class BossBar {
 					}
 				}
 				if(ca.containsKey("visible")) {
-					bar.setVisible(Static.getBoolean(ca.get("visible", t), t));
+					bar.setVisible(ArgumentValidation.getBoolean(ca.get("visible", t), t));
 				}
 				if(ca.containsKey("percent")) {
 					try {

--- a/src/main/java/com/laytonsmith/core/functions/ByteArrays.java
+++ b/src/main/java/com/laytonsmith/core/functions/ByteArrays.java
@@ -4,6 +4,7 @@ import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.seealso;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CBoolean;
@@ -757,7 +758,7 @@ public class ByteArrays {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			CByteArray ba = Static.getByteArray(args[0], t);
-			boolean setLittle = Static.getBoolean(args[1], t);
+			boolean setLittle = ArgumentValidation.getBoolean(args[1], t);
 			ba.setOrder(setLittle ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
 			return CVoid.VOID;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -13,6 +13,7 @@ import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.noboilerplate;
 import com.laytonsmith.annotations.seealso;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Optimizable;
@@ -629,7 +630,7 @@ public class Cmdline {
 			}
 			boolean mask = true;
 			if(args.length > 1) {
-				mask = Static.getBoolean(args[1], t);
+				mask = ArgumentValidation.getBoolean(args[1], t);
 			}
 
 			String prompt = args[0].val();
@@ -978,7 +979,7 @@ public class Cmdline {
 				exit = (options.containsKey("exit") && !(options.get("exit", t) instanceof CNull)
 						? Static.getObject(options.get("exit", t), t, CClosure.class) : null);
 				subshell = (options.containsKey("subshell")
-						? Static.getBoolean(options.get("subshell", t), t) : false);
+						? ArgumentValidation.getBoolean(options.get("subshell", t), t) : false);
 			} else {
 				stdout = null;
 				stderr = null;
@@ -1487,7 +1488,7 @@ public class Cmdline {
 			}
 			boolean binary = false;
 			if(args.length > 0) {
-				binary = Static.getBoolean(args[0], t);
+				binary = ArgumentValidation.getBoolean(args[0], t);
 			}
 			try {
 				if(binary) {

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -68,7 +68,7 @@ import com.laytonsmith.core.exceptions.FunctionReturnException;
 import com.laytonsmith.core.exceptions.LoopBreakException;
 import com.laytonsmith.core.exceptions.LoopContinueException;
 import com.laytonsmith.core.exceptions.StackTraceManager;
-import com.laytonsmith.core.natives.interfaces.ArrayAccess;
+import com.laytonsmith.core.natives.interfaces.Iterator;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.tools.docgen.templates.ArrayIteration;
 import com.laytonsmith.tools.docgen.templates.Loops;
@@ -593,7 +593,7 @@ public class DataHandling {
 			}
 			int _continue = 0;
 			while(true) {
-				boolean cond = Static.getBoolean(parent.seval(condition, env), t);
+				boolean cond = ArgumentValidation.getBoolean(parent.seval(condition, env), t);
 				if(cond == false) {
 					break;
 				}
@@ -703,13 +703,14 @@ public class DataHandling {
 					arr = new ArrayHandling.range().exec(t, env, new CInt(start, t), new CInt(finish + 1, t));
 				}
 			}
-			if(!(arr instanceof ArrayAccess)) {
-				throw new CRECastException("Parameter 1 of " + getName() + " must be an array or array like data structure", t);
+			if(!(arr instanceof Iterable)) {
+				throw new CRECastException("Parameter 1 of " + getName() + " must be an Iterable data structure", t);
 			}
 			if(!(iv instanceof IVariable)) {
 				throw new CRECastException("Parameter " + (2 + offset) + " of " + getName() + " must be an ivariable", t);
 			}
-			ArrayAccess one = (ArrayAccess) arr;
+			com.laytonsmith.core.natives.interfaces.Iterable one
+				= (com.laytonsmith.core.natives.interfaces.Iterable) arr;
 			IVariable kkey = (IVariable) ik;
 			IVariable two = (IVariable) iv;
 			if(one.isAssociative()) {
@@ -762,8 +763,8 @@ public class DataHandling {
 				//is to avoid cloning the array, and iterating that. Arrays may be extremely large, and cloning the
 				//entire array is wasteful in that case. We are essentially tracking deltas this way, which prevents
 				//memory usage from getting out of hand.
-				ArrayAccess.ArrayAccessIterator iterator = new ArrayAccess.ArrayAccessIterator(one);
-				List<ArrayAccess.ArrayAccessIterator> arrayAccessList = env.getEnv(GlobalEnv.class).GetArrayAccessIterators();
+				Iterator iterator = new Iterator(one);
+				List<Iterator> arrayAccessList = env.getEnv(GlobalEnv.class).GetArrayAccessIterators();
 				try {
 					arrayAccessList.add(iterator);
 					int continues = 0;
@@ -1122,7 +1123,7 @@ public class DataHandling {
 		@Override
 		public Mixed execs(Target t, Environment env, Script parent, ParseTree... nodes) {
 			try {
-				while(Static.getBoolean(parent.seval(nodes[0], env), t)) {
+				while(ArgumentValidation.getBoolean(parent.seval(nodes[0], env), t)) {
 					//We allow while(thing()); to be done. This makes certain
 					//types of coding styles possible.
 					if(nodes.length > 1) {
@@ -1242,7 +1243,7 @@ public class DataHandling {
 					} catch (LoopContinueException e) {
 						//ok. No matter how many times it tells us to continue, we're only going to continue once.
 					}
-				} while(Static.getBoolean(parent.seval(nodes[1], env), t));
+				} while(ArgumentValidation.getBoolean(parent.seval(nodes[1], env), t));
 			} catch (LoopBreakException e) {
 				if(e.getTimes() > 1) {
 					throw new LoopBreakException(e.getTimes() - 1, t);
@@ -3368,7 +3369,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(Static.getBoolean(args[0], t));
+			return CBoolean.get(ArgumentValidation.getBoolean(args[0], t));
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/DataTransformations.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataTransformations.java
@@ -5,6 +5,7 @@ import com.laytonsmith.PureUtilities.XMLDocument;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.noboilerplate;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
@@ -168,7 +169,7 @@ public class DataTransformations {
 			CArray ca = Static.getArray(args[0], t);
 			boolean prettyPrint = false;
 			if(args.length == 2) {
-				prettyPrint = Static.getBoolean(args[1], t);
+				prettyPrint = ArgumentValidation.getBoolean(args[1], t);
 			}
 			DumperOptions options = new DumperOptions();
 			if(prettyPrint) {

--- a/src/main/java/com/laytonsmith/core/functions/Debug.java
+++ b/src/main/java/com/laytonsmith/core/functions/Debug.java
@@ -6,6 +6,7 @@ import com.laytonsmith.PureUtilities.TermColors;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.noboilerplate;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.MethodScriptFileLocations;
@@ -351,7 +352,7 @@ public class Debug {
 //			if(!(Boolean) Static.getPreferences().getPreference("allow-debug-logging")) {
 //				throw new ConfigRuntimeException("allow-debug-logging is currently set to false. To use " + this.getVariableName() + ", enable it in your preferences.", CRESecurityException.class, t);
 //			}
-//			boolean on = Static.getBoolean(args[0]);
+//			boolean on = ArgumentValidation.getBoolean(args[0]);
 //			int level = 1;
 //			if(args.length >= 2){
 //				level = Static.Normalize(Static.getInt32(args[1]), 1, 5);
@@ -359,7 +360,7 @@ public class Debug {
 //			Debug.EVENT_LOGGING = on;
 //			Debug.EVENT_LOGGING_LEVEL = level;
 //			if(args.length >= 3){
-//				Debug.LOG_TO_SCREEN = Static.getBoolean(args[2]);
+//				Debug.LOG_TO_SCREEN = ArgumentValidation.getBoolean(args[2]);
 //			}
 //			return CVoid.VOID;
 //		}
@@ -620,7 +621,7 @@ public class Debug {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			Script.debugOutput = Static.getBoolean(args[0], t);
+			Script.debugOutput = ArgumentValidation.getBoolean(args[0], t);
 			if(Script.debugOutput) {
 				StreamUtils.GetSystemOut().println(TermColors.BG_RED + "[[DEBUG]] set_debug_output(true)"
 						+ TermColors.RESET);

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -9,6 +9,7 @@ import com.laytonsmith.abstraction.MCServer;
 import com.laytonsmith.abstraction.enums.MCChatColor;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.noboilerplate;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Optimizable;
 import com.laytonsmith.core.Static;
@@ -742,7 +743,7 @@ public class Echoes {
 			String mes = Static.MCToANSIColors(args[0].val());
 			boolean prefix = true;
 			if(args.length > 1) {
-				prefix = Static.getBoolean(args[1], t);
+				prefix = ArgumentValidation.getBoolean(args[1], t);
 			}
 			if(prefix) {
 				mes = "CommandHelper: " + mes;

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1498,7 +1498,7 @@ public class EntityManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			try {
-				Static.getEntity(args[0], t).setCustomNameVisible(Static.getBoolean(args[1], t));
+				Static.getEntity(args[0], t).setCustomNameVisible(ArgumentValidation.getBoolean(args[1], t));
 			} catch (IllegalArgumentException e) {
 				throw new CRECastException(e.getMessage(), t);
 			}
@@ -2239,7 +2239,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ARROW_CRITICAL:
-								arrow.setCritical(Static.getBoolean(specArray.get(index, t), t));
+								arrow.setCritical(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARROW_KNOCKBACK:
 								int k = Static.getInt32(specArray.get(index, t), t);
@@ -2259,22 +2259,22 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ARMORSTAND_ARMS:
-								stand.setHasArms(Static.getBoolean(specArray.get(index, t), t));
+								stand.setHasArms(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_BASEPLATE:
-								stand.setHasBasePlate(Static.getBoolean(specArray.get(index, t), t));
+								stand.setHasBasePlate(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_GRAVITY:
-								stand.setHasGravity(Static.getBoolean(specArray.get(index, t), t));
+								stand.setHasGravity(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_MARKER:
-								stand.setMarker(Static.getBoolean(specArray.get(index, t), t));
+								stand.setMarker(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_SMALLSIZE:
-								stand.setSmall(Static.getBoolean(specArray.get(index, t), t));
+								stand.setSmall(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_VISIBLE:
-								stand.setVisible(Static.getBoolean(specArray.get(index, t), t));
+								stand.setVisible(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARMORSTAND_POSES:
 								Map<MCBodyPart, Vector3D> poseMap = stand.getAllPoses();
@@ -2320,7 +2320,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_CREEPER_POWERED:
-								creeper.setPowered(Static.getBoolean(specArray.get(index, t), t));
+								creeper.setPowered(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_CREEPER_MAXFUSETICKS:
 								try {
@@ -2347,7 +2347,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_HORSE_CHEST:
-								chestedhorse.setHasChest(Static.getBoolean(specArray.get(index, t), t));
+								chestedhorse.setHasChest(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_HORSE_JUMP:
 								try {
@@ -2394,7 +2394,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ENDERCRYSTAL_BASE:
-								endercrystal.setShowingBottom(Static.getBoolean(specArray.get(index, t), t));
+								endercrystal.setShowingBottom(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ENDERCRYSTAL_BEAMTARGET:
 								Mixed c = specArray.get(index, t);
@@ -2445,7 +2445,7 @@ public class EntityManagement {
 								endereye.setDespawnTicks(Static.getInt32(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ENDEREYE_DROP:
-								endereye.setDropItem(Static.getBoolean(specArray.get(index, t), t));
+								endereye.setDropItem(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ENDEREYE_TARGET:
 								break;
@@ -2501,10 +2501,10 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_FALLING_BLOCK_DROPITEM:
-								block.setDropItem(Static.getBoolean(specArray.get(index, t), t));
+								block.setDropItem(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_FALLING_BLOCK_DAMAGE:
-								block.setHurtEntities(Static.getBoolean(specArray.get(index, t), t));
+								block.setHurtEntities(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2576,7 +2576,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ZOMBIE_BABY:
-								husk.setBaby(Static.getBoolean(specArray.get(index, t), t));
+								husk.setBaby(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2588,7 +2588,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_IRON_GOLEM_PLAYERCREATED:
-								golem.setPlayerCreated(Static.getBoolean(specArray.get(index, t), t));
+								golem.setPlayerCreated(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2631,7 +2631,7 @@ public class EntityManagement {
 								}
 								break;
 							case entity_spec.KEY_HORSE_CHEST:
-								llama.setHasChest(Static.getBoolean(specArray.get(index, t), t));
+								llama.setHasChest(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_HORSE_DOMESTICATION:
 								try {
@@ -2722,7 +2722,7 @@ public class EntityManagement {
 								}
 								break;
 							case entity_spec.KEY_OCELOT_SITTING:
-								ocelot.setSitting(Static.getBoolean(specArray.get(index, t), t));
+								ocelot.setSitting(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2750,7 +2750,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_PARROT_SITTING:
-								parrot.setSitting(Static.getBoolean(specArray.get(index, t), t));
+								parrot.setSitting(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_PARROT_TYPE:
 								try {
@@ -2769,7 +2769,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_PIG_SADDLED:
-								pig.setSaddled(Static.getBoolean(specArray.get(index, t), t));
+								pig.setSaddled(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2781,10 +2781,10 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ZOMBIE_BABY:
-								pigZombie.setBaby(Static.getBoolean(specArray.get(index, t), t));
+								pigZombie.setBaby(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_PIG_ZOMBIE_ANGRY:
-								pigZombie.setAngry(Static.getBoolean(specArray.get(index, t), t));
+								pigZombie.setAngry(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_PIG_ZOMBIE_ANGER:
 								pigZombie.setAnger(Static.getInt32(specArray.get(index, t), t));
@@ -2834,7 +2834,7 @@ public class EntityManagement {
 								}
 								break;
 							case entity_spec.KEY_SHEEP_SHEARED:
-								sheep.setSheared(Static.getBoolean(specArray.get(index, t), t));
+								sheep.setSheared(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2909,7 +2909,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_SNOWMAN_DERP:
-								snowman.setDerp(Static.getBoolean(specArray.get(index, t), t));
+								snowman.setDerp(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -2939,7 +2939,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ARROW_CRITICAL:
-								tippedarrow.setCritical(Static.getBoolean(specArray.get(index, t), t));
+								tippedarrow.setCritical(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_ARROW_KNOCKBACK:
 								int k = Static.getInt32(specArray.get(index, t), t);
@@ -3030,7 +3030,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_WITHER_SKULL_CHARGED:
-								skull.setCharged(Static.getBoolean(specArray.get(index, t), t));
+								skull.setCharged(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_FIREBALL_DIRECTION:
 								skull.setDirection(ObjectGenerator.GetGenerator().vector(specArray.get(index, t), t));
@@ -3045,7 +3045,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_WOLF_ANGRY:
-								wolf.setAngry(Static.getBoolean(specArray.get(index, t), t));
+								wolf.setAngry(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_WOLF_COLOR:
 								try {
@@ -3055,7 +3055,7 @@ public class EntityManagement {
 								}
 								break;
 							case entity_spec.KEY_WOLF_SITTING:
-								wolf.setSitting(Static.getBoolean(specArray.get(index, t), t));
+								wolf.setSitting(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -3067,7 +3067,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ZOMBIE_BABY:
-								zombie.setBaby(Static.getBoolean(specArray.get(index, t), t));
+								zombie.setBaby(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							default:
 								throwException(index, t);
@@ -3079,7 +3079,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ZOMBIE_BABY:
-								zombievillager.setBaby(Static.getBoolean(specArray.get(index, t), t));
+								zombievillager.setBaby(ArgumentValidation.getBoolean(specArray.get(index, t), t));
 								break;
 							case entity_spec.KEY_VILLAGER_PROFESSION:
 								try {
@@ -3235,7 +3235,7 @@ public class EntityManagement {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCEntity entity = Static.getEntity(args[0], t);
 			if(entity instanceof MCProjectile) {
-				((MCProjectile) entity).setBounce(Static.getBoolean(args[1], t));
+				((MCProjectile) entity).setBounce(ArgumentValidation.getBoolean(args[1], t));
 			} else {
 				throw new CREBadEntityException("The given entity is not a projectile.", t);
 			}
@@ -3312,7 +3312,7 @@ public class EntityManagement {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			Static.getEntity(args[0], t).setGlowing(Static.getBoolean(args[1], t));
+			Static.getEntity(args[0], t).setGlowing(ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -3387,7 +3387,7 @@ public class EntityManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCEntity e = Static.getEntity(args[0], t);
-			e.setSilent(Static.getBoolean(args[1], t));
+			e.setSilent(ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -3437,7 +3437,7 @@ public class EntityManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCEntity e = Static.getEntity(args[0], t);
-			e.setHasGravity(Static.getBoolean(args[1], t));
+			e.setHasGravity(ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -3488,7 +3488,7 @@ public class EntityManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCEntity e = Static.getEntity(args[0], t);
-			e.setInvulnerable(Static.getBoolean(args[1], t));
+			e.setInvulnerable(ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -3649,7 +3649,7 @@ public class EntityManagement {
 				return CNull.NULL;
 			}
 			if(args.length == 3) {
-				natural = Static.getBoolean(args[2], t);
+				natural = ArgumentValidation.getBoolean(args[2], t);
 			}
 			MCItem item;
 			if(natural) {

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -23,6 +23,7 @@ import com.laytonsmith.abstraction.enums.MCTreeType;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.hide;
 import com.laytonsmith.annotations.noboilerplate;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ObjectGenerator;
@@ -141,7 +142,7 @@ public class Environment {
 			MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], null, t);
 			boolean physics = true;
 			if(args.length == 3) {
-				physics = Static.getBoolean(args[2], t);
+				physics = ArgumentValidation.getBoolean(args[2], t);
 			}
 			MCMaterial mat = StaticLayer.GetMaterial(args[1].val());
 			if(mat == null) {
@@ -260,7 +261,7 @@ public class Environment {
 			}
 			boolean physics = true;
 			if(args.length == 3) {
-				physics = Static.getBoolean(args[2], t);
+				physics = ArgumentValidation.getBoolean(args[2], t);
 			}
 			b.setBlockData(bd, physics);
 			return CVoid.VOID;
@@ -450,7 +451,7 @@ public class Environment {
 				w = l.getWorld();
 				id = args[1].val();
 				if(args.length == 3) {
-					physics = Static.getBoolean(args[2], t);
+					physics = ArgumentValidation.getBoolean(args[2], t);
 				}
 
 			} else {
@@ -464,7 +465,7 @@ public class Environment {
 						throw new CREInvalidWorldException("The specified world " + args[4].val() + " doesn't exist", t);
 					}
 					if(args.length == 6) {
-						physics = Static.getBoolean(args[5], t);
+						physics = ArgumentValidation.getBoolean(args[5], t);
 					}
 				} else if(w == null) {
 					throw new CREInvalidWorldException("No world was provided", t);
@@ -1071,7 +1072,7 @@ public class Environment {
 			boolean safe = false;
 
 			if(args.length >= 3) {
-				safe = Static.getBoolean(args[2], t);
+				safe = ArgumentValidation.getBoolean(args[2], t);
 			}
 			if(args.length >= 2) {
 				if(!(args[1] instanceof CNull)) {

--- a/src/main/java/com/laytonsmith/core/functions/EventBinding.java
+++ b/src/main/java/com/laytonsmith/core/functions/EventBinding.java
@@ -4,11 +4,11 @@ import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Optimizable;
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Script;
-import com.laytonsmith.core.Static;
 import com.laytonsmith.core.compiler.FileOptions;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
@@ -374,7 +374,7 @@ public class EventBinding {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			boolean cancelled = true;
 			if(args.length == 1) {
-				cancelled = Static.getBoolean(args[0], t);
+				cancelled = ArgumentValidation.getBoolean(args[0], t);
 			}
 
 			BoundEvent.ActiveEvent original = environment.getEnv(GlobalEnv.class).GetEvent();
@@ -496,7 +496,7 @@ public class EventBinding {
 			}
 			boolean serverWide = false;
 			if(args.length == 3) {
-				serverWide = Static.getBoolean(args[2], t);
+				serverWide = ArgumentValidation.getBoolean(args[2], t);
 			}
 			EventUtils.ManualTrigger(args[0].val(), obj, t, serverWide);
 			return CVoid.VOID;
@@ -557,7 +557,7 @@ public class EventBinding {
 			Mixed value = args[1];
 			boolean throwOnFailure = false;
 			if(args.length == 3) {
-				throwOnFailure = Static.getBoolean(args[3], t);
+				throwOnFailure = ArgumentValidation.getBoolean(args[3], t);
 			}
 			if(environment.getEnv(GlobalEnv.class).GetEvent() == null) {
 				throw new CREBindException(this.getName() + " must be called from within an event handler", t);

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -12,6 +12,7 @@ import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.noboilerplate;
 import com.laytonsmith.core.AliasCore;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.LogLevel;
@@ -778,10 +779,10 @@ public class Meta {
 			if(args.length == 1) {
 				player = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
 				Static.AssertPlayerNonNull(player, t);
-				state = Static.getBoolean(args[0], t);
+				state = ArgumentValidation.getBoolean(args[0], t);
 			} else {
 				player = Static.GetPlayer(args[0].val(), t);
-				state = Static.getBoolean(args[1], t);
+				state = ArgumentValidation.getBoolean(args[1], t);
 			}
 			player.setOp(state);
 			return CVoid.VOID;

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -1031,7 +1031,7 @@ public class Minecraft {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCServer s = Static.getServer();
 			String ip = args[0].val();
-			if(Static.getBoolean(args[1], t)) {
+			if(ArgumentValidation.getBoolean(args[1], t)) {
 				s.banIP(ip);
 			} else {
 				s.unbanIP(ip);
@@ -1272,7 +1272,7 @@ public class Minecraft {
 			MCLocation location = ObjectGenerator.GetGenerator().location(args[0], world, t);
 			boolean add = true;
 			if(args.length > 1) {
-				add = Static.getBoolean(args[1], t);
+				add = ArgumentValidation.getBoolean(args[1], t);
 			}
 			Map<MCLocation, Boolean> redstoneMonitors = ServerEvents.getRedstoneMonitors();
 			if(add) {

--- a/src/main/java/com/laytonsmith/core/functions/MobManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/MobManagement.java
@@ -27,6 +27,7 @@ import com.laytonsmith.abstraction.enums.MCWolfType;
 import com.laytonsmith.abstraction.enums.MCZombieType;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.hide;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ObjectGenerator;
@@ -517,7 +518,7 @@ public class MobManagement {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			boolean breed = Static.getBoolean(args[1], t);
+			boolean breed = ArgumentValidation.getBoolean(args[1], t);
 
 			MCEntity ent = Static.getEntity(args[0], t);
 
@@ -599,7 +600,7 @@ public class MobManagement {
 			int age = Static.getInt32(args[1], t);
 			boolean lock = false;
 			if(args.length == 3) {
-				lock = Static.getBoolean(args[2], t);
+				lock = ArgumentValidation.getBoolean(args[2], t);
 			}
 			MCLivingEntity ent = Static.getLivingEntity(args[0], t);
 			if(ent == null) {
@@ -742,13 +743,13 @@ public class MobManagement {
 					}
 
 					if(args.length >= 5) {
-						ambient = Static.getBoolean(args[4], t);
+						ambient = ArgumentValidation.getBoolean(args[4], t);
 
 						if(args.length >= 6) {
-							particles = Static.getBoolean(args[5], t);
+							particles = ArgumentValidation.getBoolean(args[5], t);
 
 							if(args.length == 7) {
-								icon = Static.getBoolean(args[6], t);
+								icon = ArgumentValidation.getBoolean(args[6], t);
 							}
 						}
 					}
@@ -1108,7 +1109,7 @@ public class MobManagement {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			Static.getLivingEntity(args[0], t).setCanPickupItems(Static.getBoolean(args[1], t));
+			Static.getLivingEntity(args[0], t).setCanPickupItems(ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -1158,7 +1159,7 @@ public class MobManagement {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			Static.getLivingEntity(args[0], t).setRemoveWhenFarAway(!Static.getBoolean(args[1], t));
+			Static.getLivingEntity(args[0], t).setRemoveWhenFarAway(!ArgumentValidation.getBoolean(args[1], t));
 			return CVoid.VOID;
 		}
 
@@ -1522,7 +1523,7 @@ public class MobManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCLivingEntity e = Static.getLivingEntity(args[0], t);
-			boolean glide = Static.getBoolean(args[1], t);
+			boolean glide = ArgumentValidation.getBoolean(args[1], t);
 
 			e.setGliding(glide);
 
@@ -1599,7 +1600,7 @@ public class MobManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCLivingEntity e = Static.getLivingEntity(args[0], t);
-			boolean ai = Static.getBoolean(args[1], t);
+			boolean ai = ArgumentValidation.getBoolean(args[1], t);
 
 			e.setAI(ai);
 
@@ -1652,7 +1653,7 @@ public class MobManagement {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCLivingEntity e = Static.getLivingEntity(args[0], t);
-			boolean collidable = Static.getBoolean(args[1], t);
+			boolean collidable = ArgumentValidation.getBoolean(args[1], t);
 			e.setCollidable(collidable);
 			return CVoid.VOID;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/Performance.java
+++ b/src/main/java/com/laytonsmith/core/functions/Performance.java
@@ -1,6 +1,7 @@
 package com.laytonsmith.core.functions;
 
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Prefs;
 import com.laytonsmith.core.Static;
@@ -86,7 +87,7 @@ public class Performance {
 			if(!Prefs.AllowProfiling()) {
 				throw new CRESecurityException("allow-profiling is currently off, you must set it to true in your preferences.", t);
 			}
-			performanceLogging = Static.getBoolean(args[0], t);
+			performanceLogging = ArgumentValidation.getBoolean(args[0], t);
 			return CVoid.VOID;
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -26,6 +26,7 @@ import com.laytonsmith.abstraction.enums.MCWeather;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.seealso;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.LogLevel;
@@ -193,7 +194,7 @@ public class PlayerManagement {
 				}
 			}
 			if(args.length == 2) {
-				dashless = Static.getBoolean(args[1], t);
+				dashless = ArgumentValidation.getBoolean(args[1], t);
 			}
 			if(pl == null) {
 				throw new CREPlayerOfflineException("No matching player could be found.", t);
@@ -2211,13 +2212,13 @@ public class PlayerManagement {
 					}
 
 					if(args.length >= 5) {
-						ambient = Static.getBoolean(args[4], t);
+						ambient = ArgumentValidation.getBoolean(args[4], t);
 
 						if(args.length >= 6) {
-							particles = Static.getBoolean(args[5], t);
+							particles = ArgumentValidation.getBoolean(args[5], t);
 
 							if(args.length == 7) {
-								icon = Static.getBoolean(args[6], t);
+								icon = ArgumentValidation.getBoolean(args[6], t);
 							}
 						}
 					}
@@ -2663,7 +2664,7 @@ public class PlayerManagement {
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			MCOfflinePlayer pl = Static.GetUser(args[0].val(), t);
-			boolean whitelist = Static.getBoolean(args[1], t);
+			boolean whitelist = ArgumentValidation.getBoolean(args[1], t);
 			if(pl == null) {
 				throw new CRENotFoundException(
 						this.getName() + " could not get the offline player (are you running in cmdline mode?)", t);
@@ -2781,7 +2782,7 @@ public class PlayerManagement {
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			String target = args[0].val();
-			boolean ban = Static.getBoolean(args[1], t);
+			boolean ban = ArgumentValidation.getBoolean(args[1], t);
 			String reason = "";
 			String source = "";
 
@@ -3415,10 +3416,10 @@ public class PlayerManagement {
 			MCPlayer p = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
 			boolean flight;
 			if(args.length == 1) {
-				flight = Static.getBoolean(args[0], t);
+				flight = ArgumentValidation.getBoolean(args[0], t);
 			} else {
 				p = Static.GetPlayer(args[0], t);
-				flight = Static.getBoolean(args[1], t);
+				flight = ArgumentValidation.getBoolean(args[1], t);
 			}
 			Static.AssertPlayerNonNull(p, t);
 			p.setAllowFlight(flight);
@@ -3506,7 +3507,7 @@ public class PlayerManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 			if(args.length == 3) {
-				relative = Static.getBoolean(args[2], t);
+				relative = ArgumentValidation.getBoolean(args[2], t);
 			}
 			Static.AssertPlayerNonNull(p, t);
 			long time = 0;
@@ -3737,7 +3738,7 @@ public class PlayerManagement {
 			Static.AssertPlayerNonNull(m, t);
 			if(args[offset] instanceof CNull) {
 				m.resetPlayerWeather();
-			} else if(Static.getBoolean(args[offset], t)) {
+			} else if(ArgumentValidation.getBoolean(args[offset], t)) {
 				m.setPlayerWeather(MCWeather.DOWNFALL);
 			} else {
 				m.setPlayerWeather(MCWeather.CLEAR);
@@ -4521,7 +4522,7 @@ public class PlayerManagement {
 						m = ((MCPlayer) p);
 					}
 					locationIndex = 0;
-					forced = Static.getBoolean(args[1], t);
+					forced = ArgumentValidation.getBoolean(args[1], t);
 				} else {
 					throw new CRECastException("Expecting an array in set_pbed_location", t);
 				}
@@ -4529,7 +4530,7 @@ public class PlayerManagement {
 				if(args[1] instanceof CArray) {
 					pname = args[0].val();
 					locationIndex = 1;
-					forced = Static.getBoolean(args[2], t);
+					forced = ArgumentValidation.getBoolean(args[2], t);
 				} else {
 					if(p instanceof MCPlayer) {
 						m = (MCPlayer) p;
@@ -4545,12 +4546,12 @@ public class PlayerManagement {
 						m = (MCPlayer) p;
 					}
 					locationIndex = 0;
-					forced = Static.getBoolean(args[3], t);
+					forced = ArgumentValidation.getBoolean(args[3], t);
 				}
 			} else {
 				m = Static.GetPlayer(args[0], t);
 				locationIndex = 1;
-				forced = Static.getBoolean(args[4], t);
+				forced = ArgumentValidation.getBoolean(args[4], t);
 			}
 
 			if(m == null && pname != null) {
@@ -5067,10 +5068,10 @@ public class PlayerManagement {
 			MCPlayer p = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
 			boolean flight;
 			if(args.length == 1) {
-				flight = Static.getBoolean(args[0], t);
+				flight = ArgumentValidation.getBoolean(args[0], t);
 			} else {
 				p = Static.GetPlayer(args[0], t);
-				flight = Static.getBoolean(args[1], t);
+				flight = ArgumentValidation.getBoolean(args[1], t);
 			}
 			Static.AssertPlayerNonNull(p, t);
 			if(!p.getAllowFlight()) {

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.seealso;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.LogLevel;
@@ -202,7 +203,7 @@ public class SQL {
 							} else if(params[i] instanceof CByteArray) {
 								ps.setBytes(i + 1, ((CByteArray) params[i]).asByteArrayCopy());
 							} else if(params[i] instanceof CBoolean) {
-								ps.setBoolean(i + 1, Static.getBoolean(params[i], t));
+								ps.setBoolean(i + 1, ArgumentValidation.getBoolean(params[i], t));
 							} else {
 								throw new CRECastException("The type " + params[i].getClass().getSimpleName()
 										+ " of parameter " + (i + 1) + " is not supported.", t);

--- a/src/main/java/com/laytonsmith/core/functions/Sandbox.java
+++ b/src/main/java/com/laytonsmith/core/functions/Sandbox.java
@@ -162,11 +162,11 @@ public class Sandbox {
 			MCPlayer other;
 			if(args.length == 2) {
 				me = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
-				isVanished = Static.getBoolean(args[0], t);
+				isVanished = ArgumentValidation.getBoolean(args[0], t);
 				other = Static.GetPlayer(args[1], t);
 			} else {
 				me = Static.GetPlayer(args[0], t);
-				isVanished = Static.getBoolean(args[1], t);
+				isVanished = ArgumentValidation.getBoolean(args[1], t);
 				other = Static.GetPlayer(args[2], t);
 			}
 

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -12,6 +12,7 @@ import com.laytonsmith.abstraction.enums.MCDisplaySlot;
 import com.laytonsmith.abstraction.enums.MCOption;
 import com.laytonsmith.abstraction.enums.MCOptionStatus;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.NotInitializedYetException;
@@ -920,7 +921,7 @@ public class Scoreboards {
 			String id = args[0].val();
 			boolean nullify = true;
 			if(args.length == 2) {
-				nullify = Static.getBoolean(args[1], t);
+				nullify = ArgumentValidation.getBoolean(args[1], t);
 			}
 			if(nullify) {
 				MCScoreboard s = getBoard(id, t);
@@ -1175,10 +1176,10 @@ public class Scoreboards {
 			if(args[1] instanceof CArray) {
 				CArray options = (CArray) args[1];
 				if(options.containsKey("friendlyfire")) {
-					team.setAllowFriendlyFire(Static.getBoolean(options.get("friendlyfire", t), t));
+					team.setAllowFriendlyFire(ArgumentValidation.getBoolean(options.get("friendlyfire", t), t));
 				}
 				if(options.containsKey("friendlyinvisibles")) {
-					team.setCanSeeFriendlyInvisibles(Static.getBoolean(options.get("friendlyinvisibles", t), t));
+					team.setCanSeeFriendlyInvisibles(ArgumentValidation.getBoolean(options.get("friendlyinvisibles", t), t));
 				}
 				if(options.containsKey("nametagvisibility")) {
 					MCOptionStatus namevisibility;

--- a/src/main/java/com/laytonsmith/core/functions/StringHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/StringHandling.java
@@ -356,7 +356,7 @@ public class StringHandling {
 			String string = args[0].val();
 			boolean useAdvanced = false;
 			if(args.length >= 2) {
-				useAdvanced = Static.getBoolean(args[1], t);
+				useAdvanced = ArgumentValidation.getBoolean(args[1], t);
 			}
 			List<Mixed> a = new ArrayList<>();
 			if(!useAdvanced) {
@@ -1402,7 +1402,7 @@ public class StringHandling {
 					//Further processing is needed
 					if(c == Conversion.BOOLEAN || c == Conversion.BOOLEAN_UPPER) {
 						//Boolean, parse as such
-						o = Static.getBoolean(arg, t);
+						o = ArgumentValidation.getBoolean(arg, t);
 					} else {
 						//Else it's either a string or a hash code, in which case
 						//we will treat it as a string anyways

--- a/src/main/java/com/laytonsmith/core/functions/Trades.java
+++ b/src/main/java/com/laytonsmith/core/functions/Trades.java
@@ -10,6 +10,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.entities.MCVillager;
 import com.laytonsmith.abstraction.enums.MCRecipeType;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ObjectGenerator;
 import com.laytonsmith.core.Static;
@@ -295,7 +296,7 @@ public class Trades {
 				player = Static.getPlayer(env, t);
 			}
 			if(args.length == 3) {
-				force = Static.getBoolean(args[2], t);
+				force = ArgumentValidation.getBoolean(args[2], t);
 			}
 			MCMerchant merchant = GetMerchant(args[0], t);
 			if(!force && merchant.isTrading()) {
@@ -409,7 +410,7 @@ public class Trades {
 			mer.setUses(Static.getInt32(recipe.get("uses", t), t));
 		}
 		if(recipe.containsKey("hasxpreward")) {
-			mer.setHasExperienceReward(Static.getBoolean(recipe.get("hasxpreward", t), t));
+			mer.setHasExperienceReward(ArgumentValidation.getBoolean(recipe.get("hasxpreward", t), t));
 		}
 
 		CArray ingredients = Static.getArray(recipe.get("ingredients", t), t);

--- a/src/main/java/com/laytonsmith/core/functions/Weather.java
+++ b/src/main/java/com/laytonsmith/core/functions/Weather.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.entities.MCCommandMinecart;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ObjectGenerator;
 import com.laytonsmith.core.Static;
@@ -81,7 +82,7 @@ public class Weather {
 				safeIndex = 3;
 			}
 			if(args.length >= safeIndex + 1) {
-				safe = Static.getBoolean(args[safeIndex], t);
+				safe = ArgumentValidation.getBoolean(args[safeIndex], t);
 			}
 			if(w != null) {
 				if(!safe) {
@@ -136,7 +137,7 @@ public class Weather {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			boolean b = Static.getBoolean(args[0], t);
+			boolean b = ArgumentValidation.getBoolean(args[0], t);
 			MCWorld w = null;
 			int duration = -1;
 			if(args.length == 2) {
@@ -232,7 +233,7 @@ public class Weather {
 				w = Static.getServer().getWorld(args[1].val());
 			}
 			if(w != null) {
-				w.setThundering(Static.getBoolean(args[0], t));
+				w.setThundering(ArgumentValidation.getBoolean(args[0], t));
 			} else {
 				throw new CREInvalidWorldException("No existing world specified!", t);
 			}

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -163,10 +163,10 @@ public class Web {
 				expiration = Static.getInt(cookie.get("expiration", t), t);
 			}
 			if(cookie.containsKey("httpOnly")) {
-				httpOnly = Static.getBoolean(cookie.get("httpOnly", t), t);
+				httpOnly = ArgumentValidation.getBoolean(cookie.get("httpOnly", t), t);
 			}
 			if(cookie.containsKey("secureOnly")) {
-				secureOnly = Static.getBoolean(cookie.get("secureOnly", t), t);
+				secureOnly = ArgumentValidation.getBoolean(cookie.get("secureOnly", t), t);
 			}
 			Cookie c = new Cookie(name, value, domain, path, expiration, httpOnly, secureOnly);
 			ret.addCookie(c);
@@ -253,7 +253,7 @@ public class Web {
 					}
 				}
 				if(csettings.containsKey("useDefaultHeaders")) {
-					useDefaultHeaders = Static.getBoolean(csettings.get("useDefaultHeaders", t), t);
+					useDefaultHeaders = ArgumentValidation.getBoolean(csettings.get("useDefaultHeaders", t), t);
 				}
 				if(csettings.containsKey("headers") && !(csettings.get("headers", t) instanceof CNull)) {
 					CArray headers = Static.getArray(csettings.get("headers", t), t);
@@ -324,7 +324,7 @@ public class Web {
 					arrayJar = null;
 				}
 				if(csettings.containsKey("followRedirects")) {
-					settings.setFollowRedirects(Static.getBoolean(csettings.get("followRedirects", t), t));
+					settings.setFollowRedirects(ArgumentValidation.getBoolean(csettings.get("followRedirects", t), t));
 				}
 				//Only required parameter
 				if(csettings.containsKey("success")) {
@@ -374,7 +374,7 @@ public class Web {
 				}
 				if(csettings.containsKey("trustStore")) {
 					Mixed trustStore = csettings.get("trustStore", t);
-					if(trustStore instanceof CBoolean && Static.getBoolean(trustStore, t) == false) {
+					if(trustStore instanceof CBoolean && ArgumentValidation.getBoolean(trustStore, t) == false) {
 						settings.setDisableCertChecking(true);
 					} else if(trustStore instanceof CArray) {
 						CArray trustStoreA = ((CArray) trustStore);
@@ -425,7 +425,7 @@ public class Web {
 					settings.setDownloadStrategy(puMode);
 				}
 				if(csettings.containsKey("binary")) {
-					binary = Static.getBoolean(csettings.get("binary", t), t);
+					binary = ArgumentValidation.getBoolean(csettings.get("binary", t), t);
 				} else {
 					binary = false;
 				}
@@ -437,10 +437,10 @@ public class Web {
 				}
 
 				if(csettings.containsKey("blocking")) {
-					boolean blocking = Static.getBoolean(csettings.get("blocking", t), t);
+					boolean blocking = ArgumentValidation.getBoolean(csettings.get("blocking", t), t);
 					settings.setBlocking(blocking);
 				}
-				if(csettings.containsKey("log") && Static.getBoolean(csettings.get("log", t), t)) {
+				if(csettings.containsKey("log") && ArgumentValidation.getBoolean(csettings.get("log", t), t)) {
 					settings.setLogger(Logger.getLogger(Web.class.getName()));
 				}
 				settings.setAuthenticationDetails(username, password);
@@ -835,8 +835,8 @@ public class Web {
 			final String mailUser = ArgumentValidation.getItemFromArray(options, "user", t, new CString("", t)).val();
 			final String mailPassword = ArgumentValidation.getItemFromArray(options, "password", t, new CString("", t)).val();
 			int mailPort = ArgumentValidation.getInt32(ArgumentValidation.getItemFromArray(options, "port", t, new CInt(587, t)), t);
-			boolean useSSL = ArgumentValidation.getBoolean(ArgumentValidation.getItemFromArray(options, "use_ssl", t, CBoolean.FALSE), t);
-			boolean useStartTLS = ArgumentValidation.getBoolean(ArgumentValidation.getItemFromArray(options, "use_start_tls", t, CBoolean.FALSE), t);
+			boolean useSSL = ArgumentValidation.getBooleanObject(ArgumentValidation.getItemFromArray(options, "use_ssl", t, CBoolean.FALSE), t);
+			boolean useStartTLS = ArgumentValidation.getBooleanObject(ArgumentValidation.getItemFromArray(options, "use_start_tls", t, CBoolean.FALSE), t);
 			int timeout = ArgumentValidation.getInt32(ArgumentValidation.getItemFromArray(options, "timeout", t, new CInt(10000, t)), t);
 
 			//Standard email options

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -1241,7 +1241,7 @@ public class World {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			boolean save = true;
 			if(args.length == 2) {
-				save = Static.getBoolean(args[1], t);
+				save = ArgumentValidation.getBoolean(args[1], t);
 			}
 			MCWorld world = Static.getServer().getWorld(args[0].val());
 			if(world == null) {
@@ -1479,7 +1479,7 @@ public class World {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			if(args.length == 1) {
-				boolean pvp = Static.getBoolean(args[0], t);
+				boolean pvp = ArgumentValidation.getBoolean(args[0], t);
 				for(MCWorld world : Static.getServer().getWorlds()) {
 					world.setPVP(pvp);
 				}
@@ -1488,7 +1488,7 @@ public class World {
 				if(world == null) {
 					throw new CREInvalidWorldException("Unknown world: " + args[0].val(), t);
 				}
-				world.setPVP(Static.getBoolean(args[1], t));
+				world.setPVP(ArgumentValidation.getBoolean(args[1], t));
 			}
 			return CVoid.VOID;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/XGUI.java
+++ b/src/main/java/com/laytonsmith/core/functions/XGUI.java
@@ -7,6 +7,7 @@ import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.hide;
 import com.laytonsmith.annotations.noboilerplate;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CInt;
@@ -152,7 +153,7 @@ public class XGUI {
 			int id = Static.getInt32(args[0], t);
 			boolean show = true;
 			if(args.length > 1) {
-				show = Static.getBoolean(args[1], t);
+				show = ArgumentValidation.getBoolean(args[1], t);
 			}
 			Window w = windows.get(id);
 			w.setVisible(show);

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccess.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccess.java
@@ -5,14 +5,13 @@ import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import java.util.Arrays;
 import java.util.Set;
 
 /**
  * Things that implement this can be accessed like an array, with array_get, or [].
  */
 @typeof("ms.lang.ArrayAccess")
-public interface ArrayAccess extends Mixed, Sizeable {
+public interface ArrayAccess extends Mixed {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 	public static final CClassType TYPE = CClassType.get("ms.lang.ArrayAccess");
@@ -58,14 +57,6 @@ public interface ArrayAccess extends Mixed, Sizeable {
 	public Set<Mixed> keySet();
 
 	/**
-	 * Return the size of the array
-	 *
-	 * @return
-	 */
-	@Override
-	public long size();
-
-	/**
 	 * Unlike {@link #canBeAssociative()}, this is a runtime flag. If the underlying object is associative (that is, it
 	 * is an unordered, non numeric key set), this should return true. If this is true, then
 	 * {@link #get(java.lang.String, com.laytonsmith.core.constructs.Target)} will not be called, and
@@ -95,113 +86,6 @@ public interface ArrayAccess extends Mixed, Sizeable {
 	 */
 	public Mixed slice(int begin, int end, Target t);
 
-	/**
-	 * This class contains iteration information for the ArrayAccess object as it is being iterated. This assumes that
-	 * the object being iterated is not associative. Associative arrays have far simpler handling, and can therefore
-	 * skip the handling needed for non-associative arrays.
-	 */
-	public static class ArrayAccessIterator {
-
-		private final ArrayAccess array;
-		private int current = 0;
-		private int[] blacklist = new int[]{-1};
-		private int blacklistSize = 0;
-
-		/**
-		 * Creates a new ArrayAccessIterator. If the array is associative, a RuntimeException is thrown, since
-		 * associative arrays have far simpler handling, and should not use this mechanism.
-		 *
-		 * @param array
-		 */
-		public ArrayAccessIterator(ArrayAccess array) {
-			if(array.isAssociative()) {
-				throw new RuntimeException();
-			}
-			this.array = array;
-		}
-
-		/**
-		 * Returns the index of the currently iterated object.
-		 *
-		 * @return
-		 */
-		public int getCurrent() {
-			return current;
-		}
-
-		/**
-		 * Decrements the current counter. This operation is used when the current item, or an item before the current
-		 * item is removed.
-		 */
-		public void decrementCurrent() {
-			--current;
-		}
-
-		/**
-		 * Increments the current counter. This operation is used when a new item is inserted before or at the current
-		 * item. It is also used at the end of the loop.
-		 */
-		public void incrementCurrent() {
-			++current;
-		}
-
-		/**
-		 * Increments all the values in the blacklist. This is used when a new item is inserted into the array, after
-		 * the current index.
-		 *
-		 * @param from The value to search from. Any values after this are incremented, and values before it are not.
-		 */
-		public void incrementBlacklistAfter(int from) {
-			for(int i = 0; i < blacklist.length; i++) {
-				if(blacklist[i] > from) {
-					blacklist[i]++;
-				}
-			}
-		}
-
-		/**
-		 * Adds a value to the blacklist. This is used when a value is added after the current index. This value will
-		 * not be iterated in the future.
-		 *
-		 * @param index The index to add to the blacklist.
-		 */
-		public void addToBlacklist(int index) {
-			if(blacklistSize == blacklist.length) {
-				int[] bl = new int[blacklist.length * 2];
-				Arrays.fill(bl, -1);
-				System.arraycopy(blacklist, 0, bl, 0, blacklist.length);
-				blacklist = bl;
-			}
-			blacklist[blacklistSize] = index;
-			blacklistSize++;
-		}
-
-		/**
-		 * Checks through the blacklist, and returns true if this index is blacklisted. If so, this value should be
-		 * skipped in the iteration.
-		 *
-		 * @param index The index to check.
-		 * @return True if this value should be skipped.
-		 */
-		public boolean isBlacklisted(int index) {
-			for(int v : blacklist) {
-				if(v == index) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-		/**
-		 * Gets the underlying ArrayAccess object.
-		 *
-		 * @return
-		 */
-		public ArrayAccess underlyingArray() {
-			return array;
-		}
-
-	}
 
 	@Override
 	public String docs();

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccessRunner.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccessRunner.java
@@ -24,7 +24,7 @@ public class ArrayAccessRunner extends AbstractMixedInterfaceRunner {
 
 	@Override
 	public CClassType[] getSuperclasses() {
-		return new CClassType[]{Mixed.TYPE, Sizeable.TYPE};
+		return new CClassType[]{Mixed.TYPE};
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Booleanish.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Booleanish.java
@@ -1,0 +1,33 @@
+package com.laytonsmith.core.natives.interfaces;
+
+import com.laytonsmith.annotations.typeof;
+import com.laytonsmith.core.ArgumentValidation;
+import com.laytonsmith.core.constructs.CClassType;
+import com.laytonsmith.core.constructs.Target;
+
+
+/**
+ * A value that is Booleanish is a non-boolean value, that can be converted to Boolean.
+ */
+@typeof("ms.lang.Booleanish")
+public interface Booleanish extends Mixed {
+
+	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
+	public static final CClassType TYPE = CClassType.get("ms.lang.Booleanish");
+
+	/**
+	 * Returns true if this value is a trueish value. Each implementation is free to define this as they wish. In
+	 * general, code that supports Booleanish values should not use this method directly, use
+	 * {@link ArgumentValidation#getBoolean(com.laytonsmith.core.natives.interfaces.Mixed,
+	 * com.laytonsmith.core.constructs.Target)}, which ensures that the error message, if this is not an actual
+	 * Booleanish value, is standardized. In general, methods should not accept a Booleanish value (with some critical
+	 * exceptions, such as if(), for(), etc) as in the future, this will prevent functions from being fully strongly
+	 * typed in strict mode. In non-strict mode (or strict mode with the auto keyword) Booleanish types will be cross
+	 * cast to a boolean first anyways, so there is no point in accepting Booleanish values.
+	 *
+	 * @param t The code target, in case there are errors that are thrown, the correct target can be provided in the
+	 * error.
+	 * @return True if the value is trueish, false if it is falseish.
+	 */
+	boolean getBooleanValue(Target t);
+}

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/BooleanishRunner.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/BooleanishRunner.java
@@ -1,0 +1,42 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.laytonsmith.core.natives.interfaces;
+
+import com.laytonsmith.PureUtilities.Common.Annotations.InterfaceRunnerFor;
+import com.laytonsmith.PureUtilities.Version;
+import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.constructs.CClassType;
+
+/**
+ *
+ */
+@InterfaceRunnerFor(Booleanish.class)
+public class BooleanishRunner extends AbstractMixedInterfaceRunner {
+	@Override
+	public String docs() {
+		return "A value that is Booleanish is a non-boolean value, that can be converted to boolean.";
+	}
+
+	@Override
+	public Version since() {
+		return MSVersion.V3_3_4;
+	}
+
+	@Override
+	public CClassType[] getSuperclasses() {
+		return new CClassType[]{Mixed.TYPE};
+	}
+
+	@Override
+	public CClassType[] getInterfaces() {
+		return CClassType.EMPTY_CLASS_ARRAY;
+	}
+
+	@Override
+	public ObjectType getObjectType() {
+		return ObjectType.INTERFACE;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Iterable.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Iterable.java
@@ -1,0 +1,20 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.laytonsmith.core.natives.interfaces;
+
+import com.laytonsmith.annotations.typeof;
+import com.laytonsmith.core.constructs.CClassType;
+
+/**
+ * An object that is iterable is one that can be iterated. It must implement both ArrayAccess and Sizeable.
+ */
+@typeof("ms.lang.Iterable")
+public interface Iterable extends ArrayAccess, Sizeable {
+
+	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
+	public static final CClassType TYPE = CClassType.get("ms.lang.Iterable");
+
+}

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/IterableRunner.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/IterableRunner.java
@@ -1,0 +1,45 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.laytonsmith.core.natives.interfaces;
+
+import com.laytonsmith.PureUtilities.Common.Annotations.InterfaceRunnerFor;
+import com.laytonsmith.PureUtilities.Version;
+import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.constructs.CClassType;
+
+/**
+ *
+ * @author caismith
+ */
+@InterfaceRunnerFor(Iterable.class)
+public class IterableRunner extends AbstractMixedInterfaceRunner {
+
+	@Override
+	public String docs() {
+		return "Provides access to an object using the square bracket notation.";
+	}
+
+	@Override
+	public Version since() {
+		return MSVersion.V3_3_1;
+	}
+
+	@Override
+	public CClassType[] getSuperclasses() {
+		return new CClassType[]{ArrayAccess.TYPE, Sizeable.TYPE};
+	}
+
+	@Override
+	public CClassType[] getInterfaces() {
+		return CClassType.EMPTY_CLASS_ARRAY;
+	}
+
+	@Override
+	public ObjectType getObjectType() {
+		return ObjectType.INTERFACE;
+	}
+
+}

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Iterator.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Iterator.java
@@ -1,0 +1,116 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.laytonsmith.core.natives.interfaces;
+
+import java.util.Arrays;
+
+/**
+ * This class contains iteration information for the ArrayAccess object as it is being iterated. This assumes that
+ * the object being iterated is not associative. Associative arrays have far simpler handling, and can therefore
+ * skip the handling needed for non-associative arrays.
+ */
+public class Iterator {
+
+	private final Iterable array;
+	private int current = 0;
+	private int[] blacklist = new int[]{-1};
+	private int blacklistSize = 0;
+
+	/**
+	 * Creates a new ArrayAccessIterator. If the array is associative, a RuntimeException is thrown, since
+	 * associative arrays have far simpler handling, and should not use this mechanism.
+	 *
+	 * @param array
+	 */
+	public Iterator(Iterable array) {
+		if(array.isAssociative()) {
+			throw new RuntimeException();
+		}
+		this.array = array;
+	}
+
+	/**
+	 * Returns the index of the currently iterated object.
+	 *
+	 * @return
+	 */
+	public int getCurrent() {
+		return current;
+	}
+
+	/**
+	 * Decrements the current counter. This operation is used when the current item, or an item before the current
+	 * item is removed.
+	 */
+	public void decrementCurrent() {
+		--current;
+	}
+
+	/**
+	 * Increments the current counter. This operation is used when a new item is inserted before or at the current
+	 * item. It is also used at the end of the loop.
+	 */
+	public void incrementCurrent() {
+		++current;
+	}
+
+	/**
+	 * Increments all the values in the blacklist. This is used when a new item is inserted into the array, after
+	 * the current index.
+	 *
+	 * @param from The value to search from. Any values after this are incremented, and values before it are not.
+	 */
+	public void incrementBlacklistAfter(int from) {
+		for(int i = 0; i < blacklist.length; i++) {
+			if(blacklist[i] > from) {
+				blacklist[i]++;
+			}
+		}
+	}
+
+	/**
+	 * Adds a value to the blacklist. This is used when a value is added after the current index. This value will
+	 * not be iterated in the future.
+	 *
+	 * @param index The index to add to the blacklist.
+	 */
+	public void addToBlacklist(int index) {
+		if(blacklistSize == blacklist.length) {
+			int[] bl = new int[blacklist.length * 2];
+			Arrays.fill(bl, -1);
+			System.arraycopy(blacklist, 0, bl, 0, blacklist.length);
+			blacklist = bl;
+		}
+		blacklist[blacklistSize] = index;
+		blacklistSize++;
+	}
+
+	/**
+	 * Checks through the blacklist, and returns true if this index is blacklisted. If so, this value should be
+	 * skipped in the iteration.
+	 *
+	 * @param index The index to check.
+	 * @return True if this value should be skipped.
+	 */
+	public boolean isBlacklisted(int index) {
+		for(int v : blacklist) {
+			if(v == index) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Gets the underlying ArrayAccess object.
+	 *
+	 * @return
+	 */
+	public Iterable underlyingArray() {
+		return array;
+	}
+
+}

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Iterator.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Iterator.java
@@ -8,7 +8,7 @@ package com.laytonsmith.core.natives.interfaces;
 import java.util.Arrays;
 
 /**
- * This class contains iteration information for the ArrayAccess object as it is being iterated. This assumes that
+ * This class contains iteration information for the Iterator object as it is being iterated. This assumes that
  * the object being iterated is not associative. Associative arrays have far simpler handling, and can therefore
  * skip the handling needed for non-associative arrays.
  */
@@ -105,7 +105,7 @@ public class Iterator {
 	}
 
 	/**
-	 * Gets the underlying ArrayAccess object.
+	 * Gets the underlying Iterable object.
 	 *
 	 * @return
 	 */

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  * automatically added to the ecosystem, however.
  */
 @typeof("ms.lang.enum")
-public abstract class MEnumType implements Mixed, ArrayAccess {
+public abstract class MEnumType implements Mixed, com.laytonsmith.core.natives.interfaces.Iterable {
 
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
@@ -393,7 +393,7 @@ public abstract class MEnumType implements Mixed, ArrayAccess {
 
 	@Override
 	public CClassType[] getInterfaces() {
-		return CClassType.EMPTY_CLASS_ARRAY;
+		return new CClassType[]{Iterable.TYPE};
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/MObject.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/MObject.java
@@ -1,6 +1,7 @@
 package com.laytonsmith.core.natives.interfaces;
 
 import com.laytonsmith.annotations.nofield;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CNull;
@@ -120,7 +121,7 @@ public class MObject {
 							val = value.val().charAt(0);
 						}
 					} else if(fType == boolean.class) {
-						val = Static.getBoolean(value, t);
+						val = ArgumentValidation.getBoolean(value, t);
 					} else if(fType == float.class) {
 						val = Static.getDouble32(value, t);
 					} else if(fType == double.class) {

--- a/src/main/resources/docs/Logic
+++ b/src/main/resources/docs/Logic
@@ -146,8 +146,13 @@ The following are considered to evaluate to true:
 * The keyword and boolean value <code>true</code>
 * Any non-empty string
 * Any number different from 0
+* A non-empty array
 
-Anything else, including arrays, are considered false.
+Null values are always considered false. All primitives, and some more complex objects implement the
+ms.lang.Booleanish type, which allows them to return true if the value is '''trueish''', meaning that while the value
+itself is not a boolean, it has a true/false interpretation, and can explicitely be cast to a boolean with the
+{{function|boolean}} function. This is a generic concept though, and so it's not possible to create a comprehensive
+list of things that are supported with this mechanism.
 
 ==else if==
 if/else if/else chains can be formed as well, if multiple conditions need to be checked. Using only

--- a/src/test/java/com/laytonsmith/core/TestStatic.java
+++ b/src/test/java/com/laytonsmith/core/TestStatic.java
@@ -72,11 +72,11 @@ public class TestStatic {
 
 	@Test
 	public void testGetBoolean() {
-		assertEquals(true, Static.getBoolean(C.Boolean(true), Target.UNKNOWN));
-		assertEquals(true, Static.getBoolean(C.String("non-empty string"), Target.UNKNOWN));
-		assertEquals(false, Static.getBoolean(C.String(""), Target.UNKNOWN));
-		assertEquals(true, Static.getBoolean(C.Int(1), Target.UNKNOWN));
-		assertEquals(false, Static.getBoolean(C.Int(0), Target.UNKNOWN));
+		assertEquals(true, ArgumentValidation.getBoolean(C.Boolean(true), Target.UNKNOWN));
+		assertEquals(true, ArgumentValidation.getBoolean(C.String("non-empty string"), Target.UNKNOWN));
+		assertEquals(false, ArgumentValidation.getBoolean(C.String(""), Target.UNKNOWN));
+		assertEquals(true, ArgumentValidation.getBoolean(C.Int(1), Target.UNKNOWN));
+		assertEquals(false, ArgumentValidation.getBoolean(C.Int(0), Target.UNKNOWN));
 	}
 
 	@Test

--- a/src/test/java/com/laytonsmith/core/constructs/InstanceofUtilTest.java
+++ b/src/test/java/com/laytonsmith/core/constructs/InstanceofUtilTest.java
@@ -1,5 +1,6 @@
 package com.laytonsmith.core.constructs;
 
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -12,6 +13,7 @@ public class InstanceofUtilTest {
 
 	@Test
 	public void testInstanceofUtil() {
+		assertTrue(InstanceofUtil.isInstanceof(CBoolean.FALSE, Booleanish.class));
 		assertTrue(InstanceofUtil.isInstanceof(new CInt(0, Target.UNKNOWN), CInt.class));
 		assertTrue(InstanceofUtil.isInstanceof(new CInt(0, Target.UNKNOWN), CNumber.class));
 		assertTrue(InstanceofUtil.isInstanceof(new CInt(0, Target.UNKNOWN), Mixed.class));

--- a/src/test/java/com/laytonsmith/core/constructs/TestCClassType.java
+++ b/src/test/java/com/laytonsmith/core/constructs/TestCClassType.java
@@ -58,6 +58,7 @@ public class TestCClassType {
 		assertTrue(get("array").doesExtend(get("ArrayAccess")));
 		assertFalse(get("array").doesExtend(get("string")));
 		assertTrue(get("array").doesExtend(get("array")));
+		assertTrue(get("array").doesExtend(get("Booleanish")));
 	}
 
 	@Test

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -43,6 +43,7 @@ import com.laytonsmith.annotations.noboilerplate;
 import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
 import com.laytonsmith.core.AliasCore;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.MethodScriptComplete;
@@ -364,25 +365,25 @@ public class StaticTest {
 	}
 
 	/**
-	 * Verifies that the given construct <em>resolves</em> to true. The resolution uses Static.getBoolean to do the
+	 * Verifies that the given construct <em>resolves</em> to true. The resolution uses ArgumentValidation.getBoolean to do the
 	 * resolution.
 	 *
 	 * @param actual
 	 */
 	public static void assertCTrue(Mixed actual) {
-		if(!Static.getBoolean(actual, Target.UNKNOWN)) {
+		if(!ArgumentValidation.getBoolean(actual, Target.UNKNOWN)) {
 			fail("Expected '" + actual.val() + "' to resolve to true, but it did not");
 		}
 	}
 
 	/**
-	 * Verifies that the given construct <em>resolves</em> to false. The resolution uses Static.getBoolean to do the
+	 * Verifies that the given construct <em>resolves</em> to false. The resolution uses ArgumentValidation.getBoolean to do the
 	 * resolution.
 	 *
 	 * @param actual
 	 */
 	public static void assertCFalse(Mixed actual) {
-		if(Static.getBoolean(actual, Target.UNKNOWN)) {
+		if(ArgumentValidation.getBoolean(actual, Target.UNKNOWN)) {
 			fail("Expected '" + actual.val() + "' to resolve to false, but it did not");
 		}
 	}


### PR DESCRIPTION
This allows objects to specifically declare that, while not booleans
themselves (except CBoolean), they do have a way to convert to a truth
value. This distinction allows functions like if and for to formally
declare that they accept a Booleanish value, but others, will only
accept an actual boolean value. As it stands today, everything accepts
booleanish values, and that is unfortunate, but that will be addressed
when strong typing is added, so that it will reduce most of the errors
that would be runtime.