### PR TITLE
Use isInstanceOf everywhere.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
@@ -253,7 +253,7 @@ public class BukkitMCCommand implements MCCommand {
 				Mixed fret = closure.executeCallable(null, t, new CString(label, t), new CString(sender.getName(), t), cargs,
 						new CArray(t) // reserved for an obgen style command array
 				);
-				if(fret instanceof CBoolean) {
+				if(fret.isInstanceOf(CBoolean.class)) {
 					return ((CBoolean) fret).getBoolean();
 				}
 			} catch (ConfigRuntimeException cre) {

--- a/src/main/java/com/laytonsmith/core/ArgumentValidation.java
+++ b/src/main/java/com/laytonsmith/core/ArgumentValidation.java
@@ -233,10 +233,10 @@ public final class ArgumentValidation {
 		if(c == null || c instanceof CNull) {
 			return 0;
 		}
-		if(c instanceof CInt) {
-			i = ((CInt) c).getInt();
-		} else if(c instanceof CBoolean) {
-			if(((CBoolean) c).getBoolean()) {
+		if(c.isInstanceOf(CInt.class)) {
+			i = getObject(c, t, CInt.class).getInt();
+		} else if(c.isInstanceOf(CBoolean.class)) {
+			if(getObject(c, t, CBoolean.class).getBoolean()) {
 				i = 1;
 			} else {
 				i = 0;

--- a/src/main/java/com/laytonsmith/core/MainSandbox.java
+++ b/src/main/java/com/laytonsmith/core/MainSandbox.java
@@ -31,12 +31,14 @@ public class MainSandbox {
 					|| m.getSimpleName().equals("CLabel")
 					|| m.getSimpleName().equals("CLabel")
 					|| m.getSimpleName().equals("AbstractCREException")
+					|| m.getSimpleName().equals("CSlice")
+					|| m.getSimpleName().equals("CArray")
 					) {
 				continue;
 			}
 			l.add(m.getSimpleName());
 		}
-		System.out.println(" instanceof (" + StringUtils.Join(l, "|") + ")([^a-zA-Z0-9])");
+		System.out.println(" instanceof (" + StringUtils.Join(l, "|") + ")(?![a-zA-Z0-9])");
 		System.out.println(".isInstanceOf($1.class)$2");
 	}
 

--- a/src/main/java/com/laytonsmith/core/Method.java
+++ b/src/main/java/com/laytonsmith/core/Method.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 public class Method extends Construct implements Callable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Method");
+	public static final CClassType TYPE = CClassType.get(Method.class);
 
 	private final CClassType returnType;
 	private final String name;

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -286,7 +286,7 @@ public class ObjectGenerator {
 				}
 			} else {
 				Mixed type = item.get("type", t);
-				if(type instanceof CString) {
+				if(type.isInstanceOf(CString.class)) {
 					int seperatorIndex = type.val().indexOf(':');
 					if(seperatorIndex != -1) {
 						try {
@@ -634,7 +634,7 @@ public class ObjectGenerator {
 					Mixed li = ma.get("lore", t);
 					if(li instanceof CNull) {
 						//do nothing
-					} else if(li instanceof CString) {
+					} else if(li.isInstanceOf(CString.class)) {
 						List<String> ll = new ArrayList<>();
 						ll.add(li.val());
 						meta.setLore(ll);
@@ -940,7 +940,7 @@ public class ObjectGenerator {
 						Mixed color = ma.get("color", t);
 						if(color instanceof CArray) {
 							((MCPotionMeta) meta).setColor(color((CArray) color, t));
-						} else if(color instanceof CString) {
+						} else if(color.isInstanceOf(CString.class)) {
 							((MCPotionMeta) meta).setColor(StaticLayer.GetConvertor().GetColor(color.val(), t));
 						}
 					}
@@ -1193,7 +1193,7 @@ public class ObjectGenerator {
 			Mixed value = enchantArray.get(key, t);
 			if(enchantArray.isAssociative()) {
 				etype = StaticLayer.GetEnchantmentByName(key);
-				if(etype != null && value instanceof CInt) {
+				if(etype != null && value.isInstanceOf(CInt.class)) {
 					ret.put(etype, Static.getInt32(value, t));
 					continue;
 				}
@@ -1304,7 +1304,7 @@ public class ObjectGenerator {
 		boolean upgraded = false;
 		if(pd.containsKey("extended")) {
 			Mixed cext = pd.get("extended", t);
-			if(cext instanceof CBoolean) {
+			if(cext.isInstanceOf(CBoolean.class)) {
 				extended = ((CBoolean) cext).getBoolean();
 			} else {
 				throw new CREFormatException(
@@ -1313,7 +1313,7 @@ public class ObjectGenerator {
 		}
 		if(pd.containsKey("upgraded")) {
 			Mixed cupg = pd.get("upgraded", t);
-			if(cupg instanceof CBoolean) {
+			if(cupg.isInstanceOf(CBoolean.class)) {
 				upgraded = ((CBoolean) cupg).getBoolean();
 			} else {
 				throw new CREFormatException(
@@ -1367,11 +1367,11 @@ public class ObjectGenerator {
 				} else {
 					for(Mixed color : ccolors.asList()) {
 						MCColor mccolor;
-						if(color instanceof CString) {
+						if(color.isInstanceOf(CString.class)) {
 							mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
 						} else if(color instanceof CArray) {
 							mccolor = color((CArray) color, t);
-						} else if(color instanceof CInt && ccolors.size() == 3) {
+						} else if(color.isInstanceOf(CInt.class) && ccolors.size() == 3) {
 							// Appears to be a single color
 							builder.addColor(color(ccolors, t));
 							break;
@@ -1382,7 +1382,7 @@ public class ObjectGenerator {
 						builder.addColor(mccolor);
 					}
 				}
-			} else if(colors instanceof CString) {
+			} else if(colors.isInstanceOf(CString.class)) {
 				String split[] = colors.val().split("\\|");
 				if(split.length == 0) {
 					builder.addColor(MCColor.WHITE);
@@ -1406,9 +1406,9 @@ public class ObjectGenerator {
 					MCColor mccolor;
 					if(color instanceof CArray) {
 						mccolor = color((CArray) color, t);
-					} else if(color instanceof CString) {
+					} else if(color.isInstanceOf(CString.class)) {
 						mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
-					} else if(color instanceof CInt && ccolors.size() == 3) {
+					} else if(color.isInstanceOf(CInt.class) && ccolors.size() == 3) {
 						// Appears to be a single color
 						builder.addFadeColor(color(ccolors, t));
 						break;
@@ -1418,7 +1418,7 @@ public class ObjectGenerator {
 					}
 					builder.addFadeColor(mccolor);
 				}
-			} else if(colors instanceof CString) {
+			} else if(colors.isInstanceOf(CString.class)) {
 				String split[] = colors.val().split("\\|");
 				for(String s : split) {
 					builder.addFadeColor(StaticLayer.GetConvertor().GetColor(s, t));
@@ -1504,7 +1504,7 @@ public class ObjectGenerator {
 				}
 				int i = 0;
 				for(Mixed row : shaped.asList()) {
-					if(row instanceof CString && row.val().length() >= 1 && row.val().length() <= 3) {
+					if(row.isInstanceOf(CString.class) && row.val().length() >= 1 && row.val().length() <= 3) {
 						shape[i] = row.val();
 						i++;
 					} else {
@@ -1520,7 +1520,7 @@ public class ObjectGenerator {
 				for(String key : shapedIngredients.stringKeySet()) {
 					MCMaterial mat = null;
 					Mixed ingredient = shapedIngredients.get(key, t);
-					if(ingredient instanceof CString) {
+					if(ingredient.isInstanceOf(CString.class)) {
 						mat = StaticLayer.GetMaterial(ingredient.val());
 						if(mat == null) {
 							// maybe legacy item format
@@ -1534,7 +1534,7 @@ public class ObjectGenerator {
 								MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Numeric item formats (eg. \"0:0\" are deprecated.", t);
 							} catch (NumberFormatException ex) {}
 						}
-					} else if(ingredient instanceof CInt) {
+					} else if(ingredient.isInstanceOf(CInt.class)) {
 						mat = StaticLayer.GetMaterialFromLegacy(Static.getInt32(ingredient, t), 0);
 						MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Numeric item ingredients are deprecated.", t);
 					} else if(ingredient instanceof CArray) {
@@ -1553,7 +1553,7 @@ public class ObjectGenerator {
 					throw new CREFormatException("Ingredients array is invalid.", t);
 				}
 				for(Mixed ingredient : ingredients.asList()) {
-					if(ingredient instanceof CString) {
+					if(ingredient.isInstanceOf(CString.class)) {
 						MCMaterial mat = StaticLayer.GetMaterial(ingredient.val());
 						if(mat == null) {
 							// maybe legacy item format
@@ -1581,7 +1581,7 @@ public class ObjectGenerator {
 
 			case FURNACE:
 				Mixed input = recipe.get("input", t);
-				if(input instanceof CString) {
+				if(input.isInstanceOf(CString.class)) {
 					MCMaterial mat = StaticLayer.GetMaterial(input.val());
 					if(mat == null) {
 						throw new CREFormatException("Furnace input is invalid: " + input.val(), t);

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -55,6 +55,7 @@ import com.laytonsmith.core.exceptions.CRE.CRELengthException;
 import com.laytonsmith.core.exceptions.CRE.CRENullPointerException;
 import com.laytonsmith.core.exceptions.CRE.CREPlayerOfflineException;
 import com.laytonsmith.core.exceptions.CRE.CRERangeException;
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Function;
 import com.laytonsmith.core.natives.interfaces.Mixed;
@@ -578,7 +579,12 @@ public final class Static {
 		}
 		String fqType = NativeTypeList.resolveNativeType(val);
 		if(fqType != null) {
-			return CClassType.get(fqType);
+			try {
+				return CClassType.get(FullyQualifiedClassName.forFullyQualifiedClass(fqType));
+			} catch(ClassNotFoundException ex) {
+				// Can't happen, because we just resolved the type, and it wasn't null.
+				throw new Error(ex);
+			}
 		}
 		if(returnBareStrings) {
 			return new CBareString(val, t);
@@ -755,7 +761,7 @@ public final class Static {
 			try {
 				ofp = getServer().getOfflinePlayer(GetUUID(search, t));
 			} catch (ConfigRuntimeException cre) {
-				if(cre instanceof CRELengthException) {
+				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.class)) {
 					throw new CRELengthException("The given string was the wrong size to identify a player."
 							+ " A player name is expected to be between 1 and 16 characters. " + cre.getMessage(), t);
 				} else {
@@ -789,7 +795,7 @@ public final class Static {
 			try {
 				m = getServer().getPlayer(GetUUID(player, t));
 			} catch (ConfigRuntimeException cre) {
-				if(cre instanceof CRELengthException) {
+				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.class)) {
 					throw new CRELengthException("The given string was the wrong size to identify a player."
 							+ " A player name is expected to be between 1 and 16 characters. " + cre.getMessage(), t);
 				} else {

--- a/src/main/java/com/laytonsmith/core/compiler/OptimizationUtilities.java
+++ b/src/main/java/com/laytonsmith/core/compiler/OptimizationUtilities.java
@@ -75,7 +75,9 @@ public class OptimizationUtilities {
 			return b.toString();
 		} else if(node.getData() instanceof CString) {
 			//strings
-			return new StringBuilder().append("'").append(node.getData().val().replaceAll("\t", "\\t").replaceAll("\n", "\\n").replace("\\", "\\\\").replace("'", "\\'")).append("'").toString();
+			return new StringBuilder().append("'").append(node.getData().val()
+					.replaceAll("\t", "\\t").replaceAll("\n", "\\n").replace("\\", "\\\\")
+					.replace("'", "\\'")).append("'").toString();
 		} else if(node.getData() instanceof IVariable) {
 			return ((IVariable) node.getData()).getVariableName();
 		} else if(node.getData() instanceof Variable) {

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -18,12 +18,14 @@ import com.laytonsmith.core.functions.BasicLogic;
 import com.laytonsmith.core.functions.DataHandling;
 import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.core.objects.ObjectModifier;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -43,7 +45,7 @@ import java.util.TreeMap;
 public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 		com.laytonsmith.core.natives.interfaces.Iterable {
 
-	public static final CClassType TYPE = CClassType.get("ms.lang.array");
+	public static final CClassType TYPE = CClassType.get(CArray.class);
 	private boolean associativeMode = false;
 	private long nextIndex = 0;
 	private List<Mixed> array;
@@ -622,11 +624,11 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 	private String normalizeConstruct(Mixed c) {
 		if(c instanceof CArray) {
 			throw new CRECastException("Arrays cannot be used as the key in an associative array", c.getTarget());
-		} else if(c instanceof CString || c instanceof CInt) {
+		} else if(c.isInstanceOf(CString.class) || c.isInstanceOf(CInt.class)) {
 			return c.val();
 		} else if(c instanceof CNull) {
 			return "";
-		} else if(c instanceof CBoolean) {
+		} else if(c.isInstanceOf(CBoolean.class)) {
 			if(((CBoolean) c).getBoolean()) {
 				return "1";
 			} else {
@@ -874,8 +876,8 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 					if(c instanceof CArray) {
 						throw new CRECastException("Cannot sort an array of arrays.", CArray.this.getTarget());
 					}
-					if(!(c instanceof CBoolean || c instanceof CString || c instanceof CInt
-							|| c instanceof CDouble || c instanceof CNull || c instanceof CClassType)) {
+					if(!(c.isInstanceOf(CBoolean.class) || c.isInstanceOf(CString.class) || c.isInstanceOf(CInt.class)
+							|| c.isInstanceOf(CDouble.class) || c instanceof CNull || c.isInstanceOf(CClassType.class))) {
 						throw new CREFormatException("Unsupported type being sorted: " + c.typeof(), CArray.this.getTarget());
 					}
 				}
@@ -888,7 +890,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 						return o1.val().compareTo("");
 					}
 				}
-				if(o1 instanceof CBoolean || o2 instanceof CBoolean) {
+				if(o1.isInstanceOf(CBoolean.class) || o2.isInstanceOf(CBoolean.class)) {
 					if(ArgumentValidation.getBoolean(o1, Target.UNKNOWN) == ArgumentValidation.getBoolean(o2, Target.UNKNOWN)) {
 						return 0;
 					} else {
@@ -957,6 +959,11 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 
 	public void ensureCapacity(int capacity) {
 		((ArrayList) array).ensureCapacity(capacity);
+	}
+
+	@Override
+	public Set<ObjectModifier> getObjectModifiers() {
+		return EnumSet.of(ObjectModifier.FINAL);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/constructs/CBareString.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CBareString.java
@@ -14,7 +14,7 @@ import com.laytonsmith.annotations.typeof;
 public class CBareString extends CString {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.barestring");
+	public static final CClassType TYPE = CClassType.get(CBareString.class);
 
 	public CBareString(String value, Target t) {
 		super(value, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CBoolean.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public final class CBoolean extends CPrimitive implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.boolean");
+	public static final CClassType TYPE = CClassType.get(CBoolean.class);
 
 	public static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/laytonsmith/core/constructs/CByteArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CByteArray.java
@@ -28,7 +28,7 @@ import java.util.EnumSet;
 public class CByteArray extends CArray implements Sizeable, ArrayAccess {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.byte_array");
+	public static final CClassType TYPE = CClassType.get(CByteArray.class);
 
 	/**
 	 * Initial size of the ByteBuffer
@@ -529,7 +529,7 @@ public class CByteArray extends CArray implements Sizeable, ArrayAccess {
 	private static class CArrayByteBacking extends CArray {
 
 		@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-		public static final CClassType TYPE = CClassType.get("ms.lang.ByteBackingArray");
+		public static final CClassType TYPE = CClassType.get(CArrayByteBacking.class);
 		private final byte[] backing;
 		private String value = null;
 
@@ -631,7 +631,7 @@ public class CByteArray extends CArray implements Sizeable, ArrayAccess {
 		public static class CREByteArrayReadOnlyException extends CREReadOnlyException {
 
 			@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-			public static final CClassType TYPE = CClassType.get("ms.lang.ByteArrayReadOnlyException");
+			public static final CClassType TYPE = CClassType.get(CREByteArrayReadOnlyException.class);
 
 			public CREByteArrayReadOnlyException(java.lang.String msg, com.laytonsmith.core.constructs.Target t) {
 				super(msg, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CClassType.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClassType.java
@@ -88,15 +88,21 @@ public final class CClassType extends Construct implements com.laytonsmith.core.
 	 *
 	 * <p>IMPORTANT: The type MUST be fully qualified AND exist as a real, instantiable class, or this will cause
 	 * errors. The only time this method is preferred vs {@link #get(com.laytonsmith.core.FullyQualifiedClassName)} is
-	 * when used to define the TYPE value.
+	 * when used to define the TYPE value. The native class must also be provided at the same time, which is used
+	 * for various operations to increase efficiency when dealing with native classes.
 	 *
 	 * Unlike the other getters, this will not throw a ClassNotFoundException, it will instead throw an Error.
 	 * @param type
 	 * @return
 	 */
-	public static CClassType get(String type) {
+	public static CClassType get(Class<? extends Mixed> type) {
 		try {
-			return get(FullyQualifiedClassName.forFullyQualifiedClass(type));
+			typeof typeof = type.getAnnotation(typeof.class);
+			if(typeof == null) {
+				throw new IllegalArgumentException("Missing typeof annotation for " + type);
+			}
+			String fqcn = typeof.value();
+			return get(FullyQualifiedClassName.forFullyQualifiedClass(fqcn));
 		} catch (ClassNotFoundException ex) {
 			throw new Error(ex);
 		}

--- a/src/main/java/com/laytonsmith/core/constructs/CClosure.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClosure.java
@@ -42,7 +42,7 @@ public class CClosure extends Construct implements Callable {
 	protected final CClassType returnType;
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.closure");
+	public static final CClassType TYPE = CClassType.get(CClosure.class);
 
 	public CClosure(ParseTree node, Environment env, CClassType returnType, String[] names, Mixed[] defaults,
 			CClassType[] types, Target t) {
@@ -81,7 +81,7 @@ public class CClosure extends Construct implements Callable {
 				}
 			}
 			b.append(")");
-		} else if(node.getData() instanceof CString) {
+		} else if(node.getData().isInstanceOf(CString.class)) {
 			String data = ArgumentValidation.getString(node.getData(), node.getTarget());
 			// Convert: \ -> \\ and ' -> \'
 			b.append("'").append(data.replace("\\", "\\\\").replaceAll("\t", "\\\\t").replaceAll("\n", "\\\\n")

--- a/src/main/java/com/laytonsmith/core/constructs/CDecimal.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CDecimal.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 public class CDecimal extends CPrimitive implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.decimal");
+	public static final CClassType TYPE = CClassType.get(CDecimal.class);
 
 	private final BigDecimal val;
 

--- a/src/main/java/com/laytonsmith/core/constructs/CDouble.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CDouble.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 public class CDouble extends CNumber implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.double");
+	public static final CClassType TYPE = CClassType.get(CDouble.class);
 
 	public static final long serialVersionUID = 1L;
 	final double val;

--- a/src/main/java/com/laytonsmith/core/constructs/CIClosure.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CIClosure.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 public class CIClosure extends CClosure {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.iclosure");
+	public static final CClassType TYPE = CClassType.get(CIClosure.class);
 
 	public CIClosure(ParseTree node, Environment env, CClassType returnType, String[] names, Mixed[] defaults,
 			CClassType[] types, Target t) {

--- a/src/main/java/com/laytonsmith/core/constructs/CInt.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CInt.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 public class CInt extends CNumber implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.int");
+	public static final CClassType TYPE = CClassType.get(CInt.class);
 
 	public static final long serialVersionUID = 1L;
 	final long val;

--- a/src/main/java/com/laytonsmith/core/constructs/CMutablePrimitive.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CMutablePrimitive.java
@@ -8,6 +8,7 @@ import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.natives.interfaces.Sizeable;
+import com.laytonsmith.core.natives.interfaces.ValueType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -19,7 +20,7 @@ import java.util.Stack;
 public class CMutablePrimitive extends CArray implements Sizeable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.mutable_primitive");
+	public static final CClassType TYPE = CClassType.get(CMutablePrimitive.class);
 
 	private Mixed value = CNull.NULL;
 
@@ -44,7 +45,7 @@ public class CMutablePrimitive extends CArray implements Sizeable {
 	 * @param t
 	 */
 	public void set(Mixed value, Target t) {
-		if(value instanceof CArray) {
+		if(!value.isInstanceOf(ValueType.class)) {
 			throw new CREFormatException("mutable_primitives can only store primitive values.", t);
 		}
 		this.value = value;

--- a/src/main/java/com/laytonsmith/core/constructs/CNull.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CNull.java
@@ -12,7 +12,7 @@ import com.laytonsmith.core.natives.interfaces.Booleanish;
 public final class CNull extends Construct implements Cloneable, Booleanish {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("null");
+	public static final CClassType TYPE = CClassType.get(CNull.class);
 
 	public static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/laytonsmith/core/constructs/CNumber.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CNumber.java
@@ -11,7 +11,7 @@ import com.laytonsmith.core.MSVersion;
 public abstract class CNumber extends CPrimitive {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.number");
+	public static final CClassType TYPE = CClassType.get(CNumber.class);
 
 	public CNumber(String value, ConstructType type, Target t) {
 		super(value, type, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CPackage.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CPackage.java
@@ -18,7 +18,7 @@ import com.laytonsmith.core.MSVersion;
 public class CPackage extends Construct {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Package");
+	public static final CClassType TYPE = CClassType.get(CPackage.class);
 
 	public CPackage(Target t, String... parts) {
 		super(StringUtils.Join(parts, CClassType.PATH_SEPARATOR), Construct.ConstructType.IDENTIFIER, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CPrimitive.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CPrimitive.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.natives.interfaces.ValueType;
 public abstract class CPrimitive extends Construct implements ValueType, Booleanish {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.primitive");
+	public static final CClassType TYPE = CClassType.get(CPrimitive.class);
 
 	public CPrimitive(String value, ConstructType type, Target t) {
 		super(value, type, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CResource.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CResource.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class CResource<T> extends Construct {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.resource");
+	public static final CClassType TYPE = CClassType.get(CResource.class);
 
 	private static final AtomicLong RESOURCE_POOL = new AtomicLong(0);
 

--- a/src/main/java/com/laytonsmith/core/constructs/CSecureString.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CSecureString.java
@@ -32,7 +32,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class CSecureString extends CString {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.secure_string");
+	public static final CClassType TYPE = CClassType.get(CSecureString.class);
 
 	private byte[] encrypted;
 	private Cipher decrypter;

--- a/src/main/java/com/laytonsmith/core/constructs/CSlice.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CSlice.java
@@ -24,7 +24,7 @@ import java.util.Stack;
 public class CSlice extends CArray {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.slice");
+	public static final CClassType TYPE = CClassType.get(CSlice.class);
 
 	private long start;
 	private long finish;

--- a/src/main/java/com/laytonsmith/core/constructs/CString.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CString.java
@@ -28,7 +28,7 @@ public class CString extends CPrimitive implements Cloneable,
 		com.laytonsmith.core.natives.interfaces.Iterable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.string");
+	public static final CClassType TYPE = CClassType.get(CString.class);
 
 	public CString(String value, Target t) {
 		super(value == null ? "" : value, ConstructType.STRING, t);

--- a/src/main/java/com/laytonsmith/core/constructs/CVoid.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CVoid.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public final class CVoid extends Construct implements Cloneable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("void");
+	public static final CClassType TYPE = CClassType.get(CVoid.class);
 
 	/**
 	 * Void values do not normally need to be duplicated, since they are immutable, and for values that have an unknown

--- a/src/main/java/com/laytonsmith/core/constructs/Construct.java
+++ b/src/main/java/com/laytonsmith/core/constructs/Construct.java
@@ -190,7 +190,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 	}
 
 	private static Object json_encode0(Mixed c, Target t) throws MarshalException {
-		if(c instanceof CString || c instanceof Command) {
+		if(c.isInstanceOf(CString.class) || c instanceof Command) {
 			return c.val();
 		} else if(c instanceof CVoid) {
 			return "";
@@ -490,13 +490,11 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 	/**
 	 * Returns the typeof for the given class, using the same mechanism as the default. (Whether or not that subtype
 	 * overrode the original typeof() method.
+	 * @param that
+	 * @return
 	 */
 	public static CClassType typeof(Mixed that) {
-		typeof ann = that.getClass().getAnnotation(typeof.class);
-		if(ann == null) {
-			throw new IllegalArgumentException("Missing typeof annotation for " + that.getClass());
-		}
-		return CClassType.get(ann.value());
+		return CClassType.get(that.getClass());
 	}
 
 	/**
@@ -554,8 +552,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 	}
 
 	/**
-	 * By default, all native methodscript objects are public. If this is not true, this method must be overridden.
-	 *
+	 * By default, all native methodscript objects have no modifiers.
 	 * @return
 	 */
 	@Override
@@ -563,6 +560,11 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 		return EnumSet.noneOf(ObjectModifier.class);
 	}
 
+	/**
+	 * By default, all native methodscript objects are public. If this is not true, this method must be overridden.
+	 *
+	 * @return
+	 */
 	@Override
 	public AccessModifier getAccessModifier() {
 		return AccessModifier.PUBLIC;
@@ -585,7 +587,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 			// but anyways, for now, just return false.
 			return false;
 		}
-		return that.typeof().doesExtend(CClassType.get(type.getAnnotation(typeof.class).value()));
+		return that.typeof().doesExtend(CClassType.get(type));
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
@@ -222,12 +222,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -315,7 +315,7 @@ public class BlockEvents {
 			}
 
 			if(key.equals("xp")) {
-				if(value instanceof CInt) {
+				if(value.isInstanceOf(CInt.class)) {
 					int xp = Integer.parseInt(value.val());
 					event.setExpToDrop(xp);
 					return true;
@@ -367,12 +367,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -462,7 +462,7 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), value.getTarget());
 				return true;
 			} else if(key.equals("type")) {
-				if(value instanceof CInt) {
+				if(value.isInstanceOf(CInt.class)) {
 					MCMaterial mat = StaticLayer.GetMaterialFromLegacy((int) ((CInt) value).getInt(), 0);
 					event.getBlock().setType(mat);
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Mutable data key \"type\" in " + getName()
@@ -516,12 +516,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -702,12 +702,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -727,12 +727,12 @@ public class BlockEvents {
 						+ " is deprecated for \"toblock\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("totype")) {
 				Mixed cid = prefilter.get("totype");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("todata")) {
 						Mixed cdata = prefilter.get("todata");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -1168,12 +1168,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("oldtype")) {
 				Mixed cid = prefilter.get("oldtype");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("olddata")) {
 						Mixed cdata = prefilter.get("olddata");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -1193,12 +1193,12 @@ public class BlockEvents {
 						+ " is deprecated for \"newblock\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("newtype")) {
 				Mixed cid = prefilter.get("newtype");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("newdata")) {
 						Mixed cdata = prefilter.get("newdata");
-						if(cdata instanceof CInt) {
+						if(cdata.isInstanceOf(CInt.class)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -1382,7 +1382,7 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("oldtype")) {
 				Mixed cid = prefilter.get("oldtype");
-				if(cid instanceof CInt) {
+				if(cid.isInstanceOf(CInt.class)) {
 					int id = (int) ((CInt) cid).getInt();
 					MCMaterial mat = StaticLayer.GetMaterialFromLegacy(id, 0);
 					if(mat == null) {

--- a/src/main/java/com/laytonsmith/core/events/drivers/EntityEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/EntityEvents.java
@@ -1367,7 +1367,7 @@ public class EntityEvents {
 			MCEntityDamageByEntityEvent event = (MCEntityDamageByEntityEvent) e;
 
 			if(key.equals("amount")) {
-				if(value instanceof CInt) {
+				if(value.isInstanceOf(CInt.class)) {
 					event.setDamage(Integer.parseInt(value.val()));
 
 					return true;
@@ -1451,7 +1451,7 @@ public class EntityEvents {
 					if(value instanceof CNull) {
 						ete.setTarget(null);
 						return true;
-					} else if(value instanceof CString) {
+					} else if(value.isInstanceOf(CString.class)) {
 						MCPlayer p = Static.GetPlayer(value.val(), value.getTarget());
 
 						if(p.isOnline()) {
@@ -1575,7 +1575,7 @@ public class EntityEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("from")) {
 				Mixed type = prefilter.get("from");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"from\" prefilter.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());
@@ -1584,7 +1584,7 @@ public class EntityEvents {
 			}
 			if(prefilter.containsKey("to")) {
 				Mixed type = prefilter.get("to");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"to\" prefilter.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());
@@ -1675,7 +1675,7 @@ public class EntityEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("block")) {
 				Mixed ctype = prefilter.get("block");
-				if(ctype instanceof CString && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
+				if(ctype.isInstanceOf(CString.class) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
 					int type;
 					String notation = ctype.val();
 					int separatorIndex = notation.indexOf(':');

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -88,7 +88,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("slotitem")) {
 				Mixed type = prefilter.get("slotitem");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("slotitem").val(), 1, event.getTarget());
 					prefilter.put("slotitem", new CString(is.getType().getName(), event.getTarget()));
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format for the \"slotitem\" prefilter"
@@ -230,7 +230,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("cursoritem")) {
 				Mixed type = prefilter.get("cursoritem");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("cursoritem").val(), 1, event.getTarget());
 					prefilter.put("cursoritem", new CString(is.getType().getName(), event.getTarget()));
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format for the \"cursoritem\" prefilter"
@@ -689,7 +689,7 @@ public class InventoryEvents {
 							int[] expCosts = e.getExpLevelCostsOffered();
 
 							for(int i = 0; i <= 2; i++) {
-								if(cExpCosts.get(i, value.getTarget()) instanceof CInt) {
+								if(cExpCosts.get(i, value.getTarget()).isInstanceOf(CInt.class)) {
 									expCosts[i] = (int) ((CInt) cExpCosts.get(i, value.getTarget())).getInt();
 								} else {
 									throw new CREFormatException("Expected an intger at index " + i + "!", value.getTarget());
@@ -810,7 +810,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("main_hand")) {
 				Mixed type = prefilter.get("main_hand");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format in the \"main_hand\""
 							+ " prefilter in " + getName() + " is deprecated.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("main_hand").val(), 1, event.getTarget());
@@ -819,7 +819,7 @@ public class InventoryEvents {
 			}
 			if(prefilter.containsKey("off_hand")) {
 				Mixed type = prefilter.get("off_hand");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format in the \"off_hand\""
 							+ " prefilter in " + getName() + " is deprecated.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("off_hand").val(), 1, event.getTarget());

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -813,7 +813,7 @@ public class PlayerEvents {
 			}
 			if(prefilter.containsKey("block")) {
 				Mixed ctype = prefilter.get("block");
-				if(ctype instanceof CString && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
+				if(ctype.isInstanceOf(CString.class) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
 					int type;
 					String notation = ctype.val();
 					int separatorIndex = notation.indexOf(':');

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -229,7 +229,7 @@ public class VehicleEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("hittype")) {
 				Mixed type = prefilter.get("hittype");
-				if(type instanceof CString && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"hittype\".", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
@@ -87,7 +87,7 @@ public abstract class AbstractCREException extends ConfigRuntimeException implem
 	 * @return
 	 */
 	public CClassType getExceptionType() {
-		return CClassType.get(getName());
+		return Construct.typeof(this);
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBadEntityException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBadEntityException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREBadEntityException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.BadEntityException");
+	public static final CClassType TYPE = CClassType.get(CREBadEntityException.class);
 
 	public CREBadEntityException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBadEntityTypeException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBadEntityTypeException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREBadEntityTypeException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.BadEntityTypeException");
+	public static final CClassType TYPE = CClassType.get(CREBadEntityTypeException.class);
 
 	public CREBadEntityTypeException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBindException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREBindException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREBindException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.BindException");
+	public static final CClassType TYPE = CClassType.get(CREBindException.class);
 
 	public CREBindException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRECastException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRECastException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRECastException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.CastException");
+	public static final CClassType TYPE = CClassType.get(CRECastException.class);
 
 	public CRECastException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREClassDefinitionError.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREClassDefinitionError.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 @typeof("ms.lang.ClassDefinitionError")
 public class CREClassDefinitionError extends CREError {
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.ClassDefinitionError");
+	public static final CClassType TYPE = CClassType.get(CREClassDefinitionError.class);
 
 	public CREClassDefinitionError(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREEnchantmentException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREEnchantmentException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREEnchantmentException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.EnchantmentException");
+	public static final CClassType TYPE = CClassType.get(CREEnchantmentException.class);
 
 	public CREEnchantmentException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREError.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREError.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREError extends CREThrowable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Error");
+	public static final CClassType TYPE = CClassType.get(CREError.class);
 
 	public CREError(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREEventException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREEventException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREEventException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.EventException");
+	public static final CClassType TYPE = CClassType.get(CREEventException.class);
 
 	public CREEventException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREException extends CREThrowable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Exception");
+	public static final CClassType TYPE = CClassType.get(CREException.class);
 
 	public CREException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREFormatException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREFormatException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREFormatException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.FormatException");
+	public static final CClassType TYPE = CClassType.get(CREFormatException.class);
 
 	public CREFormatException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIOException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIOException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREIOException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.IOException");
+	public static final CClassType TYPE = CClassType.get(CREIOException.class);
 
 	public CREIOException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIllegalArgumentException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIllegalArgumentException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREIllegalArgumentException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.IllegalArgumentException");
+	public static final CClassType TYPE = CClassType.get(CREIllegalArgumentException.class);
 
 	public CREIllegalArgumentException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIncludeException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIncludeException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREIncludeException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.IncludeException");
+	public static final CClassType TYPE = CClassType.get(CREIncludeException.class);
 
 	public CREIncludeException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIndexOverflowException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREIndexOverflowException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREIndexOverflowException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.IndexOverflowException");
+	public static final CClassType TYPE = CClassType.get(CREIndexOverflowException.class);
 
 	public CREIndexOverflowException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInsufficientArgumentsException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInsufficientArgumentsException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREInsufficientArgumentsException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.InsufficientArgumentsException");
+	public static final CClassType TYPE = CClassType.get(CREInsufficientArgumentsException.class);
 
 	public CREInsufficientArgumentsException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInsufficientPermissionException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInsufficientPermissionException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREInsufficientPermissionException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.InsufficientPermissionException");
+	public static final CClassType TYPE = CClassType.get(CREInsufficientPermissionException.class);
 
 	public CREInsufficientPermissionException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidPluginException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidPluginException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREInvalidPluginException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.InvalidPluginException");
+	public static final CClassType TYPE = CClassType.get(CREInvalidPluginException.class);
 
 	public CREInvalidPluginException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidProcedureException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidProcedureException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREInvalidProcedureException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.InvalidProcedureException");
+	public static final CClassType TYPE = CClassType.get(CREInvalidProcedureException.class);
 
 	public CREInvalidProcedureException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidWorldException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREInvalidWorldException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREInvalidWorldException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.InvalidWorldException");
+	public static final CClassType TYPE = CClassType.get(CREInvalidWorldException.class);
 
 	public CREInvalidWorldException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRELengthException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRELengthException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRELengthException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.LengthException");
+	public static final CClassType TYPE = CClassType.get(CRELengthException.class);
 
 	public CRELengthException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRENotFoundException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRENotFoundException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRENotFoundException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.NotFoundException");
+	public static final CClassType TYPE = CClassType.get(CRENotFoundException.class);
 
 	public CRENotFoundException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRENullPointerException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRENullPointerException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRENullPointerException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.NullPointerException");
+	public static final CClassType TYPE = CClassType.get(CRENullPointerException.class);
 
 	public CRENullPointerException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREOAuthException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREOAuthException.java
@@ -14,7 +14,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREOAuthException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.auth.OAuthException");
+	public static final CClassType TYPE = CClassType.get(CREOAuthException.class);
 
 	public CREOAuthException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPlayerOfflineException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPlayerOfflineException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREPlayerOfflineException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.PlayerOfflineException");
+	public static final CClassType TYPE = CClassType.get(CREPlayerOfflineException.class);
 
 	public CREPlayerOfflineException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPluginChannelException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPluginChannelException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREPluginChannelException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.PluginChannelException");
+	public static final CClassType TYPE = CClassType.get(CREPluginChannelException.class);
 
 	public CREPluginChannelException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPluginInternalException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREPluginInternalException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREPluginInternalException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.PluginInternalException");
+	public static final CClassType TYPE = CClassType.get(CREPluginInternalException.class);
 
 	public CREPluginInternalException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRERangeException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRERangeException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRERangeException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.RangeException");
+	public static final CClassType TYPE = CClassType.get(CRERangeException.class);
 
 	public CRERangeException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREReadOnlyException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREReadOnlyException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREReadOnlyException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.ReadOnlyException");
+	public static final CClassType TYPE = CClassType.get(CREReadOnlyException.class);
 
 	public CREReadOnlyException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRESQLException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRESQLException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRESQLException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.SQLException");
+	public static final CClassType TYPE = CClassType.get(CRESQLException.class);
 
 	public CRESQLException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREScoreboardException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREScoreboardException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREScoreboardException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.ScoreboardException");
+	public static final CClassType TYPE = CClassType.get(CREScoreboardException.class);
 
 	public CREScoreboardException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CRESecurityException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CRESecurityException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CRESecurityException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.SecurityException");
+	public static final CClassType TYPE = CClassType.get(CRESecurityException.class);
 
 	public CRESecurityException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREShellException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREShellException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREShellException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.ShellException");
+	public static final CClassType TYPE = CClassType.get(CREShellException.class);
 
 	public CREShellException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREStackOverflowError.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREStackOverflowError.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREStackOverflowError extends CREError {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.StackOverflowError");
+	public static final CClassType TYPE = CClassType.get(CREStackOverflowError.class);
 
 	public CREStackOverflowError(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREThrowable.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREThrowable.java
@@ -3,12 +3,15 @@ package com.laytonsmith.core.exceptions.CRE;
 import com.laytonsmith.PureUtilities.Common.Annotations.ForceImplementation;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.typeof;
+import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.natives.interfaces.ArrayAccess;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.objects.ObjectType;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *
@@ -17,7 +20,7 @@ import com.laytonsmith.core.objects.ObjectType;
 public class CREThrowable extends AbstractCREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Throwable");
+	public static final CClassType TYPE = CClassType.get(CREThrowable.class);
 
 	@ForceImplementation
 	public CREThrowable(String msg, Target t) {
@@ -51,7 +54,16 @@ public class CREThrowable extends AbstractCREException {
 		if(this.getClass() == CREThrowable.class) {
 			return new CClassType[]{Mixed.TYPE};
 		} else {
-			return new CClassType[]{CClassType.get(this.getClass().getSuperclass().getAnnotation(typeof.class).value())};
+			try {
+				return new CClassType[]{
+					CClassType.get(FullyQualifiedClassName.forFullyQualifiedClass(
+							this.getClass().getSuperclass().getAnnotation(typeof.class).value()))
+				};
+			} catch(ClassNotFoundException ex) {
+				throw new Error("Subclasses can reliably return super.getSuperclasses() for this, ONLY if it follows"
+						+ " the rule that it only has one superclass, and that superclass is the underlying java"
+						+ " object as well. This appears to be wrong in " + this.getClass());
+			}
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUnageableMobException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUnageableMobException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREUnageableMobException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.UnageableMobException");
+	public static final CClassType TYPE = CClassType.get(CREUnageableMobException.class);
 
 	public CREUnageableMobException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUnsupportedOperationException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUnsupportedOperationException.java
@@ -19,7 +19,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREUnsupportedOperationException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.UnsupportedOperationException");
+	public static final CClassType TYPE = CClassType.get(CREUnsupportedOperationException.class);
 
 	public CREUnsupportedOperationException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUntameableMobException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/CREUntameableMobException.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public class CREUntameableMobException extends CREException {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("com.commandhelper.UntameableMobException");
+	public static final CClassType TYPE = CClassType.get(CREUntameableMobException.class);
 
 	public CREUntameableMobException(String msg, Target t) {
 		super(msg, t);

--- a/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
@@ -155,10 +155,10 @@ public abstract class AbstractFunction implements Function {
 				//Arrays take too long to toString, so we don't want to actually toString them here if
 				//we don't need to.
 				b.append("<arrayNotShown size:").append(((CArray) ccc).size()).append(">");
-			} else if(ccc instanceof CClosure) {
+			} else if(ccc.isInstanceOf(CClosure.class)) {
 				//The toString of a closure is too long, so let's not output them either.
 				b.append("<closureNotShown>");
-			} else if(ccc instanceof CString) {
+			} else if(ccc.isInstanceOf(CString.class)) {
 				String val = ccc.val().replace("\\", "\\\\").replace("'", "\\'");
 				int max = 1000;
 				if(val.length() > max) {

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -205,7 +205,8 @@ public class ArrayHandling {
 							return ca.get(index, t);
 						}
 					} catch (ConfigRuntimeException e) {
-						if(e instanceof CREIndexOverflowException) {
+						if(e instanceof CREThrowable
+								&& ((CREThrowable) e).isInstanceOf(CREIndexOverflowException.class)) {
 							if(defaultConstruct != null) {
 								return defaultConstruct;
 							}
@@ -224,7 +225,7 @@ public class ArrayHandling {
 						throw e;
 					}
 				}
-			} else if(args[0] instanceof ArrayAccess) {
+			} else if(args[0].isInstanceOf(ArrayAccess.class)) {
 				com.laytonsmith.core.natives.interfaces.Iterable aa
 						= (com.laytonsmith.core.natives.interfaces.Iterable) args[0];
 				if(index instanceof CSlice) {
@@ -291,10 +292,10 @@ public class ArrayHandling {
 			if(args.length == 0) {
 				throw new CRECastException("Argument 1 of array_get must be an array", t);
 			}
-			if(args[0] instanceof ArrayAccess) {
+			if(args[0].isInstanceOf(ArrayAccess.class)) {
 				ArrayAccess aa = (ArrayAccess) args[0];
 				if(!aa.canBeAssociative()) {
-					if(!(args[1] instanceof CInt) && !(args[1] instanceof CSlice)) {
+					if(!(args[1].isInstanceOf(CInt.class)) && !(args[1] instanceof CSlice)) {
 						throw new ConfigCompileException("Accessing an element as an associative array,"
 								+ " when it can only accept integers.", t);
 					}
@@ -952,7 +953,7 @@ public class ArrayHandling {
 
 		@Override
 		public CArray exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CArray && args[1] instanceof CInt) {
+			if(args[0] instanceof CArray && args[1].isInstanceOf(CInt.class)) {
 				CArray original = (CArray) args[0];
 				int size = (int) ((CInt) args[1]).getInt();
 				Mixed fill = CNull.NULL;
@@ -1109,7 +1110,7 @@ public class ArrayHandling {
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			// As an exception, strings aren't supported here. There's no reason to do this for a string that isn't accidental.
-			if(args[0] instanceof ArrayAccess && !(args[0] instanceof CString)) {
+			if(args[0].isInstanceOf(ArrayAccess.class) && !(args[0].isInstanceOf(CString.class))) {
 				ArrayAccess ca = (ArrayAccess) args[0];
 				CArray ca2 = new CArray(t);
 				for(Mixed c : ca.keySet()) {
@@ -1248,7 +1249,7 @@ public class ArrayHandling {
 				throw new CREInsufficientArgumentsException("array_merge must be called with at least two parameters", t);
 			}
 			for(Mixed arg : args) {
-				if(arg instanceof ArrayAccess) {
+				if(arg.isInstanceOf(ArrayAccess.class)) {
 					com.laytonsmith.core.natives.interfaces.Iterable cur
 							= (com.laytonsmith.core.natives.interfaces.Iterable) arg;
 					if(!cur.isAssociative()) {
@@ -1257,7 +1258,7 @@ public class ArrayHandling {
 						}
 					} else {
 						for(Mixed key : cur.keySet()) {
-							if(key instanceof CInt) {
+							if(key.isInstanceOf(CInt.class)) {
 								newArray.set(key, cur.get((int) ((CInt) key).getInt(), t), t);
 							} else {
 								newArray.set(key, cur.get(key.val(), t), t);
@@ -1392,7 +1393,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[0] instanceof ArrayAccess)) {
+			if(!(args[0].isInstanceOf(ArrayAccess.class))) {
 				throw new CRECastException("Expecting argument 1 to be an ArrayAccess type object", t);
 			}
 			StringBuilder b = new StringBuilder();
@@ -1517,7 +1518,7 @@ public class ArrayHandling {
 			}
 			try {
 				if(args.length == 2) {
-					if(args[1] instanceof CClosure) {
+					if(args[1].isInstanceOf(CClosure.class)) {
 						sortType = null;
 						customSort = (CClosure) args[1];
 					} else {
@@ -1576,7 +1577,7 @@ public class ArrayHandling {
 					int value;
 					if(c instanceof CNull) {
 						value = 0;
-					} else if(c instanceof CBoolean) {
+					} else if(c.isInstanceOf(CBoolean.class)) {
 						if(((CBoolean) c).getBoolean()) {
 							value = 1;
 						} else {
@@ -2304,7 +2305,7 @@ public class ArrayHandling {
 			if(!(args[0] instanceof com.laytonsmith.core.natives.interfaces.Iterable)) {
 				throw new CRECastException("Expecting an array for argument 1", t);
 			}
-			if(!(args[1] instanceof CClosure)) {
+			if(!(args[1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Expecting a closure for argument 2", t);
 			}
 			array = (com.laytonsmith.core.natives.interfaces.Iterable) args[0];
@@ -3037,7 +3038,7 @@ public class ArrayHandling {
 					throw new CREIllegalArgumentException("For associative arrays, only 2 parameters may be provided,"
 							+ " the comparison mode value is not used.", t);
 				}
-				if(args[2] instanceof CClosure) {
+				if(args[2].isInstanceOf(CClosure.class)) {
 					closure = Static.getObject(args[2], t, CClosure.class);
 				} else {
 					mode = ArgumentValidation.getEnum(args[2], ArrayIntersectComparisonMode.class, t);

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -421,7 +421,7 @@ public class BasicLogic {
 					if(evalStatement instanceof CSlice) { //More specific subclass of array, we can do more optimal handling here
 						long rangeLeft = ((CSlice) evalStatement).getStart();
 						long rangeRight = ((CSlice) evalStatement).getFinish();
-						if(value instanceof CInt) {
+						if(value.isInstanceOf(CInt.class)) {
 							long v = Static.getInt(value, t);
 							if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 									|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -435,7 +435,7 @@ public class BasicLogic {
 							if(inner instanceof CSlice) {
 								long rangeLeft = ((CSlice) inner).getStart();
 								long rangeRight = ((CSlice) inner).getFinish();
-								if(value instanceof CInt) {
+								if(value.isInstanceOf(CInt.class)) {
 									long v = Static.getInt(value, t);
 									if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 											|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -730,7 +730,7 @@ public class BasicLogic {
 						if(value instanceof CSlice) {
 							long rangeLeft = ((CSlice) value).getStart();
 							long rangeRight = ((CSlice) value).getFinish();
-							if(children.get(0).getData() instanceof CInt) {
+							if(children.get(0).getData().isInstanceOf(CInt.class)) {
 								long v = Static.getInt(children.get(0).getData(), t);
 								if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 										|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -990,7 +990,7 @@ public class BasicLogic {
 				throw new CREFormatException(this.getName() + " expects 2 arguments.", t);
 			}
 			if(args[1].typeof().equals(args[0].typeof())) {
-				if(args[0] instanceof CString && args[1] instanceof CString) {
+				if(args[0].isInstanceOf(CString.class) && args[1].isInstanceOf(CString.class)) {
 					// Check for actual string equality, so we don't do type massaging
 					// for numeric strings. Thus '2' !== '2.0'
 					return CBoolean.get(args[0].val().equals(args[1].val()));

--- a/src/main/java/com/laytonsmith/core/functions/BossBar.java
+++ b/src/main/java/com/laytonsmith/core/functions/BossBar.java
@@ -206,9 +206,9 @@ public class BossBar {
 			if(bar == null) {
 				throw new CRENotFoundException("That boss bar id does not exist.", t);
 			}
-			if(args[1] instanceof CString) {
+			if(args[1].isInstanceOf(CString.class)) {
 				bar.setTitle(args[1].val());
-			} else if(args[1] instanceof CDouble) {
+			} else if(args[1].isInstanceOf(CDouble.class)) {
 				try {
 					bar.setProgress(Static.getDouble(args[1], t));
 				} catch (IllegalArgumentException ex) {

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -1748,7 +1748,7 @@ public class Cmdline {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			requireCmdlineMode(environment, this, t);
-			if(!(args[0] instanceof CClosure)) {
+			if(!(args[0].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Expecting a closure for argument 1 of " + getName(), t);
 			}
 			environment.getEnv(GlobalEnv.class).SetCustom("cmdline_prompt", args[0]);

--- a/src/main/java/com/laytonsmith/core/functions/Commands.java
+++ b/src/main/java/com/laytonsmith/core/functions/Commands.java
@@ -85,7 +85,7 @@ public class Commands {
 		 * @param arg
 		 */
 		public static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
-			if(arg instanceof CClosure) {
+			if(arg.isInstanceOf(CClosure.class)) {
 				onTabComplete.remove(cmd.getName());
 				onTabComplete.put(cmd.getName(), (CClosure) arg);
 			} else {
@@ -350,7 +350,7 @@ public class Commands {
 		 * @param arg
 		 */
 		public static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
-			if(arg instanceof CClosure) {
+			if(arg.isInstanceOf(CClosure.class)) {
 				onCommand.remove(cmd.getName());
 				onCommand.put(cmd.getName(), (CClosure) arg);
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -456,7 +456,7 @@ public class Compiler {
 
 			// Look for typed assignments
 			for(int k = 0; k < list.size(); k++) {
-				if(list.get(k).getData() instanceof CClassType) {
+				if(list.get(k).getData().isInstanceOf(CClassType.class)) {
 					if(k == list.size() - 1) {
 						// This is not a typed assignment
 						break;
@@ -723,7 +723,7 @@ public class Compiler {
 			if(children.size() != 1) {
 				throw new ConfigCompileException(getName() + " can only take one parameter", t);
 			}
-			if(!(children.get(0).getData() instanceof CString)) {
+			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
 				throw new ConfigCompileException("Only hardcoded strings may be passed into " + getName(), t);
 			}
 			String value = children.get(0).getData().val();

--- a/src/main/java/com/laytonsmith/core/functions/Crypto.java
+++ b/src/main/java/com/laytonsmith/core/functions/Crypto.java
@@ -59,7 +59,7 @@ public class Crypto {
 
 	private static byte[] getByteArrayFromArg(Mixed c) {
 		byte[] val;
-		if(c instanceof CSecureString) {
+		if(c.isInstanceOf(CSecureString.class)) {
 			val = ArrayUtils.charToBytes(((CSecureString) c).getDecryptedCharArray());
 		} else {
 			val = c.val().getBytes();
@@ -448,7 +448,7 @@ public class Crypto {
 			}
 			try {
 				String val;
-				if(args[0] instanceof CSecureString) {
+				if(args[0].isInstanceOf(CSecureString.class)) {
 					val = new String(((CSecureString) args[0]).getDecryptedCharArray());
 				} else {
 					val = args[0].val();
@@ -519,7 +519,7 @@ public class Crypto {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String val;
-			if(args[0] instanceof CSecureString) {
+			if(args[0].isInstanceOf(CSecureString.class)) {
 				val = new String(((CSecureString) args[0]).getDecryptedCharArray());
 			} else {
 				val = args[0].val();

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -185,7 +185,7 @@ public class DataHandling {
 						String v;
 						if(value instanceof IVariable) {
 							v = ((IVariable) value).getVariableName();
-						} else if(value instanceof CString) {
+						} else if(value.isInstanceOf(CString.class)) {
 							v = ((CString) value).getQuote();
 						} else {
 							v = "@value";
@@ -365,7 +365,7 @@ public class DataHandling {
 			int offset = 0;
 			if(args.length == 3) {
 				offset = 1;
-				if(!(args[0] instanceof CClassType)) {
+				if(!(args[0].isInstanceOf(CClassType.class))) {
 					throw new ConfigCompileException("Expecting a ClassType for parameter 1 to assign", t);
 				}
 			}
@@ -1456,7 +1456,7 @@ public class DataHandling {
 							+ " be hard coded, and should not be dynamically determinable, since this is always a sign"
 							+ " of loose code flow, which should be avoided.", t);
 				}
-				if(!(children.get(0).getData() instanceof CInt)) {
+				if(!(children.get(0).getData().isInstanceOf(CInt.class))) {
 					throw new ConfigCompileException("break() only accepts integer values.", t);
 				}
 			}
@@ -1637,7 +1637,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CString);
+			return CBoolean.get(args[0].isInstanceOf(CString.class));
 		}
 
 		@Override
@@ -1696,7 +1696,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CByteArray);
+			return CBoolean.get(args[0].isInstanceOf(CByteArray.class));
 		}
 
 		@Override
@@ -1818,7 +1818,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CInt || args[0] instanceof CDouble);
+			return CBoolean.get(args[0].isInstanceOf(CInt.class) || args[0].isInstanceOf(CDouble.class));
 		}
 
 		@Override
@@ -1881,7 +1881,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CDouble);
+			return CBoolean.get(args[0].isInstanceOf(CDouble.class));
 		}
 
 		@Override
@@ -1942,7 +1942,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CInt);
+			return CBoolean.get(args[0].isInstanceOf(CInt.class));
 		}
 
 		@Override
@@ -2002,7 +2002,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CBoolean);
+			return CBoolean.get(args[0].isInstanceOf(CBoolean.class));
 		}
 
 		@Override
@@ -2284,7 +2284,7 @@ public class DataHandling {
 			List<String> varNames = new ArrayList<>();
 			boolean usesAssign = false;
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData() instanceof CClassType) {
+			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
 				returnType = (CClassType) nodes[0].getData();
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
@@ -2379,7 +2379,7 @@ public class DataHandling {
 			if(myProc.isPossiblyConstant()) {
 				//Oooh, it's possibly constant. So, let's run it with our children.
 				try {
-					FileOptions options = new FileOptions(new HashMap<String, String>());
+					FileOptions options = new FileOptions(new HashMap<>());
 					if(!children.isEmpty()) {
 						options = children.get(0).getFileOptions();
 					}
@@ -2391,7 +2391,8 @@ public class DataHandling {
 					//Yup! It worked. It's a const proc.
 					return c;
 				} catch (ConfigRuntimeException e) {
-					if(e instanceof CREInvalidProcedureException) {
+					if(e instanceof CREThrowable
+							&& ((CREThrowable) e).isInstanceOf(CREInvalidProcedureException.class)) {
 						//This is the only valid exception that doesn't strictly mean it's a bad
 						//call.
 						return null;
@@ -2883,7 +2884,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0] instanceof CClosure);
+			return CBoolean.get(args[0].isInstanceOf(CClosure.class));
 		}
 
 		@Override
@@ -2945,7 +2946,7 @@ public class DataHandling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String key;
-			if(args[0] instanceof CString) {
+			if(args[0].isInstanceOf(CString.class)) {
 				key = args[0].val();
 			} else if(args[0] instanceof CArray) {
 				if(((CArray) args[0]).isAssociative()) {
@@ -3016,7 +3017,7 @@ public class DataHandling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String key;
-			if(args[0] instanceof CString) {
+			if(args[0].isInstanceOf(CString.class)) {
 				key = args[0].val();
 			} else if(args[0] instanceof CArray) {
 				if(((CArray) args[0]).isAssociative()) {
@@ -3118,7 +3119,7 @@ public class DataHandling {
 			}
 			// Handle the closure type first thing
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData() instanceof CClassType) {
+			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
 				returnType = (CClassType) nodes[0].getData();
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
@@ -3237,7 +3238,7 @@ public class DataHandling {
 			}
 			// Handle the closure type first thing
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData() instanceof CClassType) {
+			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
 				returnType = (CClassType) nodes[0].getData();
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
@@ -3376,7 +3377,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[args.length - 1] instanceof CClosure) {
+			if(args[args.length - 1].isInstanceOf(CClosure.class)) {
 				Mixed[] vals = new Mixed[args.length - 1];
 				System.arraycopy(args, 0, vals, 0, args.length - 1);
 				CClosure closure = (CClosure) args[args.length - 1];
@@ -3431,7 +3432,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[args.length - 1] instanceof CClosure)) {
+			if(!(args[args.length - 1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Only a closure (created from the closure function) can be sent to executeas()", t);
 			}
 			Mixed[] vals = new Mixed[args.length - 3];
@@ -3693,7 +3694,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CString) {
+			if(args[0].isInstanceOf(CString.class)) {
 				return args[0];
 			}
 			return new CString(args[0].val(), t);
@@ -3993,7 +3994,7 @@ public class DataHandling {
 			try {
 				env.getEnv(GlobalEnv.class).SetDynamicScriptingMode(true);
 				Mixed script = parent.seval(node, env);
-				if(script instanceof CClosure) {
+				if(script.isInstanceOf(CClosure.class)) {
 					throw new CRECastException("Closures cannot be eval'd directly. Use execute() instead.", t);
 				}
 				ParseTree root = MethodScriptCompiler.compile(MethodScriptCompiler.lex(script.val(), t.file(), true),
@@ -4240,7 +4241,7 @@ public class DataHandling {
 				return CBoolean.FALSE;
 			}
 			CClassType type;
-			if(args[1] instanceof CClassType) {
+			if(args[1].isInstanceOf(CClassType.class)) {
 				type = (CClassType) args[1];
 			} else {
 				throw new RuntimeException("This should have been optimized out, this is a bug in instanceof,"
@@ -4283,7 +4284,7 @@ public class DataHandling {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions) throws ConfigCompileException, ConfigRuntimeException {
 			// There are two specific cases here where we will give more precise error messages.
 			// If it's a string, yell at them
-			if(children.get(1).getData() instanceof CString) {
+			if(children.get(1).getData().isInstanceOf(CString.class)) {
 				throw new ConfigCompileException("Unexpected string type passed to \"instanceof\"", t);
 			}
 			// If it's a variable, also yell at them
@@ -4291,7 +4292,7 @@ public class DataHandling {
 				throw new ConfigCompileException("Variable types are not allowed in \"instanceof\"", t);
 			}
 			// Unknown error, but this is still never valid.
-			if(!(children.get(1).getData() instanceof CClassType)) {
+			if(!(children.get(1).getData().isInstanceOf(CClassType.class))) {
 				throw new ConfigCompileException("Unexpected type for \"instanceof\": " + children.get(1).getData(), t);
 			}
 			// null is technically a type, but instanceof shouldn't work with that

--- a/src/main/java/com/laytonsmith/core/functions/Debug.java
+++ b/src/main/java/com/laytonsmith/core/functions/Debug.java
@@ -497,7 +497,7 @@ public class Debug {
 //				throw new ConfigRuntimeException("allow-debug-logging is currently set to false. To use " + this.getVariableName() + ", enable it in your preferences.", CRESecurityException.class, t);
 //			}
 //			Set<Event.Type> set = new HashSet<Event.Type>();
-//			if(args[0] instanceof CString) {
+//			if(args[0].isInstanceOf(CString.class)) {
 //				if(args[0].val().equals("*")) {
 //					for(Event.Type t : Event.Type.values()) {
 //						set.add(t);
@@ -572,7 +572,7 @@ public class Debug {
 //			if(!(Boolean) Static.getPreferences().getPreference("allow-debug-logging")) {
 //				throw new ConfigRuntimeException("allow-debug-logging is currently set to false. To use " + this.getVariableName() + ", enable it in your preferences.", CRESecurityException.class, t);
 //			}
-//			if(args[0] instanceof CString) {
+//			if(args[0].isInstanceOf(CString.class)) {
 //				EVENT_PLUGIN_FILTER.clear();
 //				EVENT_PLUGIN_FILTER.add(args[0].val().toUpperCase());
 //			} else if(args[0] instanceof CArray) {

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -796,7 +796,7 @@ public class Echoes {
 			if(args.length == 2) {
 				symbol = args[1].val();
 			}
-			if(text instanceof CString) {
+			if(text.isInstanceOf(CString.class)) {
 				String stext = text.val();
 				StringBuilder b = new StringBuilder();
 				int sl = symbol.length();

--- a/src/main/java/com/laytonsmith/core/functions/Enchantments.java
+++ b/src/main/java/com/laytonsmith/core/functions/Enchantments.java
@@ -69,7 +69,7 @@ public class Enchantments {
 	 * @return
 	 */
 	public static int ConvertLevel(Mixed value) {
-		if(value instanceof CInt) {
+		if(value.isInstanceOf(CInt.class)) {
 			return (int) ((CInt) value).getInt();
 		}
 		String lc = value.val().toLowerCase().trim();
@@ -813,7 +813,7 @@ public class Enchantments {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() == 1
-					&& (children.get(0).getData() instanceof CString || children.get(0).getData() instanceof CInt)) {
+					&& (children.get(0).getData().isInstanceOf(CString.class) || children.get(0).getData().isInstanceOf(CInt.class))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1145,7 +1145,7 @@ public class EntityManagement {
 			if(args.length >= 3) {
 				l = ObjectGenerator.GetGenerator().location(args[2], null, t);
 				if(args.length == 4) {
-					if(args[3] instanceof CClosure) {
+					if(args[3].isInstanceOf(CClosure.class)) {
 						consumer = (CClosure) args[3];
 					} else {
 						throw new CREIllegalArgumentException("Expected a closure as last argument for spawn_entity().", t);

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -853,7 +853,7 @@ public class Environment {
 				return null;
 			}
 			Mixed c = children.get(children.size() - 1).getData();
-			if(c instanceof CString) {
+			if(c.isInstanceOf(CString.class)) {
 				try {
 					MCBiomeType.valueOf(c.val());
 				} catch (IllegalArgumentException ex) {
@@ -1508,7 +1508,7 @@ public class Environment {
 					if(node.getData() instanceof CFunction && node.getData().val().equals("centry")) {
 						children = node.getChildren();
 						if(children.get(0).getData().val().equals("sound")
-								&& children.get(1).getData() instanceof CString) {
+								&& children.get(1).getData().isInstanceOf(CString.class)) {
 							try {
 								MCSound.MCVanillaSound.valueOf(children.get(1).getData().val().toUpperCase());
 							} catch (IllegalArgumentException ex) {
@@ -2066,7 +2066,7 @@ public class Environment {
 				throws ConfigRuntimeException {
 			String cmd = null;
 			if(args.length == 2 && !(args[1] instanceof CNull)) {
-				if(!(args[1] instanceof CString)) {
+				if(!(args[1].isInstanceOf(CString.class))) {
 					throw new CRECastException("Parameter 2 of " + getName() + " must be a string or null", t);
 				}
 				cmd = args[1].val();
@@ -2178,7 +2178,7 @@ public class Environment {
 		) throws ConfigRuntimeException {
 			String name = null;
 			if(args.length == 2 && !(args[1] instanceof CNull)) {
-				if(!(args[1] instanceof CString)) {
+				if(!(args[1].isInstanceOf(CString.class))) {
 					throw new CRECastException("Parameter 2 of " + getName() + " must be a string or null", t);
 				}
 				name = args[1].val();

--- a/src/main/java/com/laytonsmith/core/functions/Exceptions.java
+++ b/src/main/java/com/laytonsmith/core/functions/Exceptions.java
@@ -147,7 +147,7 @@ public class Exceptions {
 			List<FullyQualifiedClassName> interest = new ArrayList<>();
 			if(types != null) {
 				Mixed ptypes = that.seval(types, env);
-				if(ptypes instanceof CString) {
+				if(ptypes.isInstanceOf(CString.class)) {
 					interest.add(FullyQualifiedClassName.forName(ptypes.val(), t, env));
 				} else if(ptypes instanceof CArray) {
 					CArray ca = (CArray) ptypes;
@@ -347,7 +347,7 @@ public class Exceptions {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CClosure) {
+			if(args[0].isInstanceOf(CClosure.class)) {
 				CClosure old = environment.getEnv(GlobalEnv.class).GetExceptionHandler();
 				environment.getEnv(GlobalEnv.class).SetExceptionHandler((CClosure) args[0]);
 				if(old == null) {
@@ -530,7 +530,7 @@ public class Exceptions {
 				// TODO: Eh.. should probably move this check into the keyword, since techincally
 				// catch (Exception @e = null) { } would work.
 				ParseTree assign = children.get(i);
-				if(assign.getChildAt(0).getData() instanceof CString) {
+				if(assign.getChildAt(0).getData().isInstanceOf(CString.class)) {
 					// This is an unknown exception type, because otherwise it would have been cast to a CClassType
 					throw new ConfigCompileException("Unknown class type: " + assign.getChildAt(0).getData().val(), t);
 				}

--- a/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
@@ -57,7 +57,7 @@ public class ExecutionQueue {
 		public Mixed exec(Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final CClosure c;
 			String queue = null;
-			if(!(args[0] instanceof CClosure)) {
+			if(!(args[0].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Parameter 1 to " + getName() + " must be a closure.", t);
 			}
 			c = ((CClosure) args[0]);
@@ -139,7 +139,7 @@ public class ExecutionQueue {
 		public Mixed exec(Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final CClosure c;
 			String queue = null;
-			if(!(args[0] instanceof CClosure)) {
+			if(!(args[0].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Parameter 1 to " + getName() + " must be a closure.", t);
 			}
 			c = ((CClosure) args[0]);

--- a/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
@@ -109,7 +109,7 @@ public class ExtensionMeta {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
 			}
 
-			if(!(children.get(0).getData() instanceof CString)) {
+			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			}
 
@@ -186,7 +186,7 @@ public class ExtensionMeta {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
 			}
 
-			if(!(children.get(0).getData() instanceof CString)) {
+			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			}
 
@@ -256,7 +256,7 @@ public class ExtensionMeta {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions) throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() != 1) {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
-			} else if(!(children.get(0).getData() instanceof CString)) {
+			} else if(!(children.get(0).getData().isInstanceOf(CString.class))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			} else {
 				return new ParseTree(this.exec(t, null, children.get(0).getData()), children.get(0).getFileOptions());

--- a/src/main/java/com/laytonsmith/core/functions/FileHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/FileHandling.java
@@ -245,7 +245,7 @@ public class FileHandling {
 			startup();
 			final String file = args[0].val();
 			final CClosure callback;
-			if(!(args[1] instanceof CClosure)) {
+			if(!(args[1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Expected paramter 2 of " + getName() + " to be a closure!", t);
 			} else {
 				callback = ((CClosure) args[1]);

--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -701,7 +701,7 @@ public class InventoryManagement {
 		@Override
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
-			if(children.size() > 0 && children.get(children.size() - 1).getData() instanceof CString) {
+			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.class)) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -809,7 +809,7 @@ public class InventoryManagement {
 		@Override
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
-			if(children.size() > 0 && children.get(children.size() - 1).getData() instanceof CString) {
+			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.class)) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -877,7 +877,7 @@ public class InventoryManagement {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
-				if(args[0] instanceof CString) { // we assume player here, apparently
+				if(args[0].isInstanceOf(CString.class)) { // we assume player here, apparently
 					itemOffset = 1;
 				}
 			} else if(args.length == 4) {
@@ -926,7 +926,7 @@ public class InventoryManagement {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData() instanceof CString || children.get(1).getData() instanceof CInt)) {
+					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1045,7 +1045,7 @@ public class InventoryManagement {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData() instanceof CString || children.get(1).getData() instanceof CInt)) {
+					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1112,7 +1112,7 @@ public class InventoryManagement {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
-				if(args[0] instanceof CString) { // we assume player here, apparently
+				if(args[0].isInstanceOf(CString.class)) { // we assume player here, apparently
 					itemOffset = 1;
 				}
 			} else if(args.length == 4) {
@@ -1159,7 +1159,7 @@ public class InventoryManagement {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData() instanceof CString || children.get(1).getData() instanceof CInt)) {
+					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1276,7 +1276,7 @@ public class InventoryManagement {
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData() instanceof CString || children.get(1).getData() instanceof CInt)) {
+					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -2584,7 +2584,7 @@ public class InventoryManagement {
 			int size = 54;
 			String title = null;
 			if(args.length > 1) {
-				if(args[1] instanceof CNumber) {
+				if(args[1].isInstanceOf(CNumber.class)) {
 					size = Static.getInt32(args[1], t);
 					if(size < 9) {
 						size = 9; // minimum

--- a/src/main/java/com/laytonsmith/core/functions/Marquee.java
+++ b/src/main/java/com/laytonsmith/core/functions/Marquee.java
@@ -68,7 +68,7 @@ public class Marquee {
 			text = args[1 + offset].val();
 			stringWidth = Static.getInt32(args[2 + offset], t);
 			delayTime = Static.getInt32(args[3 + offset], t);
-			if(args[4 + offset] instanceof CClosure) {
+			if(args[4 + offset].isInstanceOf(CClosure.class)) {
 				callback = ((CClosure) args[4 + offset]);
 			} else {
 				throw new CRECastException("Expected argument " + (4 + offset + 1) + " to be a closure, but was not.", t);

--- a/src/main/java/com/laytonsmith/core/functions/Math.java
+++ b/src/main/java/com/laytonsmith/core/functions/Math.java
@@ -523,7 +523,7 @@ public class Math {
 				}
 				long delta = Static.getInt(cdelta, t);
 				//First, error check, then get the old value, and store it in temp.
-				if(!(array instanceof CArray) && !(array instanceof ArrayAccess)) {
+				if(!(array instanceof CArray) && !(array.isInstanceOf(ArrayAccess.class))) {
 					//Let's just evaluate this like normal with array_get, so it will
 					//throw the appropriate exception.
 					new ArrayHandling.array_get().exec(t, env, array, index);
@@ -539,7 +539,7 @@ public class Math {
 				Mixed value = myArray.get(index, t);
 
 				//Alright, now let's actually perform the increment, and store that in the array.
-				if(value instanceof CInt) {
+				if(value.isInstanceOf(CInt.class)) {
 					CInt newVal;
 					if(inc) {
 						newVal = new CInt(Static.getInt(value, t) + delta, t);
@@ -552,7 +552,7 @@ public class Math {
 					} else {
 						return value;
 					}
-				} else if(value instanceof CDouble) {
+				} else if(value.isInstanceOf(CDouble.class)) {
 					CDouble newVal;
 					if(inc) {
 						newVal = new CDouble(Static.getDouble(value, t) + delta, t);
@@ -1186,7 +1186,7 @@ public class Math {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CInt) {
+			if(args[0].isInstanceOf(CInt.class)) {
 				return new CInt(java.lang.Math.abs(Static.getInt(args[0], t)), t);
 			} else {
 				return new CDouble(java.lang.Math.abs(Static.getDouble(args[0], t)), t);
@@ -2463,7 +2463,7 @@ public class Math {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CInt) {
+			if(args[0].isInstanceOf(CInt.class)) {
 				return new CInt(-(Static.getInt(args[0], t)), t);
 			} else {
 				return new CDouble(-(Static.getDouble(args[0], t)), t);

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -859,7 +859,7 @@ public class Meta {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			CString s;
-			if(args[0] instanceof CString) {
+			if(args[0].isInstanceOf(CString.class)) {
 				s = (CString) args[0];
 			} else {
 				s = new CString(args[0].val(), t);

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -99,7 +99,7 @@ public class Minecraft {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args[0] instanceof CInt) {
+			if(args[0].isInstanceOf(CInt.class)) {
 				return new CInt(Static.getInt(args[0], t), t);
 			}
 			String c = args[0].val();
@@ -211,7 +211,7 @@ public class Minecraft {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			int i = -1;
 			int i2 = -1;
-			if(args[0] instanceof CString) {
+			if(args[0].isInstanceOf(CString.class)) {
 				//We also accept item notation
 				if(args[0].val().contains(":")) {
 					String[] split = args[0].val().split(":");
@@ -377,7 +377,7 @@ public class Minecraft {
 			if(children.size() < 1) {
 				return null;
 			}
-			if(children.get(0).getData() instanceof CString && children.get(0).getData().val().contains(":")
+			if(children.get(0).getData().isInstanceOf(CString.class) && children.get(0).getData().val().contains(":")
 					|| ArgumentValidation.isNumber(children.get(0).getData())) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Numeric ids are deprecated in max_stack_size()", t);
 			}
@@ -477,7 +477,7 @@ public class Minecraft {
 				return null;
 			}
 			Mixed effect = children.get(1).getData();
-			if(effect instanceof CString) {
+			if(effect.isInstanceOf(CString.class)) {
 				String effectName = effect.val().split(":")[0].toUpperCase();
 				try {
 					MCEffect.valueOf(effectName);

--- a/src/main/java/com/laytonsmith/core/functions/MobManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/MobManagement.java
@@ -711,7 +711,7 @@ public class MobManagement {
 			MCLivingEntity mob = Static.getLivingEntity(args[0], t);
 
 			MCPotionEffectType type = null;
-			if(args[1] instanceof CString) {
+			if(args[1].isInstanceOf(CString.class)) {
 				try {
 					type = MCPotionEffectType.valueOf(args[1].val().toUpperCase());
 				} catch (IllegalArgumentException ex) {

--- a/src/main/java/com/laytonsmith/core/functions/Objects.java
+++ b/src/main/java/com/laytonsmith/core/functions/Objects.java
@@ -167,7 +167,7 @@ public class Objects {
 			if(data.getData() instanceof CNull) {
 				return CNull.NULL;
 			}
-			if(!(data.getData() instanceof CString)) {
+			if(!(data.getData().isInstanceOf(CString.class))) {
 				throw new CREClassDefinitionError("Expected a string, but found " + data.getData() + " instead", t);
 			}
 			return data.getData();

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -1395,7 +1395,7 @@ public class PlayerManagement {
 					}
 				} else {
 					//if it's a number, we are setting F. Otherwise, it's a getter for the MCPlayer specified.
-					if(!(args[0] instanceof CInt)) {
+					if(!(args[0].isInstanceOf(CInt.class))) {
 						MCPlayer p2 = Static.GetPlayer(args[0], t);
 						l = p2.getLocation();
 					}
@@ -2180,7 +2180,7 @@ public class PlayerManagement {
 			MCPlayer m = Static.GetPlayer(args[0].val(), t);
 
 			MCPotionEffectType type = null;
-			if(args[1] instanceof CString) {
+			if(args[1].isInstanceOf(CString.class)) {
 				try {
 					type = MCPotionEffectType.valueOf(args[1].val().toUpperCase());
 				} catch (IllegalArgumentException ex) {
@@ -3314,7 +3314,7 @@ public class PlayerManagement {
 				ticks = args[0];
 			}
 			int tick = 0;
-			if(ticks instanceof CBoolean) {
+			if(ticks.isInstanceOf(CBoolean.class)) {
 				boolean value = ((CBoolean) ticks).getBoolean();
 				if(value) {
 					tick = 20;

--- a/src/main/java/com/laytonsmith/core/functions/Reflection.java
+++ b/src/main/java/com/laytonsmith/core/functions/Reflection.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -210,14 +212,18 @@ public class Reflection {
 				Set<ClassMirror<? extends Enum>> enums = ClassDiscovery.getDefaultInstance().getClassesWithAnnotationThatExtend(MEnum.class, Enum.class);
 				Set<ClassMirror<? extends DynamicEnum>> dEnums = ClassDiscovery.getDefaultInstance().getClassesWithAnnotationThatExtend(MDynamicEnum.class, DynamicEnum.class);
 				if(args.length == 1) {
-					//No name provided
-					for(ClassMirror<? extends Enum> e : enums) {
-						String name = (String) e.getAnnotation(MEnum.class).getValue("value");
-						a.push(CClassType.get(name), t);
-					}
-					for(ClassMirror<? extends DynamicEnum> d : dEnums) {
-						String name = (String) d.getAnnotation(MDynamicEnum.class).getValue("value");
-						a.push(CClassType.get(name), t);
+					try {
+						//No name provided
+						for(ClassMirror<? extends Enum> e : enums) {
+							String name = (String) e.getAnnotation(MEnum.class).getValue("value");
+							a.push(CClassType.get(FullyQualifiedClassName.forFullyQualifiedClass(name)), t);
+						}
+						for(ClassMirror<? extends DynamicEnum> d : dEnums) {
+							String name = (String) d.getAnnotation(MDynamicEnum.class).getValue("value");
+							a.push(CClassType.get(FullyQualifiedClassName.forFullyQualifiedClass(name)), t);
+						}
+					} catch(ClassNotFoundException ex) {
+						throw new Error(ex);
 					}
 				} else if(args.length == 2) {
 					FullyQualifiedClassName enumName = FullyQualifiedClassName.forName(args[1].val(), t, env);

--- a/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
+++ b/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
@@ -205,7 +205,7 @@ public class ResourceManager {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CResource) {
+			if(args[0].isInstanceOf(CResource.class)) {
 				CResource<?> resource = (CResource<?>) args[0];
 				if(RESOURCES.containsKey(resource.getId())) {
 					RESOURCES.remove(resource.getId());

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -195,15 +195,15 @@ public class SQL {
 							continue;
 						}
 						try {
-							if(params[i] instanceof CInt) {
+							if(params[i].isInstanceOf(CInt.class)) {
 								ps.setLong(i + 1, Static.getInt(params[i], t));
-							} else if(params[i] instanceof CDouble) {
+							} else if(params[i].isInstanceOf(CDouble.class)) {
 								ps.setDouble(i + 1, (Double) Static.getDouble(params[i], t));
-							} else if(params[i] instanceof CString) {
+							} else if(params[i].isInstanceOf(CString.class)) {
 								ps.setString(i + 1, (String) params[i].val());
-							} else if(params[i] instanceof CByteArray) {
+							} else if(params[i].isInstanceOf(CByteArray.class)) {
 								ps.setBytes(i + 1, ((CByteArray) params[i]).asByteArrayCopy());
-							} else if(params[i] instanceof CBoolean) {
+							} else if(params[i].isInstanceOf(CBoolean.class)) {
 								ps.setBoolean(i + 1, ArgumentValidation.getBoolean(params[i], t));
 							} else {
 								throw new CRECastException("The type " + params[i].getClass().getSimpleName()
@@ -326,7 +326,7 @@ public class SQL {
 							+ " must use concatenation, and you promise you know what you're doing, you"
 							+ " can use " + new unsafe_query().getName() + "() to supress this warning.", t);
 				}
-			} else if(queryData instanceof CString) {
+			} else if(queryData.isInstanceOf(CString.class)) {
 				//It's a hard coded query, so we can double check parameter lengths and other things
 				String query = queryData.val();
 				int count = 0;
@@ -347,7 +347,7 @@ public class SQL {
 				//Profile validation will simply ensure that the profile stated is listed in the profiles,
 				//and that a connection can in fact be made.
 				//Also need to figure out how to validate a prepared statement.
-//				if(children.get(0).isConst() && children.get(0).getData() instanceof CString){
+//				if(children.get(0).isConst() && children.get(0).getData().isInstanceOf(CString.class)){
 //					if(true){ //Prefs.verifyQueries()
 //						String profileName = children.get(0).getData().val();
 //						SQLProfiles.Profile profile = null;
@@ -478,7 +478,7 @@ public class SQL {
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			startup();
 			Mixed arg = args[args.length - 1];
-			if(!(arg instanceof CClosure)) {
+			if(!(arg.isInstanceOf(CClosure.class))) {
 				throw new CRECastException("The last argument to " + getName() + " must be a closure.", t);
 			}
 			final CClosure closure = ((CClosure) arg);

--- a/src/main/java/com/laytonsmith/core/functions/Sandbox.java
+++ b/src/main/java/com/laytonsmith/core/functions/Sandbox.java
@@ -603,7 +603,7 @@ public class Sandbox {
 			}
 
 			byte[] content;
-			if(!(args[1] instanceof CByteArray)) {
+			if(!(args[1].isInstanceOf(CByteArray.class))) {
 				content = args[1].val().getBytes(Charset.forName("UTF-8"));
 			} else {
 				content = ArgumentValidation.getByteArray(args[1], t).asByteArrayCopy();

--- a/src/main/java/com/laytonsmith/core/functions/Scheduling.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scheduling.java
@@ -275,7 +275,7 @@ public class Scheduling {
 				offset = 1;
 				delay = Static.getInt(args[1], t);
 			}
-			if(!(args[1 + offset] instanceof CClosure)) {
+			if(!(args[1 + offset].isInstanceOf(CClosure.class))) {
 				throw new CRECastException(getName() + " expects a closure to be sent as the second argument", t);
 			}
 			final CClosure c = (CClosure) args[1 + offset];
@@ -364,7 +364,7 @@ public class Scheduling {
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final TaskManager taskManager = environment.getEnv(GlobalEnv.class).GetTaskManager();
 			long time = Static.getInt(args[0], t);
-			if(!(args[1] instanceof CClosure)) {
+			if(!(args[1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException(getName() + " expects a closure to be sent as the second argument", t);
 			}
 			final CClosure c = (CClosure) args[1];
@@ -796,10 +796,10 @@ public class Scheduling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			//First things first, check the format of the arguments.
-			if(!(args[0] instanceof CString)) {
+			if(!(args[0].isInstanceOf(CString.class))) {
 				throw new CRECastException("Expected string for argument 1 in " + getName(), t);
 			}
-			if(!(args[1] instanceof CClosure)) {
+			if(!(args[1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Expected closure for argument 2 in " + getName(), t);
 			}
 			CronFormat format = validateFormat(args[0].val(), t);
@@ -1127,7 +1127,7 @@ public class Scheduling {
 		@Override
 		public ParseTree optimizeDynamic(Target t, Environment env, List<ParseTree> children, FileOptions fileOptions) throws ConfigCompileException, ConfigRuntimeException {
 			if(children.get(0).isConst()) {
-				if(children.get(0).getData() instanceof CString) {
+				if(children.get(0).getData().isInstanceOf(CString.class)) {
 					validateFormat(children.get(0).getData().val(), t);
 				}
 			}

--- a/src/main/java/com/laytonsmith/core/functions/StringHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/StringHandling.java
@@ -634,7 +634,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args[0] instanceof Sizeable) {
+			if(args[0].isInstanceOf(Sizeable.class)) {
 				return new CInt(((Sizeable) args[0]).size(), t);
 			} else {
 				return new CInt(args[0].val().length(), t);
@@ -696,7 +696,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0] instanceof CString)) {
+			if(!(args[0].isInstanceOf(CString.class))) {
 				throw new CREFormatException(this.getName() + " expects a string as first argument, but type "
 						+ args[0].typeof() + " was found.", t);
 			}
@@ -759,7 +759,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0] instanceof CString)) {
+			if(!(args[0].isInstanceOf(CString.class))) {
 				throw new CREFormatException(this.getName() + " expects a string as first argument, but type "
 						+ args[0].typeof() + " was found.", t);
 			}
@@ -2477,10 +2477,10 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0] instanceof CSecureString) {
+			if(args[0].isInstanceOf(CSecureString.class)) {
 				CSecureString secure = ArgumentValidation.getObject(args[0], t, CSecureString.class);
 				return secure.getDecryptedCharCArray();
-			} else if(args[0] instanceof CString) {
+			} else if(args[0].isInstanceOf(CString.class)) {
 				CArray array = new CArray(Target.UNKNOWN, args[0].val().length());
 				for(char c : args[0].val().toCharArray()) {
 					array.push(new CString(c, t), t);

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -72,7 +72,7 @@ public class Threading {
 		@Override
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String id = args[0].val();
-			if(!(args[1] instanceof CClosure)) {
+			if(!(args[1].isInstanceOf(CClosure.class))) {
 				throw new CRECastException("Expected closure for arg 2", t);
 			}
 			final CClosure closure = (CClosure) args[1];

--- a/src/main/java/com/laytonsmith/core/functions/Weather.java
+++ b/src/main/java/com/laytonsmith/core/functions/Weather.java
@@ -141,9 +141,9 @@ public class Weather {
 			MCWorld w = null;
 			int duration = -1;
 			if(args.length == 2) {
-				if(args[1] instanceof CString) {
+				if(args[1].isInstanceOf(CString.class)) {
 					w = Static.getServer().getWorld(args[1].val());
-				} else if(args[1] instanceof CInt) {
+				} else if(args[1].isInstanceOf(CInt.class)) {
 					duration = Static.getInt32(args[1], t);
 				} else {
 					throw new CREFormatException("", t);

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -231,7 +231,7 @@ public class Web {
 			final boolean binary;
 			final String textEncoding;
 			boolean useDefaultHeaders = true;
-			if(args[1] instanceof CClosure) {
+			if(args[1].isInstanceOf(CClosure.class)) {
 				success = (CClosure) args[1];
 				error = null;
 				arrayJar = null;
@@ -304,7 +304,7 @@ public class Web {
 						}
 						settings.setComplexParameters(mparams);
 					} else {
-						if(csettings.get("params", t) instanceof CByteArray) {
+						if(csettings.get("params", t).isInstanceOf(CByteArray.class)) {
 							CByteArray b = (CByteArray) csettings.get("params", t);
 							settings.setRawParameter(b.asByteArrayCopy());
 						} else {
@@ -327,7 +327,7 @@ public class Web {
 				}
 				//Only required parameter
 				if(csettings.containsKey("success")) {
-					if(csettings.get("success", t) instanceof CClosure) {
+					if(csettings.get("success", t).isInstanceOf(CClosure.class)) {
 						success = (CClosure) csettings.get("success", t);
 					} else {
 						throw new CRECastException("Expecting the success parameter to be a closure.", t);
@@ -336,7 +336,7 @@ public class Web {
 					throw new CRECastException("Missing the success parameter, which is required.", t);
 				}
 				if(csettings.containsKey("error")) {
-					if(csettings.get("error", t) instanceof CClosure) {
+					if(csettings.get("error", t).isInstanceOf(CClosure.class)) {
 						error = (CClosure) csettings.get("error", t);
 					} else {
 						throw new CRECastException("Expecting the error parameter to be a closure.", t);
@@ -373,7 +373,7 @@ public class Web {
 				}
 				if(csettings.containsKey("trustStore")) {
 					Mixed trustStore = csettings.get("trustStore", t);
-					if(trustStore instanceof CBoolean && ArgumentValidation.getBoolean(trustStore, t) == false) {
+					if(trustStore.isInstanceOf(CBoolean.class) && ArgumentValidation.getBoolean(trustStore, t) == false) {
 						settings.setDisableCertChecking(true);
 					} else if(trustStore instanceof CArray) {
 						CArray trustStoreA = ((CArray) trustStore);
@@ -843,7 +843,7 @@ public class Web {
 			String body = ArgumentValidation.getItemFromArray(options, "body", t, new CString("", t)).val();
 			Mixed cto = ArgumentValidation.getItemFromArray(options, "to", t, null);
 			CArray to;
-			if(cto instanceof CString) {
+			if(cto.isInstanceOf(CString.class)) {
 				to = new CArray(t);
 				to.push(cto, t);
 			} else {
@@ -1029,9 +1029,9 @@ public class Web {
 		 * @return
 		 */
 		private Object getContent(Mixed c, Target t) {
-			if(c instanceof CString) {
+			if(c.isInstanceOf(CString.class)) {
 				return c.val();
-			} else if(c instanceof CByteArray) {
+			} else if(c.isInstanceOf(CByteArray.class)) {
 				CByteArray cb = (CByteArray) c;
 				return cb.asByteArrayCopy();
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -913,7 +913,7 @@ public class World {
 				creator.type(type).environment(environment);
 			}
 			if((args.length >= 4) && !(args[3] instanceof CNull)) {
-				if(args[3] instanceof CInt) {
+				if(args[3].isInstanceOf(CInt.class)) {
 					creator.seed(Static.getInt(args[3], t));
 				} else {
 					creator.seed(args[3].val().hashCode());

--- a/src/main/java/com/laytonsmith/core/functions/bash/BashPlatformResolver.java
+++ b/src/main/java/com/laytonsmith/core/functions/bash/BashPlatformResolver.java
@@ -13,7 +13,7 @@ public class BashPlatformResolver implements PlatformResolver {
 
 	@Override
 	public String outputConstant(Mixed c) {
-		if(c instanceof CString) {
+		if(c.isInstanceOf(CString.class)) {
 			return "\"" + c.val() + "\"";
 		} else if(c instanceof CArray) {
 			throw new RuntimeException("Not implemented yet");

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/AbstractMixedInterfaceRunner.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/AbstractMixedInterfaceRunner.java
@@ -116,7 +116,7 @@ public abstract class AbstractMixedInterfaceRunner implements MixedInterfaceRunn
 	 */
 	@Override
 	public final CClassType typeof() {
-		return CClassType.get(getName());
+		return Construct.typeof(this);
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccess.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/ArrayAccess.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public interface ArrayAccess extends Mixed {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.ArrayAccess");
+	public static final CClassType TYPE = CClassType.get(ArrayAccess.class);
 
 	/**
 	 * Return the mixed at this location. This should throw an exception if the index does not exist. This method will

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Booleanish.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Booleanish.java
@@ -13,7 +13,7 @@ import com.laytonsmith.core.constructs.Target;
 public interface Booleanish extends Mixed {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Booleanish");
+	public static final CClassType TYPE = CClassType.get(Booleanish.class);
 
 	/**
 	 * Returns true if this value is a trueish value. Each implementation is free to define this as they wish. In

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Iterable.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Iterable.java
@@ -15,6 +15,6 @@ import com.laytonsmith.core.constructs.CClassType;
 public interface Iterable extends ArrayAccess, Sizeable {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Iterable");
+	public static final CClassType TYPE = CClassType.get(Iterable.class);
 
 }

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
@@ -39,7 +39,7 @@ public abstract class MEnumType implements Mixed, com.laytonsmith.core.natives.i
 
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.enum");
+	public static final CClassType TYPE = CClassType.get(MEnumType.class);
 
 	/**
 	 * Generates a new MEnumType subclass.

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Mixed.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Mixed.java
@@ -20,7 +20,7 @@ import java.util.Set;
 public interface Mixed extends Cloneable, Documentation {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.mixed");
+	public static final CClassType TYPE = CClassType.get(Mixed.class);
 
 	public String val();
 

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Sizeable.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Sizeable.java
@@ -10,7 +10,7 @@ import com.laytonsmith.core.constructs.CClassType;
 public interface Sizeable extends Mixed {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.Sizeable");
+	public static final CClassType TYPE = CClassType.get(Sizeable.class);
 
 	/**
 	 * Returns the size of this object.

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/ValueType.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/ValueType.java
@@ -22,7 +22,7 @@ import com.laytonsmith.core.constructs.CClassType;
 public interface ValueType extends Mixed {
 
 	@SuppressWarnings("FieldNameHidesFieldInSuperclass")
-	public static final CClassType TYPE = CClassType.get("ms.lang.ValueType");
+	public static final CClassType TYPE = CClassType.get(ValueType.class);
 
 	/**
 	 * Returns a duplicated value of this object. The duplicate MUST be equals(), and it MUST NOT be ref_equals(). The


### PR DESCRIPTION
This changes the code everwhere to use .isInstanceof instead of instanceof, since
this is needed for user objects to work. However, the code is *incredibly* slow,
so much so that RandomTests takes 60 seconds on my computer. I added some caches,
but that didn't really work well enough either. So the next thought is to add this
to the jarInfo perhaps, but even still, once user classes are added,that will increase
startup time even more, so I think this has to be solved in a more general way. I think
the next step is to very closely examine the code path of isInstanceOf, and see what
steps are there today, and figure up if any can be removed, replaced with more efficient
mechanisms, or at least further cached.

This will serve as the basis of the continued work on objects, but until this is fixed,
it utterly kills the runtime performance, and simply cannot be merged in to master.