### PR TITLE
Tipped arrow update (Fix ClassCastException in ProjectileLaunchEvent)

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCTippedArrow.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCTippedArrow.java
@@ -3,7 +3,7 @@ package com.laytonsmith.abstraction.bukkit.entities;
 import com.laytonsmith.abstraction.MCLivingEntity;
 import com.laytonsmith.abstraction.MCPotionData;
 import com.laytonsmith.abstraction.bukkit.BukkitMCPotionData;
-import com.laytonsmith.abstraction.entities.MCTippedArrow;
+import com.laytonsmith.abstraction.entities.MCArrow;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCPotionEffectType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.TippedArrow;
@@ -14,7 +14,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BukkitMCTippedArrow extends BukkitMCArrow implements MCTippedArrow {
+public class BukkitMCTippedArrow extends BukkitMCArrow implements MCArrow {
 
 	TippedArrow ta;
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCTippedArrow.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCTippedArrow.java
@@ -6,7 +6,7 @@ import com.laytonsmith.abstraction.bukkit.BukkitMCPotionData;
 import com.laytonsmith.abstraction.entities.MCArrow;
 import com.laytonsmith.abstraction.enums.bukkit.BukkitMCPotionEffectType;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.TippedArrow;
+import org.bukkit.entity.Arrow;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -16,11 +16,11 @@ import java.util.List;
 
 public class BukkitMCTippedArrow extends BukkitMCArrow implements MCArrow {
 
-	TippedArrow ta;
+	Arrow ta;
 
 	public BukkitMCTippedArrow(Entity ta) {
 		super(ta);
-		this.ta = (TippedArrow) ta;
+		this.ta = (Arrow) ta;
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCTippedArrow.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCTippedArrow.java
@@ -1,19 +1,9 @@
 package com.laytonsmith.abstraction.entities;
 
-import com.laytonsmith.abstraction.MCLivingEntity;
-import com.laytonsmith.abstraction.MCPotionData;
-
-import java.util.List;
-
+/**
+ * @deprecated The {@link org.bukkit.entity.TippedArrow} interface has been deprecated on 30-04-2019.
+ * Use the {@link MCArrow} interface instead.
+ */
+@Deprecated
 public interface MCTippedArrow extends MCArrow {
-
-	MCPotionData getBasePotionData();
-
-	List<MCLivingEntity.MCEffect> getCustomEffects();
-
-	void addCustomEffect(MCLivingEntity.MCEffect effect);
-
-	void clearCustomEffects();
-
-	void setBasePotionData(MCPotionData data);
 }

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCTippedArrow.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCTippedArrow.java
@@ -1,9 +1,0 @@
-package com.laytonsmith.abstraction.entities;
-
-/**
- * @deprecated The {@link org.bukkit.entity.TippedArrow} interface has been deprecated on 30-04-2019.
- * Use the {@link MCArrow} interface instead.
- */
-@Deprecated
-public interface MCTippedArrow extends MCArrow {
-}

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -68,7 +68,6 @@ import com.laytonsmith.abstraction.entities.MCSnowman;
 import com.laytonsmith.abstraction.entities.MCSpectralArrow;
 import com.laytonsmith.abstraction.entities.MCTNT;
 import com.laytonsmith.abstraction.entities.MCThrownPotion;
-import com.laytonsmith.abstraction.entities.MCTippedArrow;
 import com.laytonsmith.abstraction.entities.MCTrident;
 import com.laytonsmith.abstraction.entities.MCTropicalFish;
 import com.laytonsmith.abstraction.entities.MCVillager;
@@ -1995,7 +1994,7 @@ public class EntityManagement {
 					specArray.set(entity_spec.KEY_SPLASH_POTION_ITEM, ObjectGenerator.GetGenerator().item(potion.getItem(), t), t);
 					break;
 				case TIPPED_ARROW: // 1.13 only
-					MCTippedArrow tippedarrow = (MCTippedArrow) entity;
+					MCArrow tippedarrow = (MCArrow) entity;
 					specArray.set(entity_spec.KEY_ARROW_CRITICAL, CBoolean.get(tippedarrow.isCritical()), t);
 					specArray.set(entity_spec.KEY_ARROW_KNOCKBACK, new CInt(tippedarrow.getKnockbackStrength(), t), t);
 					specArray.set(entity_spec.KEY_ARROW_DAMAGE, new CDouble(tippedarrow.getDamage(), t), t);
@@ -2289,7 +2288,7 @@ public class EntityManagement {
 								if(Static.getServer().getMinecraftVersion().lt(MCVersion.MC1_14)) {
 									throwException(index, t);
 								}
-								MCTippedArrow tipped = (MCTippedArrow) arrow;
+								MCArrow tipped = (MCArrow) arrow;
 								Mixed c = specArray.get(index, t);
 								if(c.isInstanceOf(CArray.class)) {
 									CArray meta = (CArray) c;
@@ -3086,7 +3085,7 @@ public class EntityManagement {
 					}
 					break;
 				case TIPPED_ARROW:
-					MCTippedArrow tippedarrow = (MCTippedArrow) entity;
+					MCArrow tippedarrow = (MCArrow) entity;
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_ARROW_CRITICAL:


### PR DESCRIPTION
CraftTippedArrow in CraftBukkit changed from implementing TippedArrow to implementing Arrow. This causes an incompatibility that is fixed in this PR.

Bukkit changes for reference:
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/c7c4cb533f426888e9eb4f1e07a6b9bb2236f476#src/main/java/org/bukkit/entity/TippedArrow.java