### PR TITLE
Fix build failure

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CFunction.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CFunction.java
@@ -100,7 +100,7 @@ public class CFunction extends Construct {
 			} else {
 				return false;
 			}
-		} catch(ConfigCompileException ex) {
+		} catch (ConfigCompileException ex) {
 			return false;
 		}
 	}

--- a/src/main/java/com/laytonsmith/core/objects/Element.java
+++ b/src/main/java/com/laytonsmith/core/objects/Element.java
@@ -113,6 +113,7 @@ public abstract class Element extends Construct {
 	 * The access modifier of the element.
 	 * @return
 	 */
+	@Override
 	public AccessModifier getAccessModifier() {
 		return accessModifier;
 	}
@@ -159,6 +160,7 @@ public abstract class Element extends Construct {
 		return name;
 	}
 
+	@Override
 	public Target getTarget() {
 		return t;
 	}

--- a/src/main/java/com/laytonsmith/core/objects/ElementDefinition.java
+++ b/src/main/java/com/laytonsmith/core/objects/ElementDefinition.java
@@ -9,7 +9,6 @@ import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
-import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import java.lang.reflect.Field;
 import java.util.Objects;

--- a/src/main/java/com/laytonsmith/core/objects/ElementDefinition.java
+++ b/src/main/java/com/laytonsmith/core/objects/ElementDefinition.java
@@ -134,6 +134,7 @@ public abstract class ElementDefinition extends Construct {
 	 * The access modifier of the element.
 	 * @return
 	 */
+	@Override
 	public AccessModifier getAccessModifier() {
 		return accessModifier;
 	}
@@ -173,6 +174,7 @@ public abstract class ElementDefinition extends Construct {
 		return name;
 	}
 
+	@Override
 	public Target getTarget() {
 		return t;
 	}

--- a/src/main/java/com/laytonsmith/core/objects/ObjectDefinition.java
+++ b/src/main/java/com/laytonsmith/core/objects/ObjectDefinition.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 


### PR DESCRIPTION
The PureUtilities CheckOverrides causes the build to fail when @override annotations are missing.