### PR TITLE
Fix operator order documentation and add operator associativity

### DIFF
--- a/src/main/resources/docs/Operators
+++ b/src/main/resources/docs/Operators
@@ -32,23 +32,26 @@ if((@var == 3) && (2 <= @var2)){
 
 The following operators are supported, and their order of operations is from top to bottom. Note that all 
 operators are simply converted to the functional notation, so if your code is incorrect, the errors you 
-get will specify function names.
+get will specify function names. Associativity tells in which order operators with equal priority are executed. This can be left (to right), right (to left) or non-assoc (not allowed to combine or nest).
 
 {| class="wikitable"
 |-
 ! Type
 ! Symbol
 ! Function Conversion
+! Associativity
 ! Notes
 |-
 | ''Postfix''
 | ++ --
 | {{function|postinc}}/{{function|postdec}}
+| Non-assoc
 | This is only considered postfix when it comes after an identifier: @i++
 |-
 | ''Array Sub-indices''
 | %%NOWIKI|[ ]%%
 | {{function|array_get}}
+| Left
 | Using square braces allows for array accesses, and in combination with the <code>=</code> sign, setting sub-indices.
 If the array set appears on the right hand side of an assignment, or in a general statement without an assign, it is an
 array_get operation. If it appears on the left hand side of an assignment, it is an array_set operation. The brackets
@@ -62,46 +65,55 @@ still uses array_get). Sub-strings within strings may be pulled out using the br
 | ''Unary''
 | ! ++ --
 | {{function|not}}/{{function|inc}}/{{function|dec}}
+| Non-assoc
 | These are ''unary'' operators, they only operate on one identifier
 |-
 | ''Exponential''
 | **
 | {{function|pow}}
+| Left
 | 
 |-
 | ''Multiplicative''
 | * / %
 | {{function|multiply}}/{{function|divide}}/{{function|mod}}
+| Left
 |
 |-
 | ''Additive''
 | + - .
 | {{function|add}}/{{function|subtract}}/{{function|concat}}
+| Left
 | If a minus or plus sign is used to denote the sign of a number, it is handled slightly differently, for instance, ''2 + -1'' does not use any subtraction
 |-
 | ''Relational''
 | &lt; &gt; &lt;= &gt;=
 | {{function|lt}}/{{function|gt}}/{{function|lte}}/{{function|gte}}
+| Left
 |
 |-
 | ''Equality''
 | == != === !==
 | {{function|equals}}/{{function|nequals}}/{{function|sequals}}/{{function|snequals}}
+| Left
 | There is no operational equivalent for equals_ic
 |-
 | ''Logical AND''
 | &&
 | {{function|and}}
+| Left
 |
 |-
 | ''Logical OR''
 | &#124;&#124;
 | {{function|or}}
+| Left
 |
 |-
 | ''Assignment''
 | = += -= *= /= .= []= []+= []-= []*= []/= [].=
 | {{function|assign}}/{{function|array_set}}/{{function|array_push}}
+| Right
 | There is no single functional equivalent except for = per se, <code>@var += 1</code> is equivalent to 
 <code>assign(@var, add(@var, 1))</code>, etc. += uses {{function|add}}, 
 -= uses {{function|subtract}}, *= uses {{function|multiply}}, /= uses {{function|divide}}, and .= uses {{function|concat}}.

--- a/src/main/resources/docs/Operators
+++ b/src/main/resources/docs/Operators
@@ -46,6 +46,19 @@ get will specify function names.
 | {{function|postinc}}/{{function|postdec}}
 | This is only considered postfix when it comes after an identifier: @i++
 |-
+| ''Array Sub-indices''
+| %%NOWIKI|[ ]%%
+| {{function|array_get}}
+| Using square braces allows for array accesses, and in combination with the <code>=</code> sign, setting sub-indices.
+If the array set appears on the right hand side of an assignment, or in a general statement without an assign, it is an
+array_get operation. If it appears on the left hand side of an assignment, it is an array_set operation. The brackets
+apply to the element just preceeding, for instance with <code>@var['index']</code>, it is assumed that <code>@var</code>
+is an array or array like value. Empty braces, <code>[]</code>, when on the left hand side works as an array push, and
+when on the right hand side, or in a general statement without an assign, it is an array clone operation (which ultimately
+still uses array_get). Sub-strings within strings may be pulled out using the bracket notation as well, and slices are supported.
+<code>array(1, 2, 3)[1..2]</code> returns an array with 2 elements in it, namely 2 and 3. <code>'string'[0]</code> returns
+'s', and <code>'string'[0..1]</code> returns 'st'.
+|-
 | ''Unary''
 | ! ++ --
 | {{function|not}}/{{function|inc}}/{{function|dec}}
@@ -83,29 +96,18 @@ get will specify function names.
 |
 |-
 | ''Logical OR''
-| %%NOWIKI|||%%
+| &#124;&#124;
 | {{function|or}}
 |
 |-
 | ''Assignment''
-| = += -= *= /= .=
-| {{function|assign}}
+| = += -= *= /= .= []= []+= []-= []*= []/= [].=
+| {{function|assign}}/{{function|array_set}}/{{function|array_push}}
 | There is no single functional equivalent except for = per se, <code>@var += 1</code> is equivalent to 
 <code>assign(@var, add(@var, 1))</code>, etc. += uses {{function|add}}, 
--= uses {{function|subtract}}, *= uses {{function|multiply}}, /= uses {{function|divide}}, and .= uses {{function|concat}}. 
-|-
-| ''Array Sub-indices''
-| %%NOWIKI|[ ]%%
-| {{function|array_get}}/{{function|array_set}}/{{function|array_push}}
-| Using square braces allows for array accesses, and in combination with the <code>=</code> sign, setting sub-indices.
-If the array set appears on the right hand side of an assignment, or in a general statement without an assign, it is an
-array_get operation. If it appears on the left hand side of an assignment, it is an array_set operation. The brackets
-apply to the element just preceeding, for instance with <code>@var['index']</code>, it is assumed that <code>@var</code>
-is an array or array like value. Empty braces, <code>[]</code>, when on the left hand side works as an array push, and
-when on the right hand side, or in a general statement without an assign, it is an array clone operation (which ultimately
-still uses array_get). Sub-strings within strings may be pulled out using the bracket notation as well, and slices are supported.
-<code>array(1, 2, 3)[1..2]</code> returns an array with 2 elements in it, namely 2 and 3. <code>'string'[0]</code> returns
-'s', and <code>'string'[0..1]</code> returns 'st'.
+-= uses {{function|subtract}}, *= uses {{function|multiply}}, /= uses {{function|divide}}, and .= uses {{function|concat}}.
+Square brackets with an assign indicate that a value is being assigned to the array element at the index that is given between the square brackets.
+If no index is given, the value is appended to the end of the array.
 |}
 
 Note the lack of bitwise operators, which are usually standard in other languages. These are not provided, because the 

--- a/src/main/resources/docs/Operators
+++ b/src/main/resources/docs/Operators
@@ -64,7 +64,6 @@ still uses array_get). Sub-strings within strings may be pulled out using the br
 | {{function|not}}/{{function|inc}}/{{function|dec}}
 | These are ''unary'' operators, they only operate on one identifier
 |-
-|-
 | ''Exponential''
 | **
 | {{function|pow}}


### PR DESCRIPTION
Since there is no obvious way to view rendered docs locally, the rendering of these changes has not been tested.