### PR TITLE
Fix void handling for proc return types and assignment

### DIFF
--- a/src/main/java/com/laytonsmith/core/Procedure.java
+++ b/src/main/java/com/laytonsmith/core/Procedure.java
@@ -235,9 +235,12 @@ public class Procedure implements Cloneable {
 		} catch (FunctionReturnException e) {
 			// Normal exit
 			Mixed ret = e.getReturn();
-			if(!InstanceofUtil.isInstanceof(ret, returnType, env)) {
-				throw new CRECastException("Expected procedure \"" + name + "\" to return a value of type " + returnType.val()
-						+ " but a value of type " + ret.typeof() + " was returned instead", ret.getTarget());
+			if(returnType.equals(CVoid.TYPE) != ret.equals(CVoid.VOID)
+					|| !ret.equals(CNull.NULL) && !ret.equals(CVoid.VOID)
+					&& !InstanceofUtil.isInstanceof(ret, returnType, env)) {
+				throw new CRECastException("Expected procedure \"" + name + "\" to return a value of type "
+						+ returnType.val() + " but a value of type " + ret.typeof() + " was returned instead",
+						ret.getTarget());
 			}
 			return ret;
 		} catch (LoopManipulationException ex) {

--- a/src/main/java/com/laytonsmith/core/Procedure.java
+++ b/src/main/java/com/laytonsmith/core/Procedure.java
@@ -235,6 +235,9 @@ public class Procedure implements Cloneable {
 		} catch (FunctionReturnException e) {
 			// Normal exit
 			Mixed ret = e.getReturn();
+			if(returnType.equals(Auto.TYPE)) {
+				return ret;
+			}
 			if(returnType.equals(CVoid.TYPE) != ret.equals(CVoid.VOID)
 					|| !ret.equals(CNull.NULL) && !ret.equals(CVoid.VOID)
 					&& !InstanceofUtil.isInstanceof(ret, returnType, env)) {

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -462,7 +462,7 @@ public class Compiler {
 
 			// Look for typed assignments
 			for(int k = 0; k < list.size(); k++) {
-				if(list.get(k).getData().isInstanceOf(CClassType.class)) {
+				if(list.get(k).getData().equals(CVoid.VOID) || list.get(k).getData().isInstanceOf(CClassType.class)) {
 					if(k == list.size() - 1) {
 						// This is not a typed assignment
 						break;
@@ -476,6 +476,11 @@ public class Compiler {
 							case "assign":
 							case "proc":
 								// Typed assign/closure
+								if(list.get(k + 1).getData().val().equals("assign")
+										&& list.get(k).getData().equals(CVoid.VOID)) {
+									throw new ConfigCompileException("Variables may not be of type void",
+											list.get(k).getTarget());
+								}
 								ParseTree type = list.remove(k);
 								List<ParseTree> children = list.get(k).getChildren();
 								children.add(0, type);

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -1167,8 +1167,12 @@ public class DataHandling {
 			List<String> varNames = new ArrayList<>();
 			boolean usesAssign = false;
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
-				returnType = (CClassType) nodes[0].getData();
+			if(nodes[0].getData().equals(CVoid.VOID) || nodes[0].getData().isInstanceOf(CClassType.class)) {
+				if(nodes[0].getData().equals(CVoid.VOID)) {
+					returnType = CVoid.TYPE;
+				} else {
+					returnType = (CClassType) nodes[0].getData();
+				}
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
 					newNodes[i - 1] = nodes[i];
@@ -1183,7 +1187,7 @@ public class DataHandling {
 				} else {
 					boolean thisNodeIsAssign = false;
 					if(nodes[i].getData() instanceof CFunction) {
-						if(((CFunction) nodes[i].getData()).val().equals("assign")) {
+						if((nodes[i].getData()).val().equals("assign")) {
 							thisNodeIsAssign = true;
 							if((nodes[i].getChildren().size() == 3 && Construct.IsDynamicHelper(nodes[i].getChildAt(0).getData()))
 									|| Construct.IsDynamicHelper(nodes[i].getChildAt(1).getData())) {
@@ -1194,23 +1198,23 @@ public class DataHandling {
 					env.getEnv(GlobalEnv.class).SetFlag("no-check-duplicate-assign", true);
 					Mixed cons = parent.eval(nodes[i], env);
 					env.getEnv(GlobalEnv.class).ClearFlag("no-check-duplicate-assign");
-					if(i == 0 && cons instanceof IVariable) {
-						throw new CREInvalidProcedureException("Anonymous Procedures are not allowed", t);
-					} else if(i == 0 && !(cons instanceof IVariable)) {
+					if(i == 0) {
+						if(cons instanceof IVariable) {
+							throw new CREInvalidProcedureException("Anonymous Procedures are not allowed", t);
+						}
 						name = cons.val();
-					} else if(!(cons instanceof IVariable)) {
-						throw new CREInvalidProcedureException("You must use IVariables as the arguments", t);
 					} else {
+						if(!(cons instanceof IVariable)) {
+							throw new CREInvalidProcedureException("You must use IVariables as the arguments", t);
+						}
 						IVariable ivar = null;
 						try {
 							Mixed c = cons;
-							if(c instanceof IVariable) {
-								String varName = ((IVariable) c).getVariableName();
-								if(varNames.contains(varName)) {
-									throw new CREInvalidProcedureException("Same variable name defined twice in " + name, t);
-								}
-								varNames.add(varName);
+							String varName = ((IVariable) c).getVariableName();
+							if(varNames.contains(varName)) {
+								throw new CREInvalidProcedureException("Same variable name defined twice in " + name, t);
 							}
+							varNames.add(varName);
 							while(c instanceof IVariable) {
 								c = env.getEnv(GlobalEnv.class).GetVarList().get(((IVariable) c).getVariableName(), t,
 										true, env).ival();

--- a/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
@@ -6,6 +6,8 @@ import com.laytonsmith.abstraction.MCServer;
 import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
+import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.RunCommand;
 import static com.laytonsmith.testing.StaticTest.SRun;
@@ -17,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -310,5 +314,30 @@ public class DataHandlingTest {
 	public void testEmptyClosureFunction() throws Exception {
 		// This should not throw an exception
 		SRun("closure()", null);
+	}
+
+	@Test
+	public void testAssignmentTypes1() throws Exception {
+		SRun("string @ivar = 'value'", null);
+	}
+
+	@Test
+	public void testAssignmentTypes2() throws Exception {
+		try {
+			SRun("array @ivar = 'value'", null);
+			fail("Excepted a CastException because string is not array");
+		} catch (CRECastException ex) {
+			// Test passed.
+		}
+	}
+
+	@Test
+	public void testAssignmentTypes3() throws Exception {
+		try {
+			SRun("void @ivar = 'value'", null);
+			fail("Expected a compile exception because IVariable cannot be assigned to void");
+		} catch (ConfigCompileException ex) {
+			// Test passed.
+		}
 	}
 }

--- a/src/test/java/com/laytonsmith/testing/ProcedureTest.java
+++ b/src/test/java/com/laytonsmith/testing/ProcedureTest.java
@@ -94,6 +94,11 @@ public class ProcedureTest {
 	}
 
 	@Test
+	public void testProcReturnType6() throws Exception {
+		SRun("proc _blah(){ return() } _blah()", null);
+	}
+
+	@Test
 	public void testProcCalledMultipleTimes() throws Exception {
 		SRun("proc(_blah, @blah, msg(@blah)) _blah('blah') _blah('blarg')", fakePlayer);
 		verify(fakePlayer).sendMessage("blah");

--- a/src/test/java/com/laytonsmith/testing/ProcedureTest.java
+++ b/src/test/java/com/laytonsmith/testing/ProcedureTest.java
@@ -2,10 +2,14 @@ package com.laytonsmith.testing;
 
 import com.laytonsmith.abstraction.MCPlayer;
 import static com.laytonsmith.testing.StaticTest.SRun;
+
+import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import org.bukkit.plugin.Plugin;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,6 +51,46 @@ public class ProcedureTest {
 	public void testProcWithArguments() throws Exception {
 		SRun("proc(_blah, msg(@arguments)) _blah(1, 2, 3, 4)", fakePlayer);
 		verify(fakePlayer).sendMessage("{1, 2, 3, 4}");
+	}
+
+	@Test
+	public void testProcReturnType1() throws Exception {
+		SRun("void proc _blah(){ return() } _blah()", null);
+	}
+
+	@Test
+	public void testProcReturnType2() throws Exception {
+		try {
+			SRun("void proc _blah(){ return(null) } _blah()", null);
+			fail("Expected a CastException because null return is not void");
+		} catch (CRECastException ex) {
+			// Test passed.
+		}
+	}
+
+	@Test
+	public void testProcReturnType3() throws Exception {
+		try {
+			SRun("string proc _blah(){ return() } _blah()", null);
+			fail("Expected a CastException because void return is not of type string");
+		} catch (CRECastException ex) {
+			// Test passed.
+		}
+	}
+
+	@Test
+	public void testProcReturnType4() throws Exception {
+		try {
+			SRun("string proc _blah(){ return(array()) } _blah()", null);
+			fail("Expected a CastException because array is not of type string");
+		} catch (CRECastException ex) {
+			// Test passed.
+		}
+	}
+
+	@Test
+	public void testProcReturnType5() throws Exception {
+		SRun("string proc _blah(){ return(null) } _blah()", null);
 	}
 
 	@Test


### PR DESCRIPTION
The tests should make it obvious what I was going for here, but I'm not sure this is entirely consistent with your plans. void is a bit weird.

Also, there's a bit of hard-to-read code that I cleaned up in the latter part of getProcedure() too. So, if you're wondering what I changed there, it does exactly the same thing. It's just easier to understand now.