### PR TITLE
Fix unknown target in CompositeFunction

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -51,7 +51,6 @@ public abstract class CompositeFunction extends AbstractFunction {
 				tree = MethodScriptCompiler.compile(MethodScriptCompiler.lex(script, null, true), environment)
 						// the root of the tree is null, so go ahead and pull it up
 						.getChildAt(0);
-				setTarget(tree, t);
 			} catch (ConfigCompileException | ConfigCompileGroupException ex) {
 				// This is really bad.
 				throw new Error(ex);
@@ -62,6 +61,7 @@ public abstract class CompositeFunction extends AbstractFunction {
 		} else {
 			tree = CACHED_SCRIPTS.get(this.getClass());
 		}
+		setTarget(tree, t);
 
 		GlobalEnv env = environment.getEnv(GlobalEnv.class);
 		IVariableList oldVariables = env.GetVarList();

--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -32,6 +32,13 @@ public abstract class CompositeFunction extends AbstractFunction {
 
 	private static final Map<Class<? extends CompositeFunction>, ParseTree> CACHED_SCRIPTS = new HashMap<>();
 
+	private static void setTarget(ParseTree tree, Target t) {
+		tree.getData().setTarget(t);
+		for(ParseTree child : tree.getChildren()) {
+			setTarget(child, t);
+		}
+	}
+
 	@Override
 	public final Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 		ParseTree tree;
@@ -44,6 +51,7 @@ public abstract class CompositeFunction extends AbstractFunction {
 				tree = MethodScriptCompiler.compile(MethodScriptCompiler.lex(script, null, true), environment)
 						// the root of the tree is null, so go ahead and pull it up
 						.getChildAt(0);
+				setTarget(tree, t);
 			} catch (ConfigCompileException | ConfigCompileGroupException ex) {
 				// This is really bad.
 				throw new Error(ex);

--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -32,13 +32,6 @@ public abstract class CompositeFunction extends AbstractFunction {
 
 	private static final Map<Class<? extends CompositeFunction>, ParseTree> CACHED_SCRIPTS = new HashMap<>();
 
-	private static void setTarget(ParseTree tree, Target t) {
-		tree.getData().setTarget(t);
-		for(ParseTree child : tree.getChildren()) {
-			setTarget(child, t);
-		}
-	}
-
 	@Override
 	public final Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 		ParseTree tree;
@@ -61,7 +54,6 @@ public abstract class CompositeFunction extends AbstractFunction {
 		} else {
 			tree = CACHED_SCRIPTS.get(this.getClass());
 		}
-		setTarget(tree, t);
 
 		GlobalEnv env = environment.getEnv(GlobalEnv.class);
 		IVariableList oldVariables = env.GetVarList();
@@ -78,6 +70,10 @@ public abstract class CompositeFunction extends AbstractFunction {
 			}
 		} catch (FunctionReturnException ex) {
 			ret = ex.getReturn();
+		} catch (ConfigRuntimeException ex) {
+			ex.setTarget(t);
+			env.GetStackTraceManager().setCurrentTarget(t);
+			throw ex;
 		}
 		env.SetVarList(oldVariables);
 

--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -71,8 +71,10 @@ public abstract class CompositeFunction extends AbstractFunction {
 		} catch (FunctionReturnException ex) {
 			ret = ex.getReturn();
 		} catch (ConfigRuntimeException ex) {
-			ex.setTarget(t);
-			env.GetStackTraceManager().setCurrentTarget(t);
+			if(ex.getTarget().file() == null) {
+				ex.setTarget(t);
+				env.GetStackTraceManager().setCurrentTarget(t);
+			}
 			throw ex;
 		}
 		env.SetVarList(oldVariables);


### PR DESCRIPTION
You can easily reproduce this problem using below code
```
@a = null
broadcast(string_contains(@a, 't'))
```
Then CommadHelper will print unknown source of error.
So I tried simple way to fix that. 
But I'm not sure that is this correct way. Please review this.