### PR TITLE
The null should be not contain in get_all_recipes()

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
@@ -567,7 +567,10 @@ public class BukkitMCServer implements MCServer {
 		List<MCRecipe> ret = new ArrayList<>();
 		for(Iterator<Recipe> recipes = s.recipeIterator(); recipes.hasNext();) {
 			Recipe recipe = recipes.next();
-			ret.add(BukkitConvertor.BukkitGetRecipe(recipe));
+			MCRecipe mcRecipe = BukkitConvertor.BukkitGetRecipe(recipe);
+			if(mcRecipe != null) {
+				ret.add(mcRecipe);
+			}
 		}
 		return ret;
 	}

--- a/src/main/java/com/laytonsmith/core/functions/Recipes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Recipes.java
@@ -177,9 +177,7 @@ public class Recipes {
 			CArray ret = new CArray(t);
 			List<MCRecipe> recipes = Static.getServer().allRecipes();
 			for(MCRecipe recipe : recipes) {
-				if(recipe != null) {
-					ret.push(ObjectGenerator.GetGenerator().recipe(recipe, t), t);
-				}
+				ret.push(ObjectGenerator.GetGenerator().recipe(recipe, t), t);
 			}
 
 			return ret;

--- a/src/main/java/com/laytonsmith/core/functions/Recipes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Recipes.java
@@ -177,7 +177,9 @@ public class Recipes {
 			CArray ret = new CArray(t);
 			List<MCRecipe> recipes = Static.getServer().allRecipes();
 			for(MCRecipe recipe : recipes) {
-				ret.push(ObjectGenerator.GetGenerator().recipe(recipe, t), t);
+				if(recipe != null) {
+					ret.push(ObjectGenerator.GetGenerator().recipe(recipe, t), t);
+				}
 			}
 
 			return ret;


### PR DESCRIPTION
If a recipe is not supported type, returns null. [Check it](https://github.com/EngineHub/CommandHelper/blob/89017ed2b790c5847c8e54438f1b666510290826/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java#L678)
There is unsupported types: `BlastingRecipe, CampfireRecipe, SmokingRecipe, StonecuttingRecipe`

Is there a case for null checking to how many types unsupported in CH? I don't think that
