### PR TITLE
Use cached CClassType earlier in isInstanceOf()

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
@@ -212,7 +212,7 @@ public class BukkitMCCommand implements MCCommand {
 				Mixed fret = closure.executeCallable(null, t, new CString(alias, t), new CString(sender.getName(), t), cargs,
 						new CArray(t) // reserved for an obgen style command array
 				);
-				if(fret.isInstanceOf(CArray.class)) {
+				if(fret.isInstanceOf(CArray.TYPE)) {
 					List<String> ret = new ArrayList<>();
 					if(((CArray) fret).inAssociativeMode()) {
 						for(Mixed key : ((CArray) fret).keySet()) {
@@ -253,7 +253,7 @@ public class BukkitMCCommand implements MCCommand {
 				Mixed fret = closure.executeCallable(null, t, new CString(label, t), new CString(sender.getName(), t), cargs,
 						new CArray(t) // reserved for an obgen style command array
 				);
-				if(fret.isInstanceOf(CBoolean.class)) {
+				if(fret.isInstanceOf(CBoolean.TYPE)) {
 					return ((CBoolean) fret).getBoolean();
 				}
 			} catch (ConfigRuntimeException cre) {

--- a/src/main/java/com/laytonsmith/core/ArgumentValidation.java
+++ b/src/main/java/com/laytonsmith/core/ArgumentValidation.java
@@ -69,7 +69,7 @@ public final class ArgumentValidation {
 	 * @return
 	 */
 	public static CArray getArray(Mixed construct, Target t) {
-		if(construct.isInstanceOf(CArray.class)) {
+		if(construct.isInstanceOf(CArray.TYPE)) {
 			return ((CArray) construct);
 		} else {
 			throw new CRECastException("Expecting array, but received " + construct.val(), t);
@@ -233,9 +233,9 @@ public final class ArgumentValidation {
 		if(c == null || c instanceof CNull) {
 			return 0;
 		}
-		if(c.isInstanceOf(CInt.class)) {
+		if(c.isInstanceOf(CInt.TYPE)) {
 			i = getObject(c, t, CInt.class).getInt();
-		} else if(c.isInstanceOf(CBoolean.class)) {
+		} else if(c.isInstanceOf(CBoolean.TYPE)) {
 			if(getObject(c, t, CBoolean.class).getBoolean()) {
 				i = 1;
 			} else {
@@ -513,7 +513,7 @@ public final class ArgumentValidation {
 		if(c instanceof CNull) {
 			return EnumSet.noneOf(enumClass);
 		}
-		if(!c.isInstanceOf(CArray.class)) {
+		if(!c.isInstanceOf(CArray.TYPE)) {
 			Mixed val = c;
 			c = new CArray(t);
 			((CArray) c).push(val, t);

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -152,7 +152,7 @@ public class ObjectGenerator {
 	 * world. <em>More conveniently: ([world], x, y, z, [yaw, pitch])</em>
 	 */
 	public MCLocation location(Mixed c, MCWorld w, Target t) {
-		if(!(c.isInstanceOf(CArray.class))) {
+		if(!(c.isInstanceOf(CArray.TYPE))) {
 			throw new CREFormatException("Expecting an array, received " + c.typeof().getSimpleName(), t);
 		}
 		CArray array = (CArray) c;
@@ -255,7 +255,7 @@ public class ObjectGenerator {
 		if(i instanceof CNull) {
 			return EmptyItem();
 		}
-		if(!(i.isInstanceOf(CArray.class))) {
+		if(!(i.isInstanceOf(CArray.TYPE))) {
 			throw new CREFormatException("Expected an array!", t);
 		}
 		CArray item = (CArray) i;
@@ -292,7 +292,7 @@ public class ObjectGenerator {
 				}
 			} else {
 				Mixed type = item.get("type", t);
-				if(type.isInstanceOf(CString.class)) {
+				if(type.isInstanceOf(CString.TYPE)) {
 					int seperatorIndex = type.val().indexOf(':');
 					if(seperatorIndex != -1) {
 						try {
@@ -324,7 +324,7 @@ public class ObjectGenerator {
 			// convert legacy meta to material
 			if(material.getName().equals("PIG_SPAWN_EGG") && item.containsKey("meta")) {
 				Mixed meta = item.get("meta", t);
-				if(meta.isInstanceOf(CArray.class) && ((CArray) meta).containsKey("spawntype")) {
+				if(meta.isInstanceOf(CArray.TYPE) && ((CArray) meta).containsKey("spawntype")) {
 					Mixed spawntype = ((CArray) meta).get("spawntype", t);
 					if(!(spawntype instanceof CNull)) {
 						MCMaterial newmaterial;
@@ -646,7 +646,7 @@ public class ObjectGenerator {
 			return meta;
 		}
 		CArray ma;
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			ma = (CArray) c;
 			try {
 				if(ma.containsKey("display")) {
@@ -659,11 +659,11 @@ public class ObjectGenerator {
 					Mixed li = ma.get("lore", t);
 					if(li instanceof CNull) {
 						//do nothing
-					} else if(li.isInstanceOf(CString.class)) {
+					} else if(li.isInstanceOf(CString.TYPE)) {
 						List<String> ll = new ArrayList<>();
 						ll.add(li.val());
 						meta.setLore(ll);
-					} else if(li.isInstanceOf(CArray.class)) {
+					} else if(li.isInstanceOf(CArray.TYPE)) {
 						CArray la = (CArray) li;
 						List<String> ll = new ArrayList<>();
 						for(int j = 0; j < la.size(); j++) {
@@ -676,7 +676,7 @@ public class ObjectGenerator {
 				}
 				if(ma.containsKey("enchants")) {
 					Mixed enchants = ma.get("enchants", t);
-					if(enchants.isInstanceOf(CArray.class)) {
+					if(enchants.isInstanceOf(CArray.TYPE)) {
 						for(Map.Entry<MCEnchantment, Integer> ench : enchants((CArray) enchants, t).entrySet()) {
 							meta.addEnchant(ench.getKey(), ench.getValue(), true);
 						}
@@ -698,7 +698,7 @@ public class ObjectGenerator {
 				}
 				if(ma.containsKey("flags")) {
 					Mixed flags = ma.get("flags", t);
-					if(flags.isInstanceOf(CArray.class)) {
+					if(flags.isInstanceOf(CArray.TYPE)) {
 						CArray flagArray = (CArray) flags;
 						for(int i = 0; i < flagArray.size(); i++) {
 							Mixed flag = flagArray.get(i, t);
@@ -727,7 +727,7 @@ public class ObjectGenerator {
 						if(ma.containsKey("inventory")) {
 							MCInventory inv = ((MCInventoryHolder) bs).getInventory();
 							Mixed cInvRaw = ma.get("inventory", t);
-							if(cInvRaw.isInstanceOf(CArray.class)) {
+							if(cInvRaw.isInstanceOf(CArray.TYPE)) {
 								CArray cinv = (CArray) cInvRaw;
 								for(String key : cinv.stringKeySet()) {
 									try {
@@ -855,7 +855,7 @@ public class ObjectGenerator {
 					MCFireworkEffectMeta femeta = (MCFireworkEffectMeta) meta;
 					if(ma.containsKey("effect")) {
 						Mixed cfem = ma.get("effect", t);
-						if(cfem.isInstanceOf(CArray.class)) {
+						if(cfem.isInstanceOf(CArray.TYPE)) {
 							femeta.setEffect(fireworkEffect((CArray) cfem, t));
 						} else if(!(cfem instanceof CNull)) {
 							throw new CREFormatException("FireworkCharge effect was expected to be an array or null.", t);
@@ -865,7 +865,7 @@ public class ObjectGenerator {
 					MCFireworkMeta fmeta = (MCFireworkMeta) meta;
 					if(ma.containsKey("firework")) {
 						Mixed construct = ma.get("firework", t);
-						if(construct.isInstanceOf(CArray.class)) {
+						if(construct.isInstanceOf(CArray.TYPE)) {
 							CArray firework = (CArray) construct;
 							if(firework.containsKey("strength")) {
 								fmeta.setStrength(Static.getInt32(firework.get("strength", t), t));
@@ -873,9 +873,9 @@ public class ObjectGenerator {
 							if(firework.containsKey("effects")) {
 								// New style (supports multiple effects)
 								Mixed effects = firework.get("effects", t);
-								if(effects.isInstanceOf(CArray.class)) {
+								if(effects.isInstanceOf(CArray.TYPE)) {
 									for(Mixed effect : ((CArray) effects).asList()) {
-										if(effect.isInstanceOf(CArray.class)) {
+										if(effect.isInstanceOf(CArray.TYPE)) {
 											fmeta.addEffect(fireworkEffect((CArray) effect, t));
 										} else {
 											throw new CREFormatException("Firework effect was expected to be an array.", t);
@@ -897,7 +897,7 @@ public class ObjectGenerator {
 						Mixed ci = ma.get("color", t);
 						if(ci instanceof CNull) {
 							//nothing
-						} else if(ci.isInstanceOf(CArray.class)) {
+						} else if(ci.isInstanceOf(CArray.TYPE)) {
 							((MCLeatherArmorMeta) meta).setColor(color((CArray) ci, t));
 						} else {
 							throw new CREFormatException("Color was expected to be an array.", t);
@@ -920,7 +920,7 @@ public class ObjectGenerator {
 						Mixed pages = ma.get("pages", t);
 						if(pages instanceof CNull) {
 							//nothing
-						} else if(pages.isInstanceOf(CArray.class)) {
+						} else if(pages.isInstanceOf(CArray.TYPE)) {
 							CArray pa = (CArray) pages;
 							List<String> pl = new ArrayList<>();
 							for(int j = 0; j < pa.size(); j++) {
@@ -943,7 +943,7 @@ public class ObjectGenerator {
 						Mixed stored = ma.get("stored", t);
 						if(stored instanceof CNull) {
 							//Still doing nothing
-						} else if(stored.isInstanceOf(CArray.class)) {
+						} else if(stored.isInstanceOf(CArray.TYPE)) {
 							for(Map.Entry<MCEnchantment, Integer> ench : enchants((CArray) stored, t).entrySet()) {
 								((MCEnchantmentStorageMeta) meta).addStoredEnchant(ench.getKey(), ench.getValue(), true);
 							}
@@ -954,7 +954,7 @@ public class ObjectGenerator {
 				} else if(meta instanceof MCPotionMeta) {
 					if(ma.containsKey("potions")) {
 						Mixed effects = ma.get("potions", t);
-						if(effects.isInstanceOf(CArray.class)) {
+						if(effects.isInstanceOf(CArray.TYPE)) {
 							for(MCLivingEntity.MCEffect e : potions((CArray) effects, t)) {
 								((MCPotionMeta) meta).addCustomEffect(e.getPotionEffectType(), e.getStrength(),
 										e.getTicksRemaining(), e.isAmbient(), e.hasParticles(), e.showIcon(), true, t);
@@ -965,16 +965,16 @@ public class ObjectGenerator {
 					}
 					if(ma.containsKey("base")) {
 						Mixed potiondata = ma.get("base", t);
-						if(potiondata.isInstanceOf(CArray.class)) {
+						if(potiondata.isInstanceOf(CArray.TYPE)) {
 							CArray pd = (CArray) potiondata;
 							((MCPotionMeta) meta).setBasePotionData(potionData((CArray) potiondata, t));
 						}
 					}
 					if(ma.containsKey("color")) {
 						Mixed color = ma.get("color", t);
-						if(color.isInstanceOf(CArray.class)) {
+						if(color.isInstanceOf(CArray.TYPE)) {
 							((MCPotionMeta) meta).setColor(color((CArray) color, t));
-						} else if(color.isInstanceOf(CString.class)) {
+						} else if(color.isInstanceOf(CString.TYPE)) {
 							((MCPotionMeta) meta).setColor(StaticLayer.GetConvertor().GetColor(color.val(), t));
 						}
 					}
@@ -1001,7 +1001,7 @@ public class ObjectGenerator {
 				} else if(meta instanceof MCMapMeta) {
 					if(ma.containsKey("color")) {
 						Mixed ci = ma.get("color", t);
-						if(ci.isInstanceOf(CArray.class)) {
+						if(ci.isInstanceOf(CArray.TYPE)) {
 							((MCMapMeta) meta).setColor(color((CArray) ci, t));
 						} else if(!(ci instanceof CNull)) {
 							throw new CREFormatException("Color was expected to be an array.", t);
@@ -1180,7 +1180,7 @@ public class ObjectGenerator {
 	 * @return the Vector
 	 */
 	public Vector3D vector(Vector3D v, Mixed c, Target t) {
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			CArray va = (CArray) c;
 			double x = v.X();
 			double y = v.Y();
@@ -1238,7 +1238,7 @@ public class ObjectGenerator {
 			Mixed value = enchantArray.get(key, t);
 			if(enchantArray.isAssociative()) {
 				etype = StaticLayer.GetEnchantmentByName(key);
-				if(etype != null && value.isInstanceOf(CInt.class)) {
+				if(etype != null && value.isInstanceOf(CInt.TYPE)) {
 					ret.put(etype, Static.getInt32(value, t));
 					continue;
 				}
@@ -1281,7 +1281,7 @@ public class ObjectGenerator {
 	public List<MCLivingEntity.MCEffect> potions(CArray ea, Target t) {
 		List<MCLivingEntity.MCEffect> ret = new ArrayList<>();
 		for(String key : ea.stringKeySet()) {
-			if(ea.get(key, t).isInstanceOf(CArray.class)) {
+			if(ea.get(key, t).isInstanceOf(CArray.TYPE)) {
 				CArray effect = (CArray) ea.get(key, t);
 				MCPotionEffectType type;
 				int strength = 0;
@@ -1349,7 +1349,7 @@ public class ObjectGenerator {
 		boolean upgraded = false;
 		if(pd.containsKey("extended")) {
 			Mixed cext = pd.get("extended", t);
-			if(cext.isInstanceOf(CBoolean.class)) {
+			if(cext.isInstanceOf(CBoolean.TYPE)) {
 				extended = ((CBoolean) cext).getBoolean();
 			} else {
 				throw new CREFormatException(
@@ -1358,7 +1358,7 @@ public class ObjectGenerator {
 		}
 		if(pd.containsKey("upgraded")) {
 			Mixed cupg = pd.get("upgraded", t);
-			if(cupg.isInstanceOf(CBoolean.class)) {
+			if(cupg.isInstanceOf(CBoolean.TYPE)) {
 				upgraded = ((CBoolean) cupg).getBoolean();
 			} else {
 				throw new CREFormatException(
@@ -1405,18 +1405,18 @@ public class ObjectGenerator {
 		}
 		if(fe.containsKey("colors")) {
 			Mixed colors = fe.get("colors", t);
-			if(colors.isInstanceOf(CArray.class)) {
+			if(colors.isInstanceOf(CArray.TYPE)) {
 				CArray ccolors = (CArray) colors;
 				if(ccolors.size() == 0) {
 					builder.addColor(MCColor.WHITE);
 				} else {
 					for(Mixed color : ccolors.asList()) {
 						MCColor mccolor;
-						if(color.isInstanceOf(CString.class)) {
+						if(color.isInstanceOf(CString.TYPE)) {
 							mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
-						} else if(color.isInstanceOf(CArray.class)) {
+						} else if(color.isInstanceOf(CArray.TYPE)) {
 							mccolor = color((CArray) color, t);
-						} else if(color.isInstanceOf(CInt.class) && ccolors.size() == 3) {
+						} else if(color.isInstanceOf(CInt.TYPE) && ccolors.size() == 3) {
 							// Appears to be a single color
 							builder.addColor(color(ccolors, t));
 							break;
@@ -1427,7 +1427,7 @@ public class ObjectGenerator {
 						builder.addColor(mccolor);
 					}
 				}
-			} else if(colors.isInstanceOf(CString.class)) {
+			} else if(colors.isInstanceOf(CString.TYPE)) {
 				String split[] = colors.val().split("\\|");
 				if(split.length == 0) {
 					builder.addColor(MCColor.WHITE);
@@ -1445,15 +1445,15 @@ public class ObjectGenerator {
 		}
 		if(fe.containsKey("fade")) {
 			Mixed colors = fe.get("fade", t);
-			if(colors.isInstanceOf(CArray.class)) {
+			if(colors.isInstanceOf(CArray.TYPE)) {
 				CArray ccolors = (CArray) colors;
 				for(Mixed color : ccolors.asList()) {
 					MCColor mccolor;
-					if(color.isInstanceOf(CArray.class)) {
+					if(color.isInstanceOf(CArray.TYPE)) {
 						mccolor = color((CArray) color, t);
-					} else if(color.isInstanceOf(CString.class)) {
+					} else if(color.isInstanceOf(CString.TYPE)) {
 						mccolor = StaticLayer.GetConvertor().GetColor(color.val(), t);
-					} else if(color.isInstanceOf(CInt.class) && ccolors.size() == 3) {
+					} else if(color.isInstanceOf(CInt.TYPE) && ccolors.size() == 3) {
 						// Appears to be a single color
 						builder.addFadeColor(color(ccolors, t));
 						break;
@@ -1463,7 +1463,7 @@ public class ObjectGenerator {
 					}
 					builder.addFadeColor(mccolor);
 				}
-			} else if(colors.isInstanceOf(CString.class)) {
+			} else if(colors.isInstanceOf(CString.TYPE)) {
 				String split[] = colors.val().split("\\|");
 				for(String s : split) {
 					builder.addFadeColor(StaticLayer.GetConvertor().GetColor(s, t));
@@ -1560,7 +1560,7 @@ public class ObjectGenerator {
 	}
 
 	public MCRecipe recipe(Mixed c, Target t) {
-		if(!(c.isInstanceOf(CArray.class))) {
+		if(!(c.isInstanceOf(CArray.TYPE))) {
 			throw new CRECastException("Expected array but received " + c.typeof().getSimpleName(), t);
 		}
 		CArray recipe = (CArray) c;
@@ -1596,7 +1596,7 @@ public class ObjectGenerator {
 				}
 				int i = 0;
 				for(Mixed row : shaped.asList()) {
-					if(row.isInstanceOf(CString.class) && row.val().length() >= 1 && row.val().length() <= 3) {
+					if(row.isInstanceOf(CString.TYPE) && row.val().length() >= 1 && row.val().length() <= 3) {
 						shape[i] = row.val();
 						i++;
 					} else {
@@ -1611,7 +1611,7 @@ public class ObjectGenerator {
 				}
 				for(String key : shapedIngredients.stringKeySet()) {
 					Mixed ingredient = shapedIngredients.get(key, t);
-					if(ingredient.isInstanceOf(CArray.class)) {
+					if(ingredient.isInstanceOf(CArray.TYPE)) {
 						if(((CArray) ingredient).isAssociative()) {
 							((MCShapedRecipe) ret).setIngredient(key.charAt(0), item(ingredient, t).getType());
 						} else {
@@ -1645,7 +1645,7 @@ public class ObjectGenerator {
 					throw new CREIllegalArgumentException("Ingredients array is invalid.", t);
 				}
 				for(Mixed ingredient : ingredients.asList()) {
-					if(ingredient.isInstanceOf(CArray.class)) {
+					if(ingredient.isInstanceOf(CArray.TYPE)) {
 						if(((CArray) ingredient).isAssociative()) {
 							((MCShapelessRecipe) ret).addIngredient(item(ingredient, t));
 						} else {
@@ -1676,7 +1676,7 @@ public class ObjectGenerator {
 			case FURNACE:
 			case SMOKING:
 				Mixed input = recipe.get("input", t);
-				if(input.isInstanceOf(CArray.class)) {
+				if(input.isInstanceOf(CArray.TYPE)) {
 					if(((CArray) input).isAssociative()) {
 						((MCCookingRecipe) ret).setInput(item(input, t));
 					} else {
@@ -1709,7 +1709,7 @@ public class ObjectGenerator {
 
 			case STONECUTTING:
 				Mixed stoneCutterInput = recipe.get("input", t);
-				if(stoneCutterInput.isInstanceOf(CArray.class)) {
+				if(stoneCutterInput.isInstanceOf(CArray.TYPE)) {
 					if(((CArray) stoneCutterInput).isAssociative()) {
 						((MCStonecuttingRecipe) ret).setInput(item(stoneCutterInput, t));
 					} else {

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -768,7 +768,7 @@ public final class Static {
 			try {
 				ofp = getServer().getOfflinePlayer(GetUUID(search, t));
 			} catch (ConfigRuntimeException cre) {
-				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.class)) {
+				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.TYPE)) {
 					throw new CRELengthException("The given string was the wrong size to identify a player."
 							+ " A player name is expected to be between 1 and 16 characters. " + cre.getMessage(), t);
 				} else {
@@ -802,7 +802,7 @@ public final class Static {
 			try {
 				m = getServer().getPlayer(GetUUID(player, t));
 			} catch (ConfigRuntimeException cre) {
-				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.class)) {
+				if(cre instanceof CREThrowable && ((CREThrowable) cre).isInstanceOf(CRELengthException.TYPE)) {
 					throw new CRELengthException("The given string was the wrong size to identify a player."
 							+ " A player name is expected to be between 1 and 16 characters. " + cre.getMessage(), t);
 				} else {
@@ -988,7 +988,7 @@ public final class Static {
 	 * @return
 	 */
 	public static MCMetadatable getMetadatable(Mixed construct, Target t) {
-		if(construct.isInstanceOf(CArray.class)) {
+		if(construct.isInstanceOf(CArray.TYPE)) {
 			return ObjectGenerator.GetGenerator().location(construct, null, t).getBlock();
 		} else if(construct instanceof CString) {
 			switch(construct.val().length()) {
@@ -1523,7 +1523,7 @@ public final class Static {
 			return ((CByteArray) construct).asByteArrayCopy();
 		} else if(construct instanceof CResource) {
 			return ((CResource) construct).getResource();
-		} else if(construct.isInstanceOf(CArray.class)) {
+		} else if(construct.isInstanceOf(CArray.TYPE)) {
 			CArray array = (CArray) construct;
 			if(array.isAssociative()) {
 				HashMap<String, Object> map = new HashMap<>();

--- a/src/main/java/com/laytonsmith/core/compiler/OptimizationUtilities.java
+++ b/src/main/java/com/laytonsmith/core/compiler/OptimizationUtilities.java
@@ -87,7 +87,7 @@ public class OptimizationUtilities {
 			return ((Variable) node.getData()).getVariableName();
 		} else if(node.getData() instanceof CSlice) {
 			return node.getData().val();
-		} else if(node.getData().isInstanceOf(CArray.class)) {
+		} else if(node.getData().isInstanceOf(CArray.TYPE)) {
 			//It's a hardcoded array. This only happens in the course of optimization, if
 			//the optimizer adds a new array. We still need to handle it appropriately though.
 			//The values in the array will be constant, guaranteed.

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -107,7 +107,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 							max = -1; //Special case, there are no integer indexes in here yet.
 						}
 						associativeArray.put(Integer.toString(max + 1), item);
-						if(item.isInstanceOf(CArray.class)) {
+						if(item.isInstanceOf(CArray.TYPE)) {
 							((CArray) item).parent = this;
 						}
 					}
@@ -117,7 +117,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 			if(items != null) {
 				for(Mixed item : items) {
 					array.add(item);
-					if(item.isInstanceOf(CArray.class)) {
+					if(item.isInstanceOf(CArray.TYPE)) {
 						((CArray) item).parent = this;
 					}
 				}
@@ -280,7 +280,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 				associativeArray.put(Integer.toString(max + 1), c);
 			}
 		}
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			((CArray) c).parent = this;
 		}
 		setDirty();
@@ -366,7 +366,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 		if(associativeMode) {
 			associativeArray.put(normalizeConstruct(index), c);
 		}
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			((CArray) c).parent = this;
 		}
 		setDirty();
@@ -514,7 +514,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 			for(int i = 0; i < this.size(); i++) {
 				Mixed value = this.get(i, t);
 				String v;
-				if(value.isInstanceOf(CArray.class)) {
+				if(value.isInstanceOf(CArray.TYPE)) {
 					if(arrays.contains(value)) {
 						//Check for recursion
 						v = "*recursion*";
@@ -543,7 +543,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 					v = "null";
 				} else {
 					Mixed value = this.get(key, t);
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						if(arrays.contains(value)) {
 							v = "*recursion*";
 						} else {
@@ -613,7 +613,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 		// Iterate over the array, recursively calling this method to perform a deep clone.
 		for(Mixed key : array.keySet()) {
 			Mixed value = array.get(key, t);
-			if(value.isInstanceOf(CArray.class)) {
+			if(value.isInstanceOf(CArray.TYPE)) {
 				value = deepClone((CArray) value, t, cloneRefs);
 			}
 			clone.set(key, value, t);
@@ -622,13 +622,13 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 	}
 
 	private String normalizeConstruct(Mixed c) {
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			throw new CRECastException("Arrays cannot be used as the key in an associative array", c.getTarget());
-		} else if(c.isInstanceOf(CString.class) || c.isInstanceOf(CInt.class)) {
+		} else if(c.isInstanceOf(CString.TYPE) || c.isInstanceOf(CInt.TYPE)) {
 			return c.val();
 		} else if(c instanceof CNull) {
 			return "";
-		} else if(c.isInstanceOf(CBoolean.class)) {
+		} else if(c.isInstanceOf(CBoolean.TYPE)) {
 			if(((CBoolean) c).getBoolean()) {
 				return "1";
 			} else {
@@ -876,11 +876,11 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 					} else {
 						c = o2;
 					}
-					if(c.isInstanceOf(CArray.class)) {
+					if(c.isInstanceOf(CArray.TYPE)) {
 						throw new CRECastException("Cannot sort an array of arrays.", CArray.this.getTarget());
 					}
-					if(!(c.isInstanceOf(CBoolean.class) || c.isInstanceOf(CString.class) || c.isInstanceOf(CInt.class)
-							|| c.isInstanceOf(CDouble.class) || c instanceof CNull || c.isInstanceOf(CClassType.class))) {
+					if(!(c.isInstanceOf(CBoolean.TYPE) || c.isInstanceOf(CString.TYPE) || c.isInstanceOf(CInt.TYPE)
+							|| c.isInstanceOf(CDouble.TYPE) || c instanceof CNull || c.isInstanceOf(CClassType.TYPE))) {
 						throw new CREFormatException("Unsupported type being sorted: " + c.typeof(), CArray.this.getTarget());
 					}
 				}
@@ -893,7 +893,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 						return o1.val().compareTo("");
 					}
 				}
-				if(o1.isInstanceOf(CBoolean.class) || o2.isInstanceOf(CBoolean.class)) {
+				if(o1.isInstanceOf(CBoolean.TYPE) || o2.isInstanceOf(CBoolean.TYPE)) {
 					if(ArgumentValidation.getBoolean(o1, Target.UNKNOWN) == ArgumentValidation.getBoolean(o2, Target.UNKNOWN)) {
 						return 0;
 					} else {

--- a/src/main/java/com/laytonsmith/core/constructs/CClassType.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClassType.java
@@ -74,7 +74,7 @@ public final class CClassType extends Construct implements com.laytonsmith.core.
 	 * This is an invalid instance of the underlying type that can only be used for Documentation purposes or finding
 	 * out meta information about the class. Because these can be a type union, this is an array.
 	 *
-	 * DO NOT USE THIS VALUE WITHOUT FIRST CALLING {@link #instantiateInvalidType()}
+	 * DO NOT USE THIS VALUE WITHOUT FIRST CALLING {@link #instantiateInvalidType}
 	 */
 	private Mixed[] invalidType = UNINITIALIZED;
 
@@ -120,10 +120,12 @@ public final class CClassType extends Construct implements com.laytonsmith.core.
 	 */
 	public static CClassType get(FullyQualifiedClassName type) throws ClassNotFoundException {
 		assert type != null;
-		if(!CACHE.containsKey(type)) {
-			CACHE.put(type, new CClassType(type, Target.UNKNOWN, false));
+		CClassType ctype = CACHE.get(type);
+		if(ctype == null) {
+			ctype = new CClassType(type, Target.UNKNOWN, false);
+			CACHE.put(type, ctype);
 		}
-		return CACHE.get(type);
+		return ctype;
 	}
 
 	/**
@@ -141,10 +143,12 @@ public final class CClassType extends Construct implements com.laytonsmith.core.
 		SortedSet<FullyQualifiedClassName> t = new TreeSet<>(Arrays.asList(types));
 		FullyQualifiedClassName type
 				= FullyQualifiedClassName.forFullyQualifiedClass(StringUtils.Join(t, "|", e -> e.getFQCN()));
-		if(!CACHE.containsKey(type)) {
-			CACHE.put(type, new CClassType(type, Target.UNKNOWN, false));
+		CClassType ctype = CACHE.get(type);
+		if(ctype == null) {
+			ctype = new CClassType(type, Target.UNKNOWN, false);
+			CACHE.put(type, ctype);
 		}
-		return CACHE.get(type);
+		return ctype;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/constructs/CClosure.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClosure.java
@@ -81,7 +81,7 @@ public class CClosure extends Construct implements Callable {
 				}
 			}
 			b.append(")");
-		} else if(node.getData().isInstanceOf(CString.class)) {
+		} else if(node.getData().isInstanceOf(CString.TYPE)) {
 			String data = ArgumentValidation.getString(node.getData(), node.getTarget());
 			// Convert: \ -> \\ and ' -> \'
 			b.append("'").append(data.replace("\\", "\\\\").replaceAll("\t", "\\\\t").replaceAll("\n", "\\\\n")

--- a/src/main/java/com/laytonsmith/core/constructs/CMutablePrimitive.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CMutablePrimitive.java
@@ -45,7 +45,7 @@ public class CMutablePrimitive extends CArray implements Sizeable {
 	 * @param t
 	 */
 	public void set(Mixed value, Target t) {
-		if(!value.isInstanceOf(ValueType.class)) {
+		if(!value.isInstanceOf(ValueType.TYPE)) {
 			throw new CREFormatException("mutable_primitives can only store primitive values.", t);
 		}
 		this.value = value;
@@ -101,7 +101,7 @@ public class CMutablePrimitive extends CArray implements Sizeable {
 
 	@Override
 	public long size() {
-		if(value.isInstanceOf(Sizeable.class)) {
+		if(value.isInstanceOf(Sizeable.TYPE)) {
 			return ArgumentValidation.getObject(value, Target.UNKNOWN, Sizeable.class).size();
 		} else {
 			return 0;

--- a/src/main/java/com/laytonsmith/core/constructs/Construct.java
+++ b/src/main/java/com/laytonsmith/core/constructs/Construct.java
@@ -190,7 +190,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 	}
 
 	private static Object json_encode0(Mixed c, Target t) throws MarshalException {
-		if(c.isInstanceOf(CString.class) || c instanceof Command) {
+		if(c.isInstanceOf(CString.TYPE) || c instanceof Command) {
 			return c.val();
 		} else if(c instanceof CVoid) {
 			return "";
@@ -202,7 +202,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 			return ((CBoolean) c).getBoolean();
 		} else if(c instanceof CNull) {
 			return null;
-		} else if(c.isInstanceOf(CArray.class)) {
+		} else if(c.isInstanceOf(CArray.TYPE)) {
 			CArray ca = (CArray) c;
 			if(!ca.inAssociativeMode()) {
 				List<Object> list = new ArrayList<Object>();
@@ -412,7 +412,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 			return Long.valueOf(((CInt) c).getInt());
 		} else if(c instanceof CDouble) {
 			return Double.valueOf(((CDouble) c).getDouble());
-		} else if(c.isInstanceOf(CArray.class)) {
+		} else if(c.isInstanceOf(CArray.TYPE)) {
 			CArray ca = (CArray) c;
 			if(ca.inAssociativeMode()) {
 				//SortedMap
@@ -576,7 +576,7 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 	}
 
 	public static boolean isInstanceof(Mixed that, CClassType type) {
-		return that.typeof().doesExtend(type);
+		return that.getClass().isAnnotationPresent(typeof.class) && that.typeof().doesExtend(type);
 	}
 
 	public static boolean isInstanceof(Mixed that, Class<? extends Mixed> type) {

--- a/src/main/java/com/laytonsmith/core/constructs/IVariable.java
+++ b/src/main/java/com/laytonsmith/core/constructs/IVariable.java
@@ -46,7 +46,7 @@ public class IVariable extends Construct implements Cloneable {
 		if(value == null) {
 			throw new NullPointerException();
 		}
-		if(value.typeof().equals(CVoid.TYPE)) {
+		if(value instanceof CVoid) {
 			throw new CRECastException("Void may not be assigned to a variable", t);
 		}
 		if(!type.equals(Auto.TYPE) && !(value instanceof CNull)) {

--- a/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
@@ -222,12 +222,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -301,7 +301,7 @@ public class BlockEvents {
 
 			if(key.equals("drops")) {
 				List<MCItemStack> drops = new ArrayList<>();
-				if(value.isInstanceOf(CArray.class)) {
+				if(value.isInstanceOf(CArray.TYPE)) {
 					CArray arr = (CArray) value;
 					for(int i = 0; i < arr.size(); i++) {
 						CArray item = Static.getArray(arr.get(i, value.getTarget()), value.getTarget());
@@ -316,7 +316,7 @@ public class BlockEvents {
 			}
 
 			if(key.equals("xp")) {
-				if(value.isInstanceOf(CInt.class)) {
+				if(value.isInstanceOf(CInt.TYPE)) {
 					int xp = Integer.parseInt(value.val());
 					event.setExpToDrop(xp);
 					return true;
@@ -368,12 +368,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -463,7 +463,7 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), value.getTarget());
 				return true;
 			} else if(key.equals("type")) {
-				if(value.isInstanceOf(CInt.class)) {
+				if(value.isInstanceOf(CInt.TYPE)) {
 					MCMaterial mat = StaticLayer.GetMaterialFromLegacy((int) ((CInt) value).getInt(), 0);
 					event.getBlock().setType(mat);
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Mutable data key \"type\" in " + getName()
@@ -517,12 +517,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -703,12 +703,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("type")) {
 				Mixed cid = prefilter.get("type");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("data")) {
 						Mixed cdata = prefilter.get("data");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -728,12 +728,12 @@ public class BlockEvents {
 						+ " is deprecated for \"toblock\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("totype")) {
 				Mixed cid = prefilter.get("totype");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("todata")) {
 						Mixed cdata = prefilter.get("todata");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -811,7 +811,7 @@ public class BlockEvents {
 			MCBlockFromToEvent e = (MCBlockFromToEvent) event;
 			if(key.equals("block")) {
 				MCBlock block = e.getBlock();
-				if(value.isInstanceOf(CArray.class)) {
+				if(value.isInstanceOf(CArray.TYPE)) {
 					CArray blockArray = (CArray) value;
 					if(blockArray.containsKey("name")) {
 						Mixed name = blockArray.get("name", value.getTarget());
@@ -867,7 +867,7 @@ public class BlockEvents {
 			}
 			if(key.equals("toblock")) {
 				MCBlock block = e.getToBlock();
-				if(value.isInstanceOf(CArray.class)) {
+				if(value.isInstanceOf(CArray.TYPE)) {
 					CArray blockArray = (CArray) value;
 					if(blockArray.containsKey("name")) {
 						Mixed name = blockArray.get("name", value.getTarget());
@@ -998,7 +998,7 @@ public class BlockEvents {
 
 			// Allow changing everything at once.
 			if(key.equals("text")) {
-				if(!(value.isInstanceOf(CArray.class))) {
+				if(!(value.isInstanceOf(CArray.TYPE))) {
 					return false;
 				}
 
@@ -1169,12 +1169,12 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("oldtype")) {
 				Mixed cid = prefilter.get("oldtype");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("olddata")) {
 						Mixed cdata = prefilter.get("olddata");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -1194,12 +1194,12 @@ public class BlockEvents {
 						+ " is deprecated for \"newblock\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("newtype")) {
 				Mixed cid = prefilter.get("newtype");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					int data = 0;
 					if(prefilter.containsKey("newdata")) {
 						Mixed cdata = prefilter.get("newdata");
-						if(cdata.isInstanceOf(CInt.class)) {
+						if(cdata.isInstanceOf(CInt.TYPE)) {
 							data = (int) ((CInt) cdata).getInt();
 						}
 					}
@@ -1383,7 +1383,7 @@ public class BlockEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("oldtype")) {
 				Mixed cid = prefilter.get("oldtype");
-				if(cid.isInstanceOf(CInt.class)) {
+				if(cid.isInstanceOf(CInt.TYPE)) {
 					int id = (int) ((CInt) cid).getInt();
 					MCMaterial mat = StaticLayer.GetMaterialFromLegacy(id, 0);
 					if(mat == null) {

--- a/src/main/java/com/laytonsmith/core/events/drivers/EntityEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/EntityEvents.java
@@ -357,7 +357,7 @@ public class EntityEvents {
 					return true;
 				}
 				if(key.equals("blocks")) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						CArray ba = (CArray) value;
 						List<MCBlock> blocks = new ArrayList<MCBlock>();
 						for(String b : ba.stringKeySet()) {
@@ -709,7 +709,7 @@ public class EntityEvents {
 					if(value instanceof CNull) {
 						value = new CArray(value.getTarget());
 					}
-					if(!(value.isInstanceOf(CArray.class))) {
+					if(!(value.isInstanceOf(CArray.TYPE))) {
 						throw new CRECastException("drops must be an array, or null", value.getTarget());
 					}
 					e.clearDrops();
@@ -1369,7 +1369,7 @@ public class EntityEvents {
 			MCEntityDamageByEntityEvent event = (MCEntityDamageByEntityEvent) e;
 
 			if(key.equals("amount")) {
-				if(value.isInstanceOf(CInt.class)) {
+				if(value.isInstanceOf(CInt.TYPE)) {
 					event.setDamage(Integer.parseInt(value.val()));
 
 					return true;
@@ -1453,7 +1453,7 @@ public class EntityEvents {
 					if(value instanceof CNull) {
 						ete.setTarget(null);
 						return true;
-					} else if(value.isInstanceOf(CString.class)) {
+					} else if(value.isInstanceOf(CString.TYPE)) {
 						MCPlayer p = Static.GetPlayer(value.val(), value.getTarget());
 
 						if(p.isOnline()) {
@@ -1577,7 +1577,7 @@ public class EntityEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("from")) {
 				Mixed type = prefilter.get("from");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"from\" prefilter.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());
@@ -1586,7 +1586,7 @@ public class EntityEvents {
 			}
 			if(prefilter.containsKey("to")) {
 				Mixed type = prefilter.get("to");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"to\" prefilter.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());
@@ -1677,7 +1677,7 @@ public class EntityEvents {
 						+ " is deprecated for \"block\". Converted to " + mat.getName(), event.getTarget());
 			} else if(prefilter.containsKey("block")) {
 				Mixed ctype = prefilter.get("block");
-				if(ctype.isInstanceOf(CString.class) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
+				if(ctype.isInstanceOf(CString.TYPE) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
 					int type;
 					String notation = ctype.val();
 					int separatorIndex = notation.indexOf(':');

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -89,7 +89,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("slotitem")) {
 				Mixed type = prefilter.get("slotitem");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("slotitem").val(), 1, event.getTarget());
 					prefilter.put("slotitem", new CString(is.getType().getName(), event.getTarget()));
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format for the \"slotitem\" prefilter"
@@ -231,7 +231,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("cursoritem")) {
 				Mixed type = prefilter.get("cursoritem");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("cursoritem").val(), 1, event.getTarget());
 					prefilter.put("cursoritem", new CString(is.getType().getName(), event.getTarget()));
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format for the \"cursoritem\" prefilter"
@@ -686,7 +686,7 @@ public class InventoryEvents {
 				}
 
 				if(key.equalsIgnoreCase("expcosts")) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						CArray cExpCosts = (CArray) value;
 						if(!cExpCosts.inAssociativeMode()) {
 							MCEnchantmentOffer[] offers = e.getOffers();
@@ -811,7 +811,7 @@ public class InventoryEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("main_hand")) {
 				Mixed type = prefilter.get("main_hand");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format in the \"main_hand\""
 							+ " prefilter in " + getName() + " is deprecated.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("main_hand").val(), 1, event.getTarget());
@@ -820,7 +820,7 @@ public class InventoryEvents {
 			}
 			if(prefilter.containsKey("off_hand")) {
 				Mixed type = prefilter.get("off_hand");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The item notation format in the \"off_hand\""
 							+ " prefilter in " + getName() + " is deprecated.", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, prefilter.get("off_hand").val(), 1, event.getTarget());
@@ -970,7 +970,7 @@ public class InventoryEvents {
 					return true;
 				}
 				if("matrix".equals(key)) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						CArray va = (CArray) value;
 						MCItemStack[] old = e.getInventory().getMatrix();
 						MCItemStack[] repl = new MCItemStack[old.length];

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -827,7 +827,7 @@ public class PlayerEvents {
 			}
 			if(prefilter.containsKey("block")) {
 				Mixed ctype = prefilter.get("block");
-				if(ctype.isInstanceOf(CString.class) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
+				if(ctype.isInstanceOf(CString.TYPE) && ctype.val().contains(":") || ArgumentValidation.isNumber(ctype)) {
 					int type;
 					String notation = ctype.val();
 					int separatorIndex = notation.indexOf(':');
@@ -1583,7 +1583,7 @@ public class PlayerEvents {
 					e.setMessage(Construct.nval(value));
 				}
 				if("recipients".equals(key)) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						List<MCPlayer> list = new ArrayList<MCPlayer>();
 						for(String index : ((CArray) value).stringKeySet()) {
 							Mixed v = ((CArray) value).get(index, value.getTarget());
@@ -1713,7 +1713,7 @@ public class PlayerEvents {
 					e.setMessage(Construct.nval(value));
 				}
 				if("recipients".equals(key)) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						List<MCPlayer> list = new ArrayList<>();
 						for(String index : ((CArray) value).stringKeySet()) {
 							Mixed v = ((CArray) value).get(index, value.getTarget());

--- a/src/main/java/com/laytonsmith/core/events/drivers/ServerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/ServerEvents.java
@@ -333,7 +333,7 @@ public class ServerEvents {
 			if(event instanceof MCCommandTabCompleteEvent) {
 				MCCommandTabCompleteEvent e = (MCCommandTabCompleteEvent) event;
 				if("completions".equals(key)) {
-					if(value.isInstanceOf(CArray.class)) {
+					if(value.isInstanceOf(CArray.TYPE)) {
 						List<String> comp = new ArrayList<>();
 						if(((CArray) value).inAssociativeMode()) {
 							for(Mixed k : ((CArray) value).keySet()) {

--- a/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/VehicleEvents.java
@@ -229,7 +229,7 @@ public class VehicleEvents {
 			Map<String, Mixed> prefilter = event.getPrefilter();
 			if(prefilter.containsKey("hittype")) {
 				Mixed type = prefilter.get("hittype");
-				if(type.isInstanceOf(CString.class) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
+				if(type.isInstanceOf(CString.TYPE) && type.val().contains(":") || ArgumentValidation.isNumber(type)) {
 					MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The 0:0 block format in " + getName()
 							+ " is deprecated in \"hittype\".", event.getTarget());
 					MCItemStack is = Static.ParseItemNotation(null, type.val(), 1, event.getTarget());

--- a/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/CRE/AbstractCREException.java
@@ -133,7 +133,7 @@ public abstract class AbstractCREException extends ConfigRuntimeException implem
 				.forName(exception.get("classType", t).val(), t, env);
 		Class<? extends Mixed> clzz = NativeTypeList.getNativeClass(classType);
 		Throwable cause = null;
-		if(exception.get("causedBy", t).isInstanceOf(CArray.class)) {
+		if(exception.get("causedBy", t).isInstanceOf(CArray.TYPE)) {
 			// It has a cause
 			cause = new CRECausedByWrapper((CArray) exception.get("causedBy", t));
 		}
@@ -295,7 +295,7 @@ public abstract class AbstractCREException extends ConfigRuntimeException implem
 	}
 
 	@Override
-	public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+	public boolean isInstanceOf(CClassType type) {
 		return Construct.isInstanceof(this, type);
 	}
 

--- a/src/main/java/com/laytonsmith/core/exceptions/ConfigRuntimeException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/ConfigRuntimeException.java
@@ -118,7 +118,7 @@ public class ConfigRuntimeException extends RuntimeException {
 			}
 			try {
 				Mixed ret = c.executeCallable(env, Target.UNKNOWN, new Mixed[]{ex});
-				if(ret.isInstanceOf(CNull.class) || ret.isInstanceOf(CVoid.class) || Prefs.ScreamErrors()) {
+				if(ret instanceof CNull || ret instanceof CVoid || Prefs.ScreamErrors()) {
 					return Reaction.REPORT; // Closure returned null or scream-errors was set in the config.
 				}
 				// Closure returned a boolean. TRUE -> IGNORE and FALSE -> FATAL.

--- a/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
@@ -154,14 +154,14 @@ public abstract class AbstractFunction implements Function {
 				b.append(", ");
 			}
 			first = false;
-			if(ccc.isInstanceOf(CArray.class)) {
+			if(ccc.isInstanceOf(CArray.TYPE)) {
 				//Arrays take too long to toString, so we don't want to actually toString them here if
 				//we don't need to.
 				b.append("<arrayNotShown size:").append(((CArray) ccc).size()).append(">");
-			} else if(ccc.isInstanceOf(CClosure.class)) {
+			} else if(ccc.isInstanceOf(CClosure.TYPE)) {
 				//The toString of a closure is too long, so let's not output them either.
 				b.append("<closureNotShown>");
-			} else if(ccc.isInstanceOf(CString.class)) {
+			} else if(ccc.isInstanceOf(CString.TYPE)) {
 				String val = ccc.val().replace("\\", "\\\\").replace("'", "\\'");
 				int max = 1000;
 				if(val.length() > max) {

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -80,7 +80,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class) && !(args[0] instanceof CMutablePrimitive)) {
+			if(args[0].isInstanceOf(CArray.TYPE) && !(args[0] instanceof CMutablePrimitive)) {
 				return new CInt(((CArray) args[0]).size(), t);
 			}
 			throw new CRECastException("Argument 1 of array_size must be an array", t);
@@ -151,7 +151,7 @@ public class ArrayHandling {
 				defaultConstruct = args[2];
 			}
 
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray ca = (CArray) args[0];
 				if(index instanceof CSlice) {
 
@@ -206,7 +206,7 @@ public class ArrayHandling {
 						}
 					} catch (ConfigRuntimeException e) {
 						if(e instanceof CREThrowable
-								&& ((CREThrowable) e).isInstanceOf(CREIndexOverflowException.class)) {
+								&& ((CREThrowable) e).isInstanceOf(CREIndexOverflowException.TYPE)) {
 							if(defaultConstruct != null) {
 								return defaultConstruct;
 							}
@@ -225,7 +225,7 @@ public class ArrayHandling {
 						throw e;
 					}
 				}
-			} else if(args[0].isInstanceOf(ArrayAccess.class)) {
+			} else if(args[0].isInstanceOf(ArrayAccess.TYPE)) {
 				com.laytonsmith.core.natives.interfaces.Iterable aa
 						= (com.laytonsmith.core.natives.interfaces.Iterable) args[0];
 				if(index instanceof CSlice) {
@@ -244,7 +244,7 @@ public class ArrayHandling {
 					} catch (NumberFormatException e) {
 						throw new CRECastException("Ranges must be integer numbers, i.e., [0..5]", t);
 					}
-				} else if(index.isInstanceOf(CInt.class)) {
+				} else if(index.isInstanceOf(CInt.TYPE)) {
 					return aa.get(Static.getInt32(index, t), t);
 				} else {
 					return aa.get(index, t);
@@ -292,10 +292,10 @@ public class ArrayHandling {
 			if(args.length == 0) {
 				throw new CRECastException("Argument 1 of array_get must be an array", t);
 			}
-			if(args[0].isInstanceOf(ArrayAccess.class)) {
+			if(args[0].isInstanceOf(ArrayAccess.TYPE)) {
 				ArrayAccess aa = (ArrayAccess) args[0];
 				if(!aa.canBeAssociative()) {
-					if(!(args[1].isInstanceOf(CInt.class)) && !(args[1] instanceof CSlice)) {
+					if(!(args[1].isInstanceOf(CInt.TYPE)) && !(args[1] instanceof CSlice)) {
 						throw new ConfigCompileException("Accessing an element as an associative array,"
 								+ " when it can only accept integers.", t);
 					}
@@ -353,7 +353,7 @@ public class ArrayHandling {
 			env.getEnv(GlobalEnv.class).ClearFlag("array-special-get");
 			Mixed index = parent.seval(nodes[1], env);
 			Mixed value = parent.seval(nodes[2], env);
-			if(!(array.isInstanceOf(CArray.class))) {
+			if(!(array.isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Argument 1 of array_set must be an array", t);
 			}
 			try {
@@ -366,7 +366,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				try {
 					((CArray) args[0]).set(args[1], args[2], t);
 				} catch (IndexOutOfBoundsException e) {
@@ -438,7 +438,7 @@ public class ArrayHandling {
 			if(args.length < 2) {
 				throw new CREInsufficientArgumentsException("At least 2 arguments must be provided to array_push", t);
 			}
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray array = (CArray) args[0];
 				int initialSize = (int) array.size();
 				for(int i = 1; i < args.length; i++) {
@@ -604,7 +604,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Argument 1 of " + this.getName() + " must be an array", t);
 			}
 			CArray ca = (CArray) args[0];
@@ -701,7 +701,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray ca = (CArray) args[0];
 				for(int i = 0; i < ca.size(); i++) {
 					if(new equals_ic().exec(t, environment, ca.get(i, t), args[1]).getBoolean()) {
@@ -744,7 +744,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Argument 1 of " + this.getName() + " must be an array", t);
 			}
 			CArray ca = (CArray) args[0];
@@ -848,10 +848,10 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				Mixed m = args[0];
 				for(int i = 1; i < args.length; i++) {
-					if(!(m.isInstanceOf(CArray.class))) {
+					if(!(m.isInstanceOf(CArray.TYPE))) {
 						return CBoolean.FALSE;
 					}
 					CArray ca = (CArray) m;
@@ -955,7 +955,7 @@ public class ArrayHandling {
 
 		@Override
 		public CArray exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class) && args[1].isInstanceOf(CInt.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE) && args[1].isInstanceOf(CInt.TYPE)) {
 				CArray original = (CArray) args[0];
 				int size = (int) ((CInt) args[1]).getInt();
 				Mixed fill = CNull.NULL;
@@ -1112,7 +1112,7 @@ public class ArrayHandling {
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			// As an exception, strings aren't supported here. There's no reason to do this for a string that isn't accidental.
-			if(args[0].isInstanceOf(ArrayAccess.class) && !(args[0].isInstanceOf(CString.class))) {
+			if(args[0].isInstanceOf(ArrayAccess.TYPE) && !(args[0].isInstanceOf(CString.TYPE))) {
 				ArrayAccess ca = (ArrayAccess) args[0];
 				CArray ca2 = new CArray(t);
 				for(Mixed c : ca.keySet()) {
@@ -1178,7 +1178,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray ca = Static.getArray(args[0], t);
 				CArray ca2 = new CArray(t);
 				for(Mixed c : ca.keySet()) {
@@ -1251,7 +1251,7 @@ public class ArrayHandling {
 				throw new CREInsufficientArgumentsException("array_merge must be called with at least two parameters", t);
 			}
 			for(Mixed arg : args) {
-				if(arg.isInstanceOf(ArrayAccess.class)) {
+				if(arg.isInstanceOf(ArrayAccess.TYPE)) {
 					com.laytonsmith.core.natives.interfaces.Iterable cur
 							= (com.laytonsmith.core.natives.interfaces.Iterable) arg;
 					if(!cur.isAssociative()) {
@@ -1260,7 +1260,7 @@ public class ArrayHandling {
 						}
 					} else {
 						for(Mixed key : cur.keySet()) {
-							if(key.isInstanceOf(CInt.class)) {
+							if(key.isInstanceOf(CInt.TYPE)) {
 								newArray.set(key, cur.get((int) ((CInt) key).getInt(), t), t);
 							} else {
 								newArray.set(key, cur.get(key.val(), t), t);
@@ -1396,7 +1396,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(ArrayAccess.class))) {
+			if(!(args[0].isInstanceOf(ArrayAccess.TYPE))) {
 				throw new CRECastException("Expecting argument 1 to be an ArrayAccess type object", t);
 			}
 			StringBuilder b = new StringBuilder();
@@ -1588,7 +1588,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("The first parameter to array_sort must be an array", t);
 			}
 			CArray ca = (CArray) args[0];
@@ -1599,7 +1599,7 @@ public class ArrayHandling {
 			}
 			try {
 				if(args.length == 2) {
-					if(args[1].isInstanceOf(CClosure.class)) {
+					if(args[1].isInstanceOf(CClosure.TYPE)) {
 						sortType = null;
 						customSort = (CClosure) args[1];
 					} else {
@@ -1658,7 +1658,7 @@ public class ArrayHandling {
 					int value;
 					if(c instanceof CNull) {
 						value = 0;
-					} else if(c.isInstanceOf(CBoolean.class)) {
+					} else if(c.isInstanceOf(CBoolean.TYPE)) {
 						if(((CBoolean) c).getBoolean()) {
 							value = 1;
 						} else {
@@ -1951,7 +1951,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expected parameter 1 to be an array, but was " + args[0].val(), t);
 			}
 			return ((CArray) args[0]).indexesOf(args[1]);
@@ -2132,7 +2132,7 @@ public class ArrayHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				((CArray) args[0]).reverse(t);
 			}
 			return CVoid.VOID;
@@ -2388,7 +2388,7 @@ public class ArrayHandling {
 			if(!(args[0] instanceof com.laytonsmith.core.natives.interfaces.Iterable)) {
 				throw new CRECastException("Expecting an array for argument 1", t);
 			}
-			if(!(args[1].isInstanceOf(CClosure.class))) {
+			if(!(args[1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Expecting a closure for argument 2", t);
 			}
 			array = (com.laytonsmith.core.natives.interfaces.Iterable) args[0];
@@ -2489,7 +2489,7 @@ public class ArrayHandling {
 			if(args.length != 1) {
 				throw new CREInsufficientArgumentsException("Expecting exactly one argument", t);
 			}
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting argument 1 to be an array", t);
 			}
 			return ((CArray) args[0]).deepClone(t);
@@ -2557,7 +2557,7 @@ public class ArrayHandling {
 			if(args.length != 1) {
 				throw new CREInsufficientArgumentsException("Expecting exactly one argument", t);
 			}
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting argument 1 to be an array", t);
 			}
 			CArray array = (CArray) args[0];
@@ -3022,7 +3022,7 @@ public class ArrayHandling {
 
 			for(Mixed c : array.keySet()) {
 				Mixed fr = closure.executeCallable(environment, t, array.get(c, t));
-				if(fr.isInstanceOf(CVoid.class)) {
+				if(fr.isInstanceOf(CVoid.TYPE)) {
 					throw new CREIllegalArgumentException("The closure passed to " + getName()
 							+ " must return a value.", t);
 				}
@@ -3121,7 +3121,7 @@ public class ArrayHandling {
 					throw new CREIllegalArgumentException("For associative arrays, only 2 parameters may be provided,"
 							+ " the comparison mode value is not used.", t);
 				}
-				if(args[2].isInstanceOf(CClosure.class)) {
+				if(args[2].isInstanceOf(CClosure.TYPE)) {
 					closure = Static.getObject(args[2], t, CClosure.class);
 				} else {
 					mode = ArgumentValidation.getEnum(args[2], ArrayIntersectComparisonMode.class, t);
@@ -3300,10 +3300,10 @@ public class ArrayHandling {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			Mixed constA = args[0];
 			Mixed constB = args[1];
-			if(!(constA.isInstanceOf(CArray.class))) {
+			if(!(constA.isInstanceOf(CArray.TYPE))) {
 				throw new CREIllegalArgumentException("Expecting an array, but received " + constA, t);
 			}
-			if(!(constB.isInstanceOf(CArray.class))) {
+			if(!(constB.isInstanceOf(CArray.TYPE))) {
 				throw new CREIllegalArgumentException("Expecting an array, but received " + constB, t);
 			}
 			return CBoolean.get(subsetOf(constA, constB, t));
@@ -3335,7 +3335,7 @@ public class ArrayHandling {
 			if(!constA.typeof().equals(constB.typeof())) {
 				return false;
 			}
-			if(constA.isInstanceOf(CArray.class)) {
+			if(constA.isInstanceOf(CArray.TYPE)) {
 				CArray arrA = (CArray) constA;
 				CArray arrB = (CArray) constB;
 				if(arrA.isAssociative() != arrB.isAssociative()) {

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -239,7 +239,7 @@ public class BasicLogic {
 				throw new CREFormatException(this.getName() + " expects 2 arguments.", t);
 			}
 			if(args[1].typeof().equals(args[0].typeof())) {
-				if(args[0].isInstanceOf(CString.class) && args[1].isInstanceOf(CString.class)) {
+				if(args[0].isInstanceOf(CString.TYPE) && args[1].isInstanceOf(CString.TYPE)) {
 					// Check for actual string equality, so we don't do type massaging
 					// for numeric strings. Thus '2' !== '2.0'
 					return CBoolean.get(args[0].val().equals(args[1].val()));
@@ -651,7 +651,7 @@ public class BasicLogic {
 
 		@Override
 		public CBoolean exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class) && args[1].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE) && args[1].isInstanceOf(CArray.TYPE)) {
 				return CBoolean.get(args[0] == args[1]);
 			} else {
 				return new equals().exec(t, environment, args);

--- a/src/main/java/com/laytonsmith/core/functions/BossBar.java
+++ b/src/main/java/com/laytonsmith/core/functions/BossBar.java
@@ -129,7 +129,7 @@ public class BossBar {
 			boolean visible = true;
 			double percent = 1.0;
 			if(args.length == 2) {
-				if(!(args[1].isInstanceOf(CArray.class))) {
+				if(!(args[1].isInstanceOf(CArray.TYPE))) {
 					throw new CRECastException("Expected array for parameter 2 of create_bar()", t);
 				}
 				CArray ca = (CArray) args[1];
@@ -206,15 +206,15 @@ public class BossBar {
 			if(bar == null) {
 				throw new CRENotFoundException("That boss bar id does not exist.", t);
 			}
-			if(args[1].isInstanceOf(CString.class)) {
+			if(args[1].isInstanceOf(CString.TYPE)) {
 				bar.setTitle(args[1].val());
-			} else if(args[1].isInstanceOf(CDouble.class)) {
+			} else if(args[1].isInstanceOf(CDouble.TYPE)) {
 				try {
 					bar.setProgress(Static.getDouble(args[1], t));
 				} catch (IllegalArgumentException ex) {
 					throw new CRERangeException("Progress percentage must be from 0.0 to 1.0.", t);
 				}
-			} else if(args[1].isInstanceOf(CArray.class)) {
+			} else if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray ca = (CArray) args[1];
 				if(ca.containsKey("title")) {
 					bar.setTitle(ca.get("title", t).val());

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -979,7 +979,7 @@ public class Cmdline {
 			final CClosure stderr;
 			final CClosure exit;
 			final boolean subshell;
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray array = (CArray) args[0];
 				command = new String[(int) array.size()];
 				for(int i = 0; i < array.size(); i++) {
@@ -1178,7 +1178,7 @@ public class Cmdline {
 			String[] command;
 			int expectedExitCode = 0;
 			File workingDir = null;
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray array = (CArray) args[0];
 				command = new String[(int) array.size()];
 				for(int i = 0; i < array.size(); i++) {
@@ -1748,7 +1748,7 @@ public class Cmdline {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			requireCmdlineMode(environment, this, t);
-			if(!(args[0].isInstanceOf(CClosure.class))) {
+			if(!(args[0].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Expecting a closure for argument 1 of " + getName(), t);
 			}
 			environment.getEnv(GlobalEnv.class).SetCustom("cmdline_prompt", args[0]);
@@ -1955,7 +1955,7 @@ public class Cmdline {
 			String startFrom = environment.getEnv(GlobalEnv.class).GetRootFolder().getAbsolutePath();
 			Set<FindType> findTypes = EnumSet.allOf(FindType.class);
 			if(args.length == 2) {
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					findTypes = ArgumentValidation.getEnumSet(args[1], FindType.class, t);
 				} else {
 					startFrom = ArgumentValidation.getString(args[1], t);

--- a/src/main/java/com/laytonsmith/core/functions/Commands.java
+++ b/src/main/java/com/laytonsmith/core/functions/Commands.java
@@ -85,7 +85,7 @@ public class Commands {
 		 * @param arg
 		 */
 		public static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
-			if(arg.isInstanceOf(CClosure.class)) {
+			if(arg.isInstanceOf(CClosure.TYPE)) {
 				onTabComplete.remove(cmd.getName());
 				onTabComplete.put(cmd.getName(), (CClosure) arg);
 			} else {
@@ -222,7 +222,7 @@ public class Commands {
 				isnew = true;
 				cmd = StaticLayer.GetConvertor().getNewCommand(args[0].val().toLowerCase());
 			}
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray ops = (CArray) args[1];
 				if(ops.containsKey("permission")) {
 					cmd.setPermission(ops.get("permission", t).val());
@@ -237,7 +237,7 @@ public class Commands {
 					cmd.setPermissionMessage(ops.get("noPermMsg", t).val());
 				}
 				if(ops.containsKey("aliases")) {
-					if(ops.get("aliases", t).isInstanceOf(CArray.class)) {
+					if(ops.get("aliases", t).isInstanceOf(CArray.TYPE)) {
 						List<Mixed> ca = ((CArray) ops.get("aliases", t)).asList();
 						List<String> aliases = new ArrayList<String>();
 						for(Mixed c : ca) {
@@ -369,7 +369,7 @@ public class Commands {
 		 * @param arg
 		 */
 		public static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
-			if(arg.isInstanceOf(CClosure.class)) {
+			if(arg.isInstanceOf(CClosure.TYPE)) {
 				onCommand.remove(cmd.getName());
 				onCommand.put(cmd.getName(), (CClosure) arg);
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -464,7 +464,7 @@ public class Compiler {
 
 			// Look for typed assignments
 			for(int k = 0; k < list.size(); k++) {
-				if(list.get(k).getData().equals(CVoid.VOID) || list.get(k).getData().isInstanceOf(CClassType.class)) {
+				if(list.get(k).getData().equals(CVoid.VOID) || list.get(k).getData().isInstanceOf(CClassType.TYPE)) {
 					if(k == list.size() - 1) {
 						// This is not a typed assignment
 						break;
@@ -745,7 +745,7 @@ public class Compiler {
 			if(children.size() != 1) {
 				throw new ConfigCompileException(getName() + " can only take one parameter", t);
 			}
-			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
+			if(!(children.get(0).getData().isInstanceOf(CString.TYPE))) {
 				throw new ConfigCompileException("Only hardcoded strings may be passed into " + getName(), t);
 			}
 			String value = children.get(0).getData().val();

--- a/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
+++ b/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
@@ -441,7 +441,7 @@ public class ControlFlow {
 					if(evalStatement instanceof CSlice) { //Can do more optimal handling for this Array subclass
 						long rangeLeft = ((CSlice) evalStatement).getStart();
 						long rangeRight = ((CSlice) evalStatement).getFinish();
-						if(value.isInstanceOf(CInt.class)) {
+						if(value.isInstanceOf(CInt.TYPE)) {
 							long v = Static.getInt(value, t);
 							if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 									|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -449,13 +449,13 @@ public class ControlFlow {
 								return parent.seval(code, env);
 							}
 						}
-					} else if(evalStatement.isInstanceOf(CArray.class)) {
+					} else if(evalStatement.isInstanceOf(CArray.TYPE)) {
 						for(String index : ((CArray) evalStatement).stringKeySet()) {
 							Mixed inner = ((CArray) evalStatement).get(index, t);
 							if(inner instanceof CSlice) {
 								long rangeLeft = ((CSlice) inner).getStart();
 								long rangeRight = ((CSlice) inner).getFinish();
-								if(value.isInstanceOf(CInt.class)) {
+								if(value.isInstanceOf(CInt.TYPE)) {
 									long v = Static.getInt(value, t);
 									if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 											|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -708,7 +708,7 @@ public class ControlFlow {
 					children.set(i, new ParseTree(data, children.get(i).getFileOptions()));
 				}
 				//Now we validate that the values are constant and non-repeating.
-				if(children.get(i).getData().isInstanceOf(CArray.class)) {
+				if(children.get(i).getData().isInstanceOf(CArray.TYPE)) {
 					List<Mixed> list = ((CArray) children.get(i).getData()).asList();
 					for(Mixed c : list) {
 						if(c instanceof CSlice) {
@@ -740,7 +740,7 @@ public class ControlFlow {
 				}
 			}
 
-			if((children.size() > 3 || (children.size() > 1 && children.get(1).getData().isInstanceOf(CArray.class)))
+			if((children.size() > 3 || (children.size() > 1 && children.get(1).getData().isInstanceOf(CArray.TYPE)))
 					//No point in doing this optimization if there are only 3 args and the case is flat.
 					//Also, doing this check prevents an inifinite loop during optimization.
 					&& (children.size() > 0 && !Construct.IsDynamicHelper(children.get(0).getData()))) {
@@ -751,7 +751,7 @@ public class ControlFlow {
 				for(int i = 1; i < children.size(); i += 2) {
 					Mixed data = children.get(i).getData();
 
-					if(!(data.isInstanceOf(CArray.class)) || data instanceof CSlice) {
+					if(!(data.isInstanceOf(CArray.TYPE)) || data instanceof CSlice) {
 						//Put it in an array to make the rest of this parsing easier.
 						data = new CArray(t);
 						((CArray) data).push(children.get(i).getData(), t);
@@ -760,7 +760,7 @@ public class ControlFlow {
 						if(value instanceof CSlice) {
 							long rangeLeft = ((CSlice) value).getStart();
 							long rangeRight = ((CSlice) value).getFinish();
-							if(children.get(0).getData().isInstanceOf(CInt.class)) {
+							if(children.get(0).getData().isInstanceOf(CInt.TYPE)) {
 								long v = Static.getInt(children.get(0).getData(), t);
 								if((rangeLeft < rangeRight && v >= rangeLeft && v <= rangeRight)
 										|| (rangeLeft > rangeRight && v >= rangeRight && v <= rangeLeft)
@@ -1501,7 +1501,7 @@ public class ControlFlow {
 
 			Mixed data = parent.seval(array, env);
 
-			if(!(data.isInstanceOf(CArray.class)) && !(data instanceof CSlice)) {
+			if(!(data.isInstanceOf(CArray.TYPE)) && !(data instanceof CSlice)) {
 				throw new CRECastException(getName() + " expects an array for parameter 1", t);
 			}
 
@@ -1885,7 +1885,7 @@ public class ControlFlow {
 							+ " be hard coded, and should not be dynamically determinable, since this is always a sign"
 							+ " of loose code flow, which should be avoided.", t);
 				}
-				if(!(children.get(0).getData().isInstanceOf(CInt.class))) {
+				if(!(children.get(0).getData().isInstanceOf(CInt.TYPE))) {
 					throw new ConfigCompileException("break() only accepts integer values.", t);
 				}
 			}

--- a/src/main/java/com/laytonsmith/core/functions/Crypto.java
+++ b/src/main/java/com/laytonsmith/core/functions/Crypto.java
@@ -59,7 +59,7 @@ public class Crypto {
 
 	private static byte[] getByteArrayFromArg(Mixed c) {
 		byte[] val;
-		if(c.isInstanceOf(CSecureString.class)) {
+		if(c.isInstanceOf(CSecureString.TYPE)) {
 			val = ArrayUtils.charToBytes(((CSecureString) c).getDecryptedCharArray());
 		} else {
 			val = c.val().getBytes();
@@ -448,7 +448,7 @@ public class Crypto {
 			}
 			try {
 				String val;
-				if(args[0].isInstanceOf(CSecureString.class)) {
+				if(args[0].isInstanceOf(CSecureString.TYPE)) {
 					val = new String(((CSecureString) args[0]).getDecryptedCharArray());
 				} else {
 					val = args[0].val();
@@ -519,7 +519,7 @@ public class Crypto {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String val;
-			if(args[0].isInstanceOf(CSecureString.class)) {
+			if(args[0].isInstanceOf(CSecureString.TYPE)) {
 				val = new String(((CSecureString) args[0]).getDecryptedCharArray());
 			} else {
 				val = args[0].val();

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -174,7 +174,7 @@ public class DataHandling {
 						String v;
 						if(value instanceof IVariable) {
 							v = ((IVariable) value).getVariableName();
-						} else if(value.isInstanceOf(CString.class)) {
+						} else if(value.isInstanceOf(CString.TYPE)) {
 							v = ((CString) value).getQuote();
 						} else {
 							v = "@value";
@@ -354,7 +354,7 @@ public class DataHandling {
 			int offset = 0;
 			if(args.length == 3) {
 				offset = 1;
-				if(!(args[0].isInstanceOf(CClassType.class))) {
+				if(!(args[0].isInstanceOf(CClassType.TYPE))) {
 					throw new ConfigCompileException("Expecting a ClassType for parameter 1 to assign", t);
 				}
 			}
@@ -461,7 +461,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(!(args[0].isInstanceOf(CArray.class)));
+			return CBoolean.get(!(args[0].isInstanceOf(CArray.TYPE)));
 		}
 
 		@Override
@@ -522,7 +522,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CString.class));
+			return CBoolean.get(args[0].isInstanceOf(CString.TYPE));
 		}
 
 		@Override
@@ -581,7 +581,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CByteArray.class));
+			return CBoolean.get(args[0].isInstanceOf(CByteArray.TYPE));
 		}
 
 		@Override
@@ -641,7 +641,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CArray.class));
+			return CBoolean.get(args[0].isInstanceOf(CArray.TYPE));
 		}
 
 		@Override
@@ -703,7 +703,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CInt.class) || args[0].isInstanceOf(CDouble.class));
+			return CBoolean.get(args[0].isInstanceOf(CInt.TYPE) || args[0].isInstanceOf(CDouble.TYPE));
 		}
 
 		@Override
@@ -766,7 +766,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CDouble.class));
+			return CBoolean.get(args[0].isInstanceOf(CDouble.TYPE));
 		}
 
 		@Override
@@ -827,7 +827,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CInt.class));
+			return CBoolean.get(args[0].isInstanceOf(CInt.TYPE));
 		}
 
 		@Override
@@ -887,7 +887,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CBoolean.class));
+			return CBoolean.get(args[0].isInstanceOf(CBoolean.TYPE));
 		}
 
 		@Override
@@ -1172,7 +1172,7 @@ public class DataHandling {
 			List<String> varNames = new ArrayList<>();
 			boolean usesAssign = false;
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData().equals(CVoid.VOID) || nodes[0].getData().isInstanceOf(CClassType.class)) {
+			if(nodes[0].getData().equals(CVoid.VOID) || nodes[0].getData().isInstanceOf(CClassType.TYPE)) {
 				if(nodes[0].getData().equals(CVoid.VOID)) {
 					returnType = CVoid.TYPE;
 				} else {
@@ -1286,7 +1286,7 @@ public class DataHandling {
 					return c;
 				} catch (ConfigRuntimeException e) {
 					if(e instanceof CREThrowable
-							&& ((CREThrowable) e).isInstanceOf(CREInvalidProcedureException.class)) {
+							&& ((CREThrowable) e).isInstanceOf(CREInvalidProcedureException.TYPE)) {
 						//This is the only valid exception that doesn't strictly mean it's a bad
 						//call.
 						return null;
@@ -1534,7 +1534,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				return CBoolean.get(((CArray) args[0]).inAssociativeMode());
 			} else {
 				throw new CRECastException(this.getName() + " expects argument 1 to be an array", t);
@@ -1593,7 +1593,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			return CBoolean.get(args[0].isInstanceOf(CClosure.class));
+			return CBoolean.get(args[0].isInstanceOf(CClosure.TYPE));
 		}
 
 		@Override
@@ -1655,9 +1655,9 @@ public class DataHandling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String key;
-			if(args[0].isInstanceOf(CString.class)) {
+			if(args[0].isInstanceOf(CString.TYPE)) {
 				key = args[0].val();
-			} else if(args[0].isInstanceOf(CArray.class)) {
+			} else if(args[0].isInstanceOf(CArray.TYPE)) {
 				if(((CArray) args[0]).isAssociative()) {
 					throw new CREIllegalArgumentException("Associative arrays may not be used as keys in " + getName(), t);
 				}
@@ -1726,9 +1726,9 @@ public class DataHandling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String key;
-			if(args[0].isInstanceOf(CString.class)) {
+			if(args[0].isInstanceOf(CString.TYPE)) {
 				key = args[0].val();
-			} else if(args[0].isInstanceOf(CArray.class)) {
+			} else if(args[0].isInstanceOf(CArray.TYPE)) {
 				if(((CArray) args[0]).isAssociative()) {
 					throw new CREIllegalArgumentException("Associative arrays may not be used as keys in " + getName(), t);
 				}
@@ -1828,7 +1828,7 @@ public class DataHandling {
 			}
 			// Handle the closure type first thing
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
+			if(nodes[0].getData().isInstanceOf(CClassType.TYPE)) {
 				returnType = (CClassType) nodes[0].getData();
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
@@ -1951,7 +1951,7 @@ public class DataHandling {
 			}
 			// Handle the closure type first thing
 			CClassType returnType = Auto.TYPE;
-			if(nodes[0].getData().isInstanceOf(CClassType.class)) {
+			if(nodes[0].getData().isInstanceOf(CClassType.TYPE)) {
 				returnType = (CClassType) nodes[0].getData();
 				ParseTree[] newNodes = new ParseTree[nodes.length - 1];
 				for(int i = 1; i < nodes.length; i++) {
@@ -2090,7 +2090,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[args.length - 1].isInstanceOf(CClosure.class)) {
+			if(args[args.length - 1].isInstanceOf(CClosure.TYPE)) {
 				Mixed[] vals = new Mixed[args.length - 1];
 				System.arraycopy(args, 0, vals, 0, args.length - 1);
 				CClosure closure = (CClosure) args[args.length - 1];
@@ -2196,7 +2196,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(!(args[args.length - 1].isInstanceOf(CClosure.class))) {
+			if(!(args[args.length - 1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Only a closure (created from the closure function) can be sent to executeas()", t);
 			}
 			Mixed[] vals = new Mixed[args.length - 3];
@@ -2464,7 +2464,7 @@ public class DataHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CString.class)) {
+			if(args[0].isInstanceOf(CString.TYPE)) {
 				return args[0];
 			}
 			return new CString(args[0].val(), t);
@@ -2764,7 +2764,7 @@ public class DataHandling {
 			try {
 				env.getEnv(GlobalEnv.class).SetDynamicScriptingMode(true);
 				Mixed script = parent.seval(node, env);
-				if(script.isInstanceOf(CClosure.class)) {
+				if(script.isInstanceOf(CClosure.TYPE)) {
 					throw new CRECastException("Closures cannot be eval'd directly. Use execute() instead.", t);
 				}
 				ParseTree root = MethodScriptCompiler.compile(MethodScriptCompiler.lex(script.val(), t.file(), true),
@@ -3013,7 +3013,7 @@ public class DataHandling {
 				return CBoolean.FALSE;
 			}
 			CClassType type;
-			if(args[1].isInstanceOf(CClassType.class)) {
+			if(args[1].isInstanceOf(CClassType.TYPE)) {
 				type = (CClassType) args[1];
 			} else {
 				throw new RuntimeException("This should have been optimized out, this is a bug in instanceof,"
@@ -3058,7 +3058,7 @@ public class DataHandling {
 				FileOptions fileOptions) throws ConfigCompileException, ConfigRuntimeException {
 			// There are two specific cases here where we will give more precise error messages.
 			// If it's a string, yell at them
-			if(children.get(1).getData().isInstanceOf(CString.class)) {
+			if(children.get(1).getData().isInstanceOf(CString.TYPE)) {
 				throw new ConfigCompileException("Unexpected string type passed to \"instanceof\"", t);
 			}
 			// If it's a variable, also yell at them
@@ -3066,7 +3066,7 @@ public class DataHandling {
 				throw new ConfigCompileException("Variable types are not allowed in \"instanceof\"", t);
 			}
 			// Unknown error, but this is still never valid.
-			if(!(children.get(1).getData().isInstanceOf(CClassType.class))) {
+			if(!(children.get(1).getData().isInstanceOf(CClassType.TYPE))) {
 				throw new ConfigCompileException("Unexpected type for \"instanceof\": " + children.get(1).getData(), t);
 			}
 			// null is technically a type, but instanceof shouldn't work with that

--- a/src/main/java/com/laytonsmith/core/functions/DataTransformations.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataTransformations.java
@@ -298,7 +298,7 @@ public class DataTransformations {
 				String val;
 				if(c instanceof CNull) {
 					val = "";
-				} else if(c.isInstanceOf(CArray.class)) {
+				} else if(c.isInstanceOf(CArray.TYPE)) {
 					throw new CRECastException("Arrays cannot be encoded with ini_encode.", t);
 				} else {
 					val = c.val();

--- a/src/main/java/com/laytonsmith/core/functions/Debug.java
+++ b/src/main/java/com/laytonsmith/core/functions/Debug.java
@@ -368,7 +368,7 @@ public class Debug {
 						+ TermColors.BRIGHT_WHITE + ivar.getDefinedType()
 						+ TermColors.RESET + " (actual type "
 						+ TermColors.BRIGHT_WHITE + val.typeof()
-						+ (val.isInstanceOf(Sizeable.class) ? ", length: " + ((Sizeable) val).size() : "")
+						+ (val.isInstanceOf(Sizeable.TYPE) ? ", length: " + ((Sizeable) val).size() : "")
 						+ TermColors.RESET + ") "
 						+ TermColors.CYAN + ivar.getVariableName()
 						+ TermColors.RESET + ": " + val.val());
@@ -499,7 +499,7 @@ public class Debug {
 //				throw new ConfigRuntimeException("allow-debug-logging is currently set to false. To use " + this.getVariableName() + ", enable it in your preferences.", CRESecurityException.class, t);
 //			}
 //			Set<Event.Type> set = new HashSet<Event.Type>();
-//			if(args[0].isInstanceOf(CString.class)) {
+//			if(args[0].isInstanceOf(CString.TYPE)) {
 //				if(args[0].val().equals("*")) {
 //					for(Event.Type t : Event.Type.values()) {
 //						set.add(t);
@@ -512,7 +512,7 @@ public class Debug {
 //						throw new ConfigRuntimeException(args[0].val() + " is not a valid filter type. The filter log has not been changed.", CREFormatException.class, t);
 //					}
 //				}
-//			} else if(args[0].isInstanceOf(CArray.class)) {
+//			} else if(args[0].isInstanceOf(CArray.TYPE)) {
 //				for(String c : ((CArray) args[0]).keySet()) {
 //					try {
 //						set.add(Event.Type.valueOf(((CArray) args[0]).get(c, t).val().toUpperCase()));
@@ -574,10 +574,10 @@ public class Debug {
 //			if(!(Boolean) Static.getPreferences().getPreference("allow-debug-logging")) {
 //				throw new ConfigRuntimeException("allow-debug-logging is currently set to false. To use " + this.getVariableName() + ", enable it in your preferences.", CRESecurityException.class, t);
 //			}
-//			if(args[0].isInstanceOf(CString.class)) {
+//			if(args[0].isInstanceOf(CString.TYPE)) {
 //				EVENT_PLUGIN_FILTER.clear();
 //				EVENT_PLUGIN_FILTER.add(args[0].val().toUpperCase());
-//			} else if(args[0].isInstanceOf(CArray.class)) {
+//			} else if(args[0].isInstanceOf(CArray.TYPE)) {
 //				for(String c : ((CArray) args[0]).keySet()) {
 //					EVENT_PLUGIN_FILTER.add(((CArray) args[0]).get(c, t).val().toUpperCase());
 //				}

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -590,7 +590,7 @@ public class Echoes {
 			}
 
 			// Handle "broadcast(message, recipientsArray)".
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 
 				// Get the CArray and validate that it is non-associative.
 				CArray array = (CArray) args[1];
@@ -722,7 +722,7 @@ public class Echoes {
 			if(args.length == 2) {
 				symbol = args[1].val();
 			}
-			if(text.isInstanceOf(CString.class)) {
+			if(text.isInstanceOf(CString.TYPE)) {
 				String stext = text.val();
 				StringBuilder b = new StringBuilder();
 				int sl = symbol.length();

--- a/src/main/java/com/laytonsmith/core/functions/Enchantments.java
+++ b/src/main/java/com/laytonsmith/core/functions/Enchantments.java
@@ -69,7 +69,7 @@ public class Enchantments {
 	 * @return
 	 */
 	public static int ConvertLevel(Mixed value) {
-		if(value.isInstanceOf(CInt.class)) {
+		if(value.isInstanceOf(CInt.TYPE)) {
 			return (int) ((CInt) value).getInt();
 		}
 		String lc = value.val().toLowerCase().trim();
@@ -197,14 +197,14 @@ public class Enchantments {
 			}
 
 			CArray enchantArray = new CArray(t);
-			if(!(args[2 - offset].isInstanceOf(CArray.class))) {
+			if(!(args[2 - offset].isInstanceOf(CArray.TYPE))) {
 				enchantArray.push(args[2 - offset], t);
 			} else {
 				enchantArray = (CArray) args[2 - offset];
 			}
 
 			CArray levelArray = new CArray(t);
-			if(!(args[3 - offset].isInstanceOf(CArray.class))) {
+			if(!(args[3 - offset].isInstanceOf(CArray.TYPE))) {
 				levelArray.push(args[3 - offset], t);
 			} else {
 				levelArray = (CArray) args[3 - offset];
@@ -275,7 +275,7 @@ public class Enchantments {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCPlayer p;
 			int offset = 0;
-			if(args.length == 4 || args.length == 3 && args[2].isInstanceOf(CArray.class)) {
+			if(args.length == 4 || args.length == 3 && args[2].isInstanceOf(CArray.TYPE)) {
 				p = Static.GetPlayer(args[0].val(), t);
 				offset = 1;
 			} else {
@@ -287,7 +287,7 @@ public class Enchantments {
 				throw new CRECastException("There is no item at slot " + args[offset], t);
 			}
 
-			if(args[args.length - 1].isInstanceOf(CArray.class)) {
+			if(args[args.length - 1].isInstanceOf(CArray.TYPE)) {
 				CArray ca = (CArray) args[args.length - 1];
 				Map<MCEnchantment, Integer> enchants = ObjectGenerator.GetGenerator().enchants(ca, t);
 				for(Map.Entry<MCEnchantment, Integer> en : enchants.entrySet()) {
@@ -362,7 +362,7 @@ public class Enchantments {
 			}
 
 			CArray enchantArray = new CArray(t);
-			if(!(args[2 - offset].isInstanceOf(CArray.class)) && !(args[2 - offset] instanceof CNull)) {
+			if(!(args[2 - offset].isInstanceOf(CArray.TYPE)) && !(args[2 - offset] instanceof CNull)) {
 				enchantArray.push(args[2 - offset], t);
 			} else if(args[2 - offset] instanceof CNull) {
 				for(MCEnchantment e : is.getEnchantments().keySet()) {
@@ -437,7 +437,7 @@ public class Enchantments {
 				throw new CRECastException("There is no item at slot " + args[offset], t);
 			}
 
-			if(args[offset + 1].isInstanceOf(CArray.class)) {
+			if(args[offset + 1].isInstanceOf(CArray.TYPE)) {
 				for(String name : ((CArray) args[offset + 1]).stringKeySet()) {
 					MCEnchantment e = GetEnchantment(name, t);
 					is.removeEnchantment(e);
@@ -788,7 +788,7 @@ public class Enchantments {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCItemStack is;
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				is = ObjectGenerator.GetGenerator().item(args[0], t);
 			} else {
 				is = Static.ParseItemNotation(null, args[0].val(), 1, t);
@@ -817,7 +817,7 @@ public class Enchantments {
 				FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() == 1
-					&& (children.get(0).getData().isInstanceOf(CString.class) || children.get(0).getData().isInstanceOf(CInt.class))) {
+					&& (children.get(0).getData().isInstanceOf(CString.TYPE) || children.get(0).getData().isInstanceOf(CInt.TYPE))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -219,7 +219,7 @@ public class EntityManagement {
 						ret.push(new CString(e.getUniqueId().toString(), t), t);
 					}
 				} else {
-					if(args[0].isInstanceOf(CArray.class)) {
+					if(args[0].isInstanceOf(CArray.TYPE)) {
 						c = ObjectGenerator.GetGenerator().location(args[0], null, t).getChunk();
 						for(MCEntity e : c.getEntities()) {
 							ret.push(new CString(e.getUniqueId().toString(), t), t);
@@ -433,7 +433,7 @@ public class EntityManagement {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			MCEntity e = Static.getEntity(args[0], t);
 			MCLocation l;
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				l = ObjectGenerator.GetGenerator().location((CArray) args[1], e.getWorld(), t);
 			} else {
 				throw new CREFormatException("An array was expected but received " + args[1], t);
@@ -860,7 +860,7 @@ public class EntityManagement {
 			int dist;
 			List<String> types = new ArrayList<>();
 
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CREBadEntityException("Expecting an array at parameter 1 of entities_in_radius", t);
 			}
 
@@ -872,7 +872,7 @@ public class EntityManagement {
 			}
 
 			if(args.length == 3) {
-				if(args[2].isInstanceOf(CArray.class)) {
+				if(args[2].isInstanceOf(CArray.TYPE)) {
 					CArray ta = (CArray) args[2];
 					for(int i = 0; i < ta.size(); i++) {
 						types.add(ta.get(i, t).val());
@@ -1123,7 +1123,7 @@ public class EntityManagement {
 			if(args.length >= 3) {
 				l = ObjectGenerator.GetGenerator().location(args[2], null, t);
 				if(args.length == 4) {
-					if(args[3].isInstanceOf(CClosure.class)) {
+					if(args[3].isInstanceOf(CClosure.TYPE)) {
 						consumer = (CClosure) args[3];
 					} else {
 						throw new CREIllegalArgumentException("Expected a closure as last argument for spawn_entity().", t);
@@ -2195,7 +2195,7 @@ public class EntityManagement {
 					for(String index : specArray.stringKeySet()) {
 						switch(index.toLowerCase()) {
 							case entity_spec.KEY_AREAEFFECTCLOUD_COLOR:
-								if(specArray.get(index, t).isInstanceOf(CArray.class)) {
+								if(specArray.get(index, t).isInstanceOf(CArray.TYPE)) {
 									CArray color = (CArray) specArray.get(index, t);
 									cloud.setColor(ObjectGenerator.GetGenerator().color(color, t));
 								} else {
@@ -2218,11 +2218,11 @@ public class EntityManagement {
 								break;
 							case entity_spec.KEY_AREAEFFECTCLOUD_POTIONMETA:
 								Mixed c = specArray.get(index, t);
-								if(c.isInstanceOf(CArray.class)) {
+								if(c.isInstanceOf(CArray.TYPE)) {
 									CArray meta = (CArray) c;
 									if(meta.containsKey("base")) {
 										Mixed base = meta.get("base", t);
-										if(base.isInstanceOf(CArray.class)) {
+										if(base.isInstanceOf(CArray.TYPE)) {
 											MCPotionData pd = ObjectGenerator.GetGenerator().potionData((CArray) base, t);
 											cloud.setBasePotionData(pd);
 										}
@@ -2230,7 +2230,7 @@ public class EntityManagement {
 									if(meta.containsKey("potions")) {
 										cloud.clearCustomEffects();
 										Mixed potions = meta.get("potions", t);
-										if(potions.isInstanceOf(CArray.class)) {
+										if(potions.isInstanceOf(CArray.TYPE)) {
 											List<MCLivingEntity.MCEffect> list = ObjectGenerator.GetGenerator().potions((CArray) potions, t);
 											for(MCLivingEntity.MCEffect effect : list) {
 												cloud.addCustomEffect(effect);
@@ -2257,7 +2257,7 @@ public class EntityManagement {
 								Mixed cloudSource = specArray.get(index, t);
 								if(cloudSource instanceof CNull) {
 									cloud.setSource(null);
-								} else if(cloudSource.isInstanceOf(CArray.class)) {
+								} else if(cloudSource.isInstanceOf(CArray.TYPE)) {
 									MCBlock b = ObjectGenerator.GetGenerator().location(cloudSource, cloud.getWorld(), t).getBlock();
 									if(b.isDispenser()) {
 										cloud.setSource(b.getDispenser().getBlockProjectileSource());
@@ -2303,11 +2303,11 @@ public class EntityManagement {
 									throwException(index, t);
 								}
 								Mixed c = specArray.get(index, t);
-								if(c.isInstanceOf(CArray.class)) {
+								if(c.isInstanceOf(CArray.TYPE)) {
 									CArray meta = (CArray) c;
 									if(meta.containsKey("base")) {
 										Mixed base = meta.get("base", t);
-										if(base.isInstanceOf(CArray.class)) {
+										if(base.isInstanceOf(CArray.TYPE)) {
 											MCPotionData pd = ObjectGenerator.GetGenerator().potionData((CArray) base, t);
 											arrow.setBasePotionData(pd);
 										}
@@ -2315,7 +2315,7 @@ public class EntityManagement {
 									if(meta.containsKey("potions")) {
 										arrow.clearCustomEffects();
 										Mixed potions = meta.get("potions", t);
-										if(potions.isInstanceOf(CArray.class)) {
+										if(potions.isInstanceOf(CArray.TYPE)) {
 											List<MCLivingEntity.MCEffect> list = ObjectGenerator.GetGenerator().potions((CArray) potions, t);
 											for(MCLivingEntity.MCEffect effect : list) {
 												arrow.addCustomEffect(effect);
@@ -2355,7 +2355,7 @@ public class EntityManagement {
 								break;
 							case entity_spec.KEY_ARMORSTAND_POSES:
 								Map<MCBodyPart, Vector3D> poseMap = stand.getAllPoses();
-								if(specArray.get(index, t).isInstanceOf(CArray.class)) {
+								if(specArray.get(index, t).isInstanceOf(CArray.TYPE)) {
 									CArray poseArray = (CArray) specArray.get(index, t);
 									for(MCBodyPart key : poseMap.keySet()) {
 										try {
@@ -2503,7 +2503,7 @@ public class EntityManagement {
 								Mixed c = specArray.get(index, t);
 								if(c instanceof CNull) {
 									endercrystal.setBeamTarget(null);
-								} else if(c.isInstanceOf(CArray.class)) {
+								} else if(c.isInstanceOf(CArray.TYPE)) {
 									MCLocation l = ObjectGenerator.GetGenerator().location((CArray) c, endercrystal.getWorld(), t);
 									endercrystal.setBeamTarget(l);
 								} else {
@@ -2640,7 +2640,7 @@ public class EntityManagement {
 								fm.clearEffects();
 								CArray effects = Static.getArray(specArray.get(index, t), t);
 								for(Mixed eff : effects.asList()) {
-									if(eff.isInstanceOf(CArray.class)) {
+									if(eff.isInstanceOf(CArray.TYPE)) {
 										fm.addEffect(ObjectGenerator.GetGenerator().fireworkEffect((CArray) eff, t));
 									} else {
 										throw new CRECastException("Firework effect expected to be an array.", t);
@@ -3146,11 +3146,11 @@ public class EntityManagement {
 								break;
 							case entity_spec.KEY_TIPPEDARROW_POTIONMETA:
 								Mixed c = specArray.get(index, t);
-								if(c.isInstanceOf(CArray.class)) {
+								if(c.isInstanceOf(CArray.TYPE)) {
 									CArray meta = (CArray) c;
 									if(meta.containsKey("base")) {
 										Mixed base = meta.get("base", t);
-										if(base.isInstanceOf(CArray.class)) {
+										if(base.isInstanceOf(CArray.TYPE)) {
 											MCPotionData pd = ObjectGenerator.GetGenerator().potionData((CArray) base, t);
 											tippedarrow.setBasePotionData(pd);
 										}
@@ -3158,7 +3158,7 @@ public class EntityManagement {
 									if(meta.containsKey("potions")) {
 										tippedarrow.clearCustomEffects();
 										Mixed potions = meta.get("potions", t);
-										if(potions.isInstanceOf(CArray.class)) {
+										if(potions.isInstanceOf(CArray.TYPE)) {
 											List<MCLivingEntity.MCEffect> list = ObjectGenerator.GetGenerator().potions((CArray) potions, t);
 											for(MCLivingEntity.MCEffect effect : list) {
 												tippedarrow.addCustomEffect(effect);
@@ -3391,7 +3391,7 @@ public class EntityManagement {
 			if(entity instanceof MCProjectile) {
 				if(args[1] instanceof CNull) {
 					((MCProjectile) entity).setShooter(null);
-				} else if(args[1].isInstanceOf(CArray.class)) {
+				} else if(args[1].isInstanceOf(CArray.TYPE)) {
 					MCBlock b = ObjectGenerator.GetGenerator().location(args[1], entity.getWorld(), t).getBlock();
 					if(b.isDispenser()) {
 						((MCProjectile) entity).setShooter(b.getDispenser().getBlockProjectileSource());
@@ -3857,7 +3857,7 @@ public class EntityManagement {
 				is = ObjectGenerator.GetGenerator().item(args[0], t);
 			} else {
 				MCPlayer p;
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					p = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
 					l = ObjectGenerator.GetGenerator().location(args[0], (p != null ? p.getWorld() : null), t);
 					natural = true;
@@ -3929,7 +3929,7 @@ public class EntityManagement {
 			List<MCFireworkEffect> effects = new ArrayList<>();
 			if(options.containsKey("effects")) {
 				Mixed cEffects = options.get("effects", t);
-				if(cEffects.isInstanceOf(CArray.class)) {
+				if(cEffects.isInstanceOf(CArray.TYPE)) {
 					for(Mixed c : ((CArray) cEffects).asList()) {
 						effects.add(ObjectGenerator.GetGenerator().fireworkEffect((CArray) c, t));
 					}

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -698,7 +698,7 @@ public class Environment {
 				String line2 = "";
 				String line3 = "";
 				String line4 = "";
-				if(args.length == 2 && args[1].isInstanceOf(CArray.class)) {
+				if(args.length == 2 && args[1].isInstanceOf(CArray.TYPE)) {
 					CArray ca = (CArray) args[1];
 					if(ca.size() >= 1) {
 						line1 = ca.get(0, t).val();
@@ -988,7 +988,7 @@ public class Environment {
 				return null;
 			}
 			Mixed c = children.get(children.size() - 1).getData();
-			if(c.isInstanceOf(CString.class)) {
+			if(c.isInstanceOf(CString.TYPE)) {
 				try {
 					MCBiomeType.valueOf(c.val());
 				} catch (IllegalArgumentException ex) {
@@ -1124,7 +1124,7 @@ public class Environment {
 				w = ((MCPlayer) sender).getWorld();
 			}
 
-			if(args[0].isInstanceOf(CArray.class) && !(args.length == 3)) {
+			if(args[0].isInstanceOf(CArray.TYPE) && !(args.length == 3)) {
 				MCLocation loc = ObjectGenerator.GetGenerator().location(args[0], w, t);
 				x = loc.getX();
 				z = loc.getZ();
@@ -1219,7 +1219,7 @@ public class Environment {
 				throw new CRERangeException("A bit excessive, don't you think? Let's scale that back some, huh?", t);
 			}
 
-			if(!(args[0].isInstanceOf(CArray.class))) {
+			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting an array at parameter 1 of explosion", t);
 			}
 
@@ -1287,7 +1287,7 @@ public class Environment {
 				noteOffset = 2;
 				l = ObjectGenerator.GetGenerator().location(args[3], p.getWorld(), t);
 			} else {
-				if(!(args[1].isInstanceOf(CArray.class)) && args[2].isInstanceOf(CArray.class)) {
+				if(!(args[1].isInstanceOf(CArray.TYPE)) && args[2].isInstanceOf(CArray.TYPE)) {
 					//Player provided, location not
 					instrumentOffset = 1;
 					noteOffset = 2;
@@ -1308,7 +1308,7 @@ public class Environment {
 						+ StringUtils.Join(MCInstrument.values(), ", ", ", or "), t);
 			}
 			MCTone tone = null;
-			if(args[noteOffset].isInstanceOf(CArray.class)) {
+			if(args[noteOffset].isInstanceOf(CArray.TYPE)) {
 				int octave = Static.getInt32(((CArray) args[noteOffset]).get("octave", t), t);
 				if(octave < 0 || octave > 2) {
 					throw new CRERangeException("The octave must be 0, 1, or 2, but was " + octave, t);
@@ -1433,7 +1433,7 @@ public class Environment {
 			double speed = 0.0;
 			Object data = null;
 
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray pa = (CArray) args[1];
 				try {
 					p = MCParticle.valueOf(pa.get("particle", t).val().toUpperCase());
@@ -1476,7 +1476,7 @@ public class Environment {
 
 				} else if(pa.containsKey("color")) {
 					Mixed c = pa.get("color", t);
-					if(c.isInstanceOf(CArray.class)) {
+					if(c.isInstanceOf(CArray.TYPE)) {
 						data = ObjectGenerator.GetGenerator().color((CArray) c, t);
 					} else {
 						data = StaticLayer.GetConvertor().GetColor(c.val(), t);
@@ -1494,7 +1494,7 @@ public class Environment {
 			try {
 				if(args.length == 3) {
 					MCPlayer player;
-					if(args[2].isInstanceOf(CArray.class)) {
+					if(args[2].isInstanceOf(CArray.TYPE)) {
 						for(Mixed playerName : ((CArray) args[2]).asList()) {
 							player = Static.GetPlayer(playerName, t);
 							player.spawnParticle(l, p, count, offsetX, offsetY, offsetZ, speed, data);
@@ -1544,7 +1544,7 @@ public class Environment {
 			float volume = 1;
 			float pitch = 1;
 
-			if(!(args[1].isInstanceOf(CArray.class))) {
+			if(!(args[1].isInstanceOf(CArray.TYPE))) {
 				throw new CREFormatException("An array was expected but received " + args[1], t);
 			}
 
@@ -1576,7 +1576,7 @@ public class Environment {
 
 			if(args.length == 3) {
 				java.util.List<MCPlayer> players = new java.util.ArrayList<MCPlayer>();
-				if(args[2].isInstanceOf(CArray.class)) {
+				if(args[2].isInstanceOf(CArray.TYPE)) {
 					for(String key : ((CArray) args[2]).stringKeySet()) {
 						players.add(Static.GetPlayer(((CArray) args[2]).get(key, t), t));
 					}
@@ -1645,7 +1645,7 @@ public class Environment {
 					if(node.getData() instanceof CFunction && node.getData().val().equals("centry")) {
 						children = node.getChildren();
 						if(children.get(0).getData().val().equals("sound")
-								&& children.get(1).getData().isInstanceOf(CString.class)) {
+								&& children.get(1).getData().isInstanceOf(CString.TYPE)) {
 							try {
 								MCSound.MCVanillaSound.valueOf(children.get(1).getData().val().toUpperCase());
 							} catch (IllegalArgumentException ex) {
@@ -1695,7 +1695,7 @@ public class Environment {
 			float volume = 1;
 			float pitch = 1;
 
-			if(!(args[1].isInstanceOf(CArray.class))) {
+			if(!(args[1].isInstanceOf(CArray.TYPE))) {
 				throw new CREFormatException("An array was expected but received " + args[1], t);
 			}
 
@@ -1721,7 +1721,7 @@ public class Environment {
 
 			if(args.length == 3) {
 				java.util.List<MCPlayer> players = new java.util.ArrayList<MCPlayer>();
-				if(args[2].isInstanceOf(CArray.class)) {
+				if(args[2].isInstanceOf(CArray.TYPE)) {
 					for(String key : ((CArray) args[2]).stringKeySet()) {
 						players.add(Static.GetPlayer(((CArray) args[2]).get(key, t), t));
 					}
@@ -2203,7 +2203,7 @@ public class Environment {
 				throws ConfigRuntimeException {
 			String cmd = null;
 			if(args.length == 2 && !(args[1] instanceof CNull)) {
-				if(!(args[1].isInstanceOf(CString.class))) {
+				if(!(args[1].isInstanceOf(CString.TYPE))) {
 					throw new CRECastException("Parameter 2 of " + getName() + " must be a string or null", t);
 				}
 				cmd = args[1].val();
@@ -2315,7 +2315,7 @@ public class Environment {
 		) throws ConfigRuntimeException {
 			String name = null;
 			if(args.length == 2 && !(args[1] instanceof CNull)) {
-				if(!(args[1].isInstanceOf(CString.class))) {
+				if(!(args[1].isInstanceOf(CString.TYPE))) {
 					throw new CRECastException("Parameter 2 of " + getName() + " must be a string or null", t);
 				}
 				name = args[1].val();

--- a/src/main/java/com/laytonsmith/core/functions/EventBinding.java
+++ b/src/main/java/com/laytonsmith/core/functions/EventBinding.java
@@ -133,10 +133,10 @@ public class EventBinding {
 			ParseTree tree = nodes[nodes.length - 1];
 
 			//Check to see if our arguments are correct
-			if(!(options instanceof CNull || options.isInstanceOf(CArray.class))) {
+			if(!(options instanceof CNull || options.isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("The options must be an array or null", t);
 			}
-			if(!(prefilter instanceof CNull || prefilter.isInstanceOf(CArray.class))) {
+			if(!(prefilter instanceof CNull || prefilter.isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("The prefilters must be an array or null", t);
 			}
 			if(!(event_obj instanceof IVariable)) {
@@ -510,7 +510,7 @@ public class EventBinding {
 			CArray obj = null;
 			if(args[1] instanceof CNull) {
 				obj = new CArray(t);
-			} else if(args[1].isInstanceOf(CArray.class)) {
+			} else if(args[1].isInstanceOf(CArray.TYPE)) {
 				obj = (CArray) args[1];
 			} else {
 				throw new CRECastException("The eventObject must be null, or an array", t);
@@ -652,7 +652,7 @@ public class EventBinding {
 			if(args.length == 0) {
 				e.lock(null);
 			} else {
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					CArray ca = (CArray) args[1];
 					for(int i = 0; i < ca.size(); i++) {
 						params.add(ca.get(i, t).val());

--- a/src/main/java/com/laytonsmith/core/functions/Exceptions.java
+++ b/src/main/java/com/laytonsmith/core/functions/Exceptions.java
@@ -147,9 +147,9 @@ public class Exceptions {
 			List<FullyQualifiedClassName> interest = new ArrayList<>();
 			if(types != null) {
 				Mixed ptypes = that.seval(types, env);
-				if(ptypes.isInstanceOf(CString.class)) {
+				if(ptypes.isInstanceOf(CString.TYPE)) {
 					interest.add(FullyQualifiedClassName.forName(ptypes.val(), t, env));
-				} else if(ptypes.isInstanceOf(CArray.class)) {
+				} else if(ptypes.isInstanceOf(CArray.TYPE)) {
 					CArray ca = (CArray) ptypes;
 					for(int i = 0; i < ca.size(); i++) {
 						interest.add(FullyQualifiedClassName.forName(ca.get(i, t).val(), t, env));
@@ -347,7 +347,7 @@ public class Exceptions {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CClosure.class)) {
+			if(args[0].isInstanceOf(CClosure.TYPE)) {
 				CClosure old = environment.getEnv(GlobalEnv.class).GetExceptionHandler();
 				environment.getEnv(GlobalEnv.class).SetExceptionHandler((CClosure) args[0]);
 				if(old == null) {
@@ -532,7 +532,7 @@ public class Exceptions {
 				// TODO: Eh.. should probably move this check into the keyword, since techincally
 				// catch (Exception @e = null) { } would work.
 				ParseTree assign = children.get(i);
-				if(assign.getChildAt(0).getData().isInstanceOf(CString.class)) {
+				if(assign.getChildAt(0).getData().isInstanceOf(CString.TYPE)) {
 					// This is an unknown exception type, because otherwise it would have been cast to a CClassType
 					throw new ConfigCompileException("Unknown class type: " + assign.getChildAt(0).getData().val(), t);
 				}

--- a/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
@@ -57,7 +57,7 @@ public class ExecutionQueue {
 		public Mixed exec(Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final CClosure c;
 			String queue = null;
-			if(!(args[0].isInstanceOf(CClosure.class))) {
+			if(!(args[0].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Parameter 1 to " + getName() + " must be a closure.", t);
 			}
 			c = ((CClosure) args[0]);
@@ -139,7 +139,7 @@ public class ExecutionQueue {
 		public Mixed exec(Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final CClosure c;
 			String queue = null;
-			if(!(args[0].isInstanceOf(CClosure.class))) {
+			if(!(args[0].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Parameter 1 to " + getName() + " must be a closure.", t);
 			}
 			c = ((CClosure) args[0]);

--- a/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExtensionMeta.java
@@ -112,7 +112,7 @@ public class ExtensionMeta {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
 			}
 
-			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
+			if(!(children.get(0).getData().isInstanceOf(CString.TYPE))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			}
 
@@ -192,7 +192,7 @@ public class ExtensionMeta {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
 			}
 
-			if(!(children.get(0).getData().isInstanceOf(CString.class))) {
+			if(!(children.get(0).getData().isInstanceOf(CString.TYPE))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			}
 
@@ -265,7 +265,7 @@ public class ExtensionMeta {
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() != 1) {
 				throw new ConfigCompileException(getName() + " can only accept one argument", t);
-			} else if(!(children.get(0).getData().isInstanceOf(CString.class))) {
+			} else if(!(children.get(0).getData().isInstanceOf(CString.TYPE))) {
 				throw new ConfigCompileException(getName() + " can only accept hardcoded string values", t);
 			} else {
 				return new ParseTree(this.exec(t, null, children.get(0).getData()), children.get(0).getFileOptions());

--- a/src/main/java/com/laytonsmith/core/functions/Federation.java
+++ b/src/main/java/com/laytonsmith/core/functions/Federation.java
@@ -263,7 +263,7 @@ public class Federation {
 //			final String allow_from;
 //			final int master_port;
 //
-//			if(!(args[0].isInstanceOf(CArray.class))) {
+//			if(!(args[0].isInstanceOf(CArray.TYPE))) {
 //				throw new Exceptions.CastException("Expecting argument 1 to be an array.", t);
 //			}
 //

--- a/src/main/java/com/laytonsmith/core/functions/FileHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/FileHandling.java
@@ -250,7 +250,7 @@ public class FileHandling {
 			startup();
 			final String file = args[0].val();
 			final CClosure callback;
-			if(!(args[1].isInstanceOf(CClosure.class))) {
+			if(!(args[1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Expected paramter 2 of " + getName() + " to be a closure!", t);
 			} else {
 				callback = ((CClosure) args[1]);

--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -503,7 +503,7 @@ public class InventoryManagement {
 				m = Static.GetPlayer(args[0], t);
 				arg = args[1];
 			}
-			if(!(arg.isInstanceOf(CArray.class))) {
+			if(!(arg.isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting an array as the last argument.", t);
 			}
 			CArray array = (CArray) arg;
@@ -660,7 +660,7 @@ public class InventoryManagement {
 				return new CInt(0, t);
 			}
 
-			if(c.isInstanceOf(CArray.class)) {
+			if(c.isInstanceOf(CArray.TYPE)) {
 				ca = (CArray) c;
 				is = ObjectGenerator.GetGenerator().item(ca, t);
 			} else {
@@ -703,7 +703,7 @@ public class InventoryManagement {
 				Set<Class<? extends Environment.EnvironmentImpl>> envs,
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
-			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.class)) {
+			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.TYPE)) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -779,7 +779,7 @@ public class InventoryManagement {
 			if(item instanceof CNull) {
 				ca = null;
 				is = StaticLayer.GetItemStack("AIR", 1);
-			} else if(item.isInstanceOf(CArray.class)) {
+			} else if(item.isInstanceOf(CArray.TYPE)) {
 				ca = (CArray) item;
 				is = ObjectGenerator.GetGenerator().item(ca, t);
 			} else {
@@ -825,7 +825,7 @@ public class InventoryManagement {
 				Set<Class<? extends Environment.EnvironmentImpl>> envs,
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
-			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.class)) {
+			if(children.size() > 0 && children.get(children.size() - 1).getData().isInstanceOf(CString.TYPE)) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -904,11 +904,11 @@ public class InventoryManagement {
 				if(args[1] instanceof CNull) {
 					return new CInt(0, t);
 				}
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
-				if(args[0].isInstanceOf(CString.class)) { // we assume player here, apparently
+				if(args[0].isInstanceOf(CString.TYPE)) { // we assume player here, apparently
 					itemOffset = 1;
 				}
 			} else if(args.length == 4) {
@@ -922,7 +922,7 @@ public class InventoryManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 
-			if(args[itemOffset].isInstanceOf(CArray.class)) {
+			if(args[itemOffset].isInstanceOf(CArray.TYPE)) {
 				is = ObjectGenerator.GetGenerator().item(args[itemOffset], t);
 			} else if(args.length > 1) {
 				is = Static.ParseItemNotation(null, args[itemOffset].val(), Static.getInt32(args[itemOffset + 1], t), t);
@@ -959,7 +959,7 @@ public class InventoryManagement {
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
+					&& (children.get(1).getData().isInstanceOf(CString.TYPE) || children.get(1).getData().isInstanceOf(CInt.TYPE))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1018,7 +1018,7 @@ public class InventoryManagement {
 				if(args[1] instanceof CNull) {
 					return new CInt(0, t);
 				}
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
@@ -1032,7 +1032,7 @@ public class InventoryManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 
-			if(args[itemOffset].isInstanceOf(CArray.class)) {
+			if(args[itemOffset].isInstanceOf(CArray.TYPE)) {
 				ca = (CArray) args[itemOffset];
 				is = ObjectGenerator.GetGenerator().item(ca, t);
 			} else {
@@ -1080,7 +1080,7 @@ public class InventoryManagement {
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
+					&& (children.get(1).getData().isInstanceOf(CString.TYPE) || children.get(1).getData().isInstanceOf(CInt.TYPE))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1160,11 +1160,11 @@ public class InventoryManagement {
 				if(args[1] instanceof CNull) {
 					return new CInt(0, t);
 				}
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
-				if(args[0].isInstanceOf(CString.class)) { // we assume player here, apparently
+				if(args[0].isInstanceOf(CString.TYPE)) { // we assume player here, apparently
 					itemOffset = 1;
 				}
 			} else if(args.length == 4) {
@@ -1178,7 +1178,7 @@ public class InventoryManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 
-			if(args[itemOffset].isInstanceOf(CArray.class)) {
+			if(args[itemOffset].isInstanceOf(CArray.TYPE)) {
 				is = ObjectGenerator.GetGenerator().item(args[itemOffset], t);
 			} else {
 				is = Static.ParseItemNotation(null, args[itemOffset].val(), Static.getInt32(args[itemOffset + 1], t), t);
@@ -1213,7 +1213,7 @@ public class InventoryManagement {
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
+					&& (children.get(1).getData().isInstanceOf(CString.TYPE) || children.get(1).getData().isInstanceOf(CInt.TYPE))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1271,7 +1271,7 @@ public class InventoryManagement {
 				if(args[1] instanceof CNull) {
 					return new CInt(0, t);
 				}
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					itemOffset = 1;
 				}
 			} else if(args.length == 3) {
@@ -1285,7 +1285,7 @@ public class InventoryManagement {
 				p = Static.GetPlayer(args[0], t);
 			}
 
-			if(args[itemOffset].isInstanceOf(CArray.class)) {
+			if(args[itemOffset].isInstanceOf(CArray.TYPE)) {
 				ca = (CArray) args[itemOffset];
 				is = ObjectGenerator.GetGenerator().item(ca, t);
 			} else {
@@ -1332,7 +1332,7 @@ public class InventoryManagement {
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.size() > 2 || children.size() == 2
-					&& (children.get(1).getData().isInstanceOf(CString.class) || children.get(1).getData().isInstanceOf(CInt.class))) {
+					&& (children.get(1).getData().isInstanceOf(CString.TYPE) || children.get(1).getData().isInstanceOf(CInt.TYPE))) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "The string item format in " + getName() + " is deprecated.", t);
 			}
 			return null;
@@ -1429,7 +1429,7 @@ public class InventoryManagement {
 				arg = args[0];
 			}
 
-			if(!(arg.isInstanceOf(CArray.class))) {
+			if(!(arg.isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting an array as argument " + (args.length == 1 ? "1" : "2"), t);
 			}
 
@@ -2042,7 +2042,7 @@ public class InventoryManagement {
 			MCInventory inventory = InventoryManagement.GetInventory(args[0], null, t);
 			Integer size = inventory.getSize();
 
-			if(!(args[1].isInstanceOf(CArray.class))) {
+			if(!(args[1].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("Expecting an array as argument 2", t);
 			}
 
@@ -2682,7 +2682,7 @@ public class InventoryManagement {
 			int size = 54;
 			String title = null;
 			if(args.length > 1) {
-				if(args[1].isInstanceOf(CNumber.class)) {
+				if(args[1].isInstanceOf(CNumber.TYPE)) {
 					size = Static.getInt32(args[1], t);
 					if(size < 9) {
 						size = 9; // minimum
@@ -2716,7 +2716,7 @@ public class InventoryManagement {
 			}
 
 			if(args.length == 4) {
-				if(!(args[3].isInstanceOf(CArray.class))) {
+				if(!(args[3].isInstanceOf(CArray.TYPE))) {
 					throw new CRECastException("Inventory argument not an array in " + getName(), t);
 				}
 				CArray array = (CArray) args[3];
@@ -2827,7 +2827,7 @@ public class InventoryManagement {
 	 */
 	private static MCInventory GetInventory(Mixed specifier, MCWorld w, Target t) {
 		MCInventory inv;
-		if(specifier.isInstanceOf(CArray.class)) {
+		if(specifier.isInstanceOf(CArray.TYPE)) {
 			MCLocation l = ObjectGenerator.GetGenerator().location(specifier, w, t);
 			inv = StaticLayer.GetConvertor().GetLocationInventory(l);
 			if(inv == null) {

--- a/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
@@ -346,14 +346,14 @@ public class ItemMeta {
 			if(args.length == 3) {
 				p = Static.GetPlayer(args[0], t);
 				slot = Static.getInt32(args[1], t);
-				if(args[2].isInstanceOf(CArray.class)) {
+				if(args[2].isInstanceOf(CArray.TYPE)) {
 					color = (CArray) args[2];
 				} else {
 					throw new CREFormatException("Expected an array but received " + args[2] + " instead.", t);
 				}
 			} else {
 				slot = Static.getInt32(args[0], t);
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					color = (CArray) args[1];
 				} else {
 					throw new CREFormatException("Expected an array but received " + args[1] + " instead.", t);

--- a/src/main/java/com/laytonsmith/core/functions/Marquee.java
+++ b/src/main/java/com/laytonsmith/core/functions/Marquee.java
@@ -68,7 +68,7 @@ public class Marquee {
 			text = args[1 + offset].val();
 			stringWidth = Static.getInt32(args[2 + offset], t);
 			delayTime = Static.getInt32(args[3 + offset], t);
-			if(args[4 + offset].isInstanceOf(CClosure.class)) {
+			if(args[4 + offset].isInstanceOf(CClosure.TYPE)) {
 				callback = ((CClosure) args[4 + offset]);
 			} else {
 				throw new CRECastException("Expected argument " + (4 + offset + 1) + " to be a closure, but was not.", t);

--- a/src/main/java/com/laytonsmith/core/functions/Math.java
+++ b/src/main/java/com/laytonsmith/core/functions/Math.java
@@ -529,12 +529,12 @@ public class Math {
 				}
 				long delta = Static.getInt(cdelta, t);
 				//First, error check, then get the old value, and store it in temp.
-				if(!(array.isInstanceOf(CArray.class)) && !(array.isInstanceOf(ArrayAccess.class))) {
+				if(!(array.isInstanceOf(CArray.TYPE)) && !(array.isInstanceOf(ArrayAccess.TYPE))) {
 					//Let's just evaluate this like normal with array_get, so it will
 					//throw the appropriate exception.
 					new ArrayHandling.array_get().exec(t, env, array, index);
 					throw ConfigRuntimeException.CreateUncatchableException("Shouldn't have gotten here. Please report this error, and how you got here.", t);
-				} else if(!(array.isInstanceOf(CArray.class))) {
+				} else if(!(array.isInstanceOf(CArray.TYPE))) {
 					//It's an ArrayAccess type, but we can't use that here, so, throw our
 					//own exception.
 					throw new CRECastException("Cannot increment/decrement a non-array array"
@@ -545,7 +545,7 @@ public class Math {
 				Mixed value = myArray.get(index, t);
 
 				//Alright, now let's actually perform the increment, and store that in the array.
-				if(value.isInstanceOf(CInt.class)) {
+				if(value.isInstanceOf(CInt.TYPE)) {
 					CInt newVal;
 					if(inc) {
 						newVal = new CInt(Static.getInt(value, t) + delta, t);
@@ -558,7 +558,7 @@ public class Math {
 					} else {
 						return value;
 					}
-				} else if(value.isInstanceOf(CDouble.class)) {
+				} else if(value.isInstanceOf(CDouble.TYPE)) {
 					CDouble newVal;
 					if(inc) {
 						newVal = new CDouble(Static.getDouble(value, t) + delta, t);
@@ -1192,7 +1192,7 @@ public class Math {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CInt.class)) {
+			if(args[0].isInstanceOf(CInt.TYPE)) {
 				return new CInt(java.lang.Math.abs(Static.getInt(args[0], t)), t);
 			} else {
 				return new CDouble(java.lang.Math.abs(Static.getDouble(args[0], t)), t);
@@ -1444,7 +1444,7 @@ public class Math {
 
 		public List<Mixed> recList(List<Mixed> list, Mixed... args) {
 			for(Mixed c : args) {
-				if(c.isInstanceOf(CArray.class)) {
+				if(c.isInstanceOf(CArray.TYPE)) {
 					for(int i = 0; i < ((CArray) c).size(); i++) {
 						recList(list, ((CArray) c).get(i, Target.UNKNOWN));
 					}
@@ -1526,7 +1526,7 @@ public class Math {
 
 		public List<Mixed> recList(List<Mixed> list, Mixed... args) {
 			for(Mixed c : args) {
-				if(c.isInstanceOf(CArray.class)) {
+				if(c.isInstanceOf(CArray.TYPE)) {
 					for(int i = 0; i < ((CArray) c).size(); i++) {
 						recList(list, ((CArray) c).get(i, Target.UNKNOWN));
 					}
@@ -2370,9 +2370,9 @@ public class Math {
 				throw new CREFormatException("Expression may not be empty", t);
 			}
 			CArray vars = null;
-			if(args.length == 2 && args[1].isInstanceOf(CArray.class)) {
+			if(args.length == 2 && args[1].isInstanceOf(CArray.TYPE)) {
 				vars = (CArray) args[1];
-			} else if(args.length == 2 && !(args[1].isInstanceOf(CArray.class))) {
+			} else if(args.length == 2 && !(args[1].isInstanceOf(CArray.TYPE))) {
 				throw new CRECastException("The second argument of expr() should be an array", t);
 			}
 			if(vars != null && !vars.inAssociativeMode()) {
@@ -2469,7 +2469,7 @@ public class Math {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CInt.class)) {
+			if(args[0].isInstanceOf(CInt.TYPE)) {
 				return new CInt(-(Static.getInt(args[0], t)), t);
 			} else {
 				return new CDouble(-(Static.getDouble(args[0], t)), t);

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -129,7 +129,7 @@ public class Meta {
 				throw new CREFormatException("The first character of the command must be a forward slash (i.e. '/give')", t);
 			}
 			String cmd = args[1].val().substring(1);
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray u = (CArray) args[0];
 				for(int i = 0; i < u.size(); i++) {
 					exec(t, env, new Mixed[]{new CString(u.get(i, t).val(), t), args[1]});
@@ -873,7 +873,7 @@ public class Meta {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			CString s;
-			if(args[0].isInstanceOf(CString.class)) {
+			if(args[0].isInstanceOf(CString.TYPE)) {
 				s = (CString) args[0];
 			} else {
 				s = new CString(args[0].val(), t);

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -99,7 +99,7 @@ public class Minecraft {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args[0].isInstanceOf(CInt.class)) {
+			if(args[0].isInstanceOf(CInt.TYPE)) {
 				return new CInt(Static.getInt(args[0], t), t);
 			}
 			String c = args[0].val();
@@ -214,7 +214,7 @@ public class Minecraft {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			int i = -1;
 			int i2 = -1;
-			if(args[0].isInstanceOf(CString.class)) {
+			if(args[0].isInstanceOf(CString.TYPE)) {
 				//We also accept item notation
 				if(args[0].val().contains(":")) {
 					String[] split = args[0].val().split(":");
@@ -226,7 +226,7 @@ public class Minecraft {
 						throw new CREFormatException("Incorrect format for the item notation: " + args[0].val(), t);
 					}
 				}
-			} else if(args[0].isInstanceOf(CArray.class)) {
+			} else if(args[0].isInstanceOf(CArray.TYPE)) {
 				MCItemStack is = ObjectGenerator.GetGenerator().item(args[0], t, true);
 				return new CString(is.getType().getName(), t);
 			}
@@ -345,7 +345,7 @@ public class Minecraft {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			Mixed id = args[0];
-			if(id.isInstanceOf(CArray.class)) {
+			if(id.isInstanceOf(CArray.TYPE)) {
 				MCItemStack is = ObjectGenerator.GetGenerator().item(id, t);
 				return new CInt(is.getType().getMaxStackSize(), t);
 			}
@@ -383,7 +383,7 @@ public class Minecraft {
 			if(children.size() < 1) {
 				return null;
 			}
-			if(children.get(0).getData().isInstanceOf(CString.class) && children.get(0).getData().val().contains(":")
+			if(children.get(0).getData().isInstanceOf(CString.TYPE) && children.get(0).getData().val().contains(":")
 					|| ArgumentValidation.isNumber(children.get(0).getData())) {
 				MSLog.GetLogger().w(MSLog.Tags.DEPRECATION, "Numeric ids are deprecated in max_stack_size()", t);
 			}
@@ -485,7 +485,7 @@ public class Minecraft {
 				return null;
 			}
 			Mixed effect = children.get(1).getData();
-			if(effect.isInstanceOf(CString.class)) {
+			if(effect.isInstanceOf(CString.TYPE)) {
 				String effectName = effect.val().split(":")[0].toUpperCase();
 				try {
 					MCEffect.valueOf(effectName);

--- a/src/main/java/com/laytonsmith/core/functions/MobManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/MobManagement.java
@@ -713,7 +713,7 @@ public class MobManagement {
 			MCLivingEntity mob = Static.getLivingEntity(args[0], t);
 
 			MCPotionEffectType type = null;
-			if(args[1].isInstanceOf(CString.class)) {
+			if(args[1].isInstanceOf(CString.TYPE)) {
 				try {
 					type = MCPotionEffectType.valueOf(args[1].val().toUpperCase());
 				} catch (IllegalArgumentException ex) {
@@ -897,7 +897,7 @@ public class MobManagement {
 			if(args[1] instanceof CNull) {
 				ee.clearEquipment();
 				return CVoid.VOID;
-			} else if(args[1].isInstanceOf(CArray.class)) {
+			} else if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray ea = (CArray) args[1];
 				for(String key : ea.stringKeySet()) {
 					try {
@@ -1048,7 +1048,7 @@ public class MobManagement {
 				for(Map.Entry<MCEquipmentSlot, Float> ent : eq.entrySet()) {
 					eq.put(ent.getKey(), 0F);
 				}
-			} else if(args[1].isInstanceOf(CArray.class)) {
+			} else if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray ea = (CArray) args[1];
 				for(String key : ea.stringKeySet()) {
 					try {

--- a/src/main/java/com/laytonsmith/core/functions/ObjectManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/ObjectManagement.java
@@ -172,7 +172,7 @@ public class ObjectManagement {
 			if(data.getData() instanceof CNull) {
 				return CNull.NULL;
 			}
-			if(!(data.getData().isInstanceOf(CString.class))) {
+			if(!(data.getData().isInstanceOf(CString.TYPE))) {
 				throw new CREClassDefinitionError("Expected a string, but found " + data.getData() + " instead", t);
 			}
 			return data.getData();

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -339,7 +339,7 @@ public class PlayerManagement {
 				Static.AssertPlayerNonNull(p, t);
 				loc = p.getLocation();
 			} else {
-				if(!(args[0].isInstanceOf(CArray.class))) {
+				if(!(args[0].isInstanceOf(CArray.TYPE))) {
 					throw new CRECastException("Expecting an array at parameter 1 of players_in_radius", t);
 				}
 
@@ -492,7 +492,7 @@ public class PlayerManagement {
 			MCPlayer p = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
 			MCLocation l;
 			if(args.length <= 2) {
-				if(!(args[args.length - 1].isInstanceOf(CArray.class))) {
+				if(!(args[args.length - 1].isInstanceOf(CArray.TYPE))) {
 					throw new CRECastException("Expecting an array at parameter " + args.length + " of set_ploc", t);
 				}
 				CArray ca = (CArray) args[args.length - 1];
@@ -588,14 +588,14 @@ public class PlayerManagement {
 			HashSet<MCMaterial> trans = null;
 			int transparentIndex = -1;
 			if(args.length == 1) {
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					transparentIndex = 0;
 				} else {
 					p = Static.GetPlayer(args[0], t);
 				}
 			} else if(args.length == 2) {
 				p = Static.GetPlayer(args[0], t);
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					transparentIndex = 1;
 				} else {
 					throw new CREFormatException("An array was expected for argument 2 but received " + args[1], t);
@@ -1395,7 +1395,7 @@ public class PlayerManagement {
 					}
 				} else {
 					//if it's a number, we are setting F. Otherwise, it's a getter for the MCPlayer specified.
-					if(!(args[0].isInstanceOf(CInt.class))) {
+					if(!(args[0].isInstanceOf(CInt.TYPE))) {
 						MCPlayer p2 = Static.GetPlayer(args[0], t);
 						l = p2.getLocation();
 					}
@@ -2180,7 +2180,7 @@ public class PlayerManagement {
 			MCPlayer m = Static.GetPlayer(args[0].val(), t);
 
 			MCPotionEffectType type = null;
-			if(args[1].isInstanceOf(CString.class)) {
+			if(args[1].isInstanceOf(CString.TYPE)) {
 				try {
 					type = MCPotionEffectType.valueOf(args[1].val().toUpperCase());
 				} catch (IllegalArgumentException ex) {
@@ -3314,7 +3314,7 @@ public class PlayerManagement {
 				ticks = args[0];
 			}
 			int tick = 0;
-			if(ticks.isInstanceOf(CBoolean.class)) {
+			if(ticks.isInstanceOf(CBoolean.TYPE)) {
 				boolean value = ((CBoolean) ticks).getBoolean();
 				if(value) {
 					tick = 20;
@@ -4513,7 +4513,7 @@ public class PlayerManagement {
 			boolean forced = true;
 
 			if(args.length == 1) {
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					if(p instanceof MCPlayer) {
 						m = ((MCPlayer) p);
 					}
@@ -4522,10 +4522,10 @@ public class PlayerManagement {
 					throw new CRECastException("Expecting an array in set_pbed_location", t);
 				}
 			} else if(args.length == 2) {
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					pname = args[0].val();
 					locationIndex = 1;
-				} else if(args[0].isInstanceOf(CArray.class)) {
+				} else if(args[0].isInstanceOf(CArray.TYPE)) {
 					if(p instanceof MCPlayer) {
 						m = ((MCPlayer) p);
 					}
@@ -4535,7 +4535,7 @@ public class PlayerManagement {
 					throw new CRECastException("Expecting an array in set_pbed_location", t);
 				}
 			} else if(args.length == 3) {
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					pname = args[0].val();
 					locationIndex = 1;
 					forced = ArgumentValidation.getBoolean(args[2], t);
@@ -4567,7 +4567,7 @@ public class PlayerManagement {
 			}
 			Static.AssertPlayerNonNull(m, t);
 
-			if(args[locationIndex].isInstanceOf(CArray.class)) {
+			if(args[locationIndex].isInstanceOf(CArray.TYPE)) {
 				CArray ca = (CArray) args[locationIndex];
 				l = ObjectGenerator.GetGenerator().location(ca, m.getWorld(), t);
 				l.add(0, 1, 0); // someone decided to match ploc() here

--- a/src/main/java/com/laytonsmith/core/functions/Regex.java
+++ b/src/main/java/com/laytonsmith/core/functions/Regex.java
@@ -613,7 +613,7 @@ public class Regex {
 		String regex = "";
 		int flags = 0;
 		String sflags = "";
-		if(c.isInstanceOf(CArray.class)) {
+		if(c.isInstanceOf(CArray.TYPE)) {
 			CArray ca = (CArray) c;
 			regex = ca.get(0, t).val();
 			sflags = ca.get(1, t).val();

--- a/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
+++ b/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
@@ -205,7 +205,7 @@ public class ResourceManager {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CResource.class)) {
+			if(args[0].isInstanceOf(CResource.TYPE)) {
 				CResource<?> resource = (CResource<?>) args[0];
 				if(RESOURCES.containsKey(resource.getId())) {
 					RESOURCES.remove(resource.getId());

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -150,7 +150,7 @@ public class SQL {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			try {
 				Profiles.Profile profile;
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					Map<String, String> data = new HashMap<>();
 					for(String key : ((CArray) args[0]).stringKeySet()) {
 						data.put(key, ((CArray) args[0]).get(key, t).val());
@@ -195,15 +195,15 @@ public class SQL {
 							continue;
 						}
 						try {
-							if(params[i].isInstanceOf(CInt.class)) {
+							if(params[i].isInstanceOf(CInt.TYPE)) {
 								ps.setLong(i + 1, Static.getInt(params[i], t));
-							} else if(params[i].isInstanceOf(CDouble.class)) {
+							} else if(params[i].isInstanceOf(CDouble.TYPE)) {
 								ps.setDouble(i + 1, (Double) Static.getDouble(params[i], t));
-							} else if(params[i].isInstanceOf(CString.class)) {
+							} else if(params[i].isInstanceOf(CString.TYPE)) {
 								ps.setString(i + 1, (String) params[i].val());
-							} else if(params[i].isInstanceOf(CByteArray.class)) {
+							} else if(params[i].isInstanceOf(CByteArray.TYPE)) {
 								ps.setBytes(i + 1, ((CByteArray) params[i]).asByteArrayCopy());
-							} else if(params[i].isInstanceOf(CBoolean.class)) {
+							} else if(params[i].isInstanceOf(CBoolean.TYPE)) {
 								ps.setBoolean(i + 1, ArgumentValidation.getBoolean(params[i], t));
 							} else {
 								throw new CRECastException("The type " + params[i].getClass().getSimpleName()
@@ -329,7 +329,7 @@ public class SQL {
 							+ " must use concatenation, and you promise you know what you're doing, you"
 							+ " can use " + new unsafe_query().getName() + "() to supress this warning.", t);
 				}
-			} else if(queryData.isInstanceOf(CString.class)) {
+			} else if(queryData.isInstanceOf(CString.TYPE)) {
 				//It's a hard coded query, so we can double check parameter lengths and other things
 				String query = queryData.val();
 				int count = 0;
@@ -350,7 +350,7 @@ public class SQL {
 				//Profile validation will simply ensure that the profile stated is listed in the profiles,
 				//and that a connection can in fact be made.
 				//Also need to figure out how to validate a prepared statement.
-//				if(children.get(0).isConst() && children.get(0).getData().isInstanceOf(CString.class)){
+//				if(children.get(0).isConst() && children.get(0).getData().isInstanceOf(CString.TYPE)){
 //					if(true){ //Prefs.verifyQueries()
 //						String profileName = children.get(0).getData().val();
 //						SQLProfiles.Profile profile = null;
@@ -481,7 +481,7 @@ public class SQL {
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			startup();
 			Mixed arg = args[args.length - 1];
-			if(!(arg.isInstanceOf(CClosure.class))) {
+			if(!(arg.isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("The last argument to " + getName() + " must be a closure.", t);
 			}
 			final CClosure closure = ((CClosure) arg);

--- a/src/main/java/com/laytonsmith/core/functions/Sandbox.java
+++ b/src/main/java/com/laytonsmith/core/functions/Sandbox.java
@@ -603,7 +603,7 @@ public class Sandbox {
 			}
 
 			byte[] content;
-			if(!(args[1].isInstanceOf(CByteArray.class))) {
+			if(!(args[1].isInstanceOf(CByteArray.TYPE))) {
 				content = args[1].val().getBytes(Charset.forName("UTF-8"));
 			} else {
 				content = ArgumentValidation.getByteArray(args[1], t).asByteArrayCopy();

--- a/src/main/java/com/laytonsmith/core/functions/Scheduling.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scheduling.java
@@ -275,7 +275,7 @@ public class Scheduling {
 				offset = 1;
 				delay = Static.getInt(args[1], t);
 			}
-			if(!(args[1 + offset].isInstanceOf(CClosure.class))) {
+			if(!(args[1 + offset].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException(getName() + " expects a closure to be sent as the second argument", t);
 			}
 			final CClosure c = (CClosure) args[1 + offset];
@@ -361,7 +361,7 @@ public class Scheduling {
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final TaskManager taskManager = environment.getEnv(GlobalEnv.class).GetTaskManager();
 			long time = Static.getInt(args[0], t);
-			if(!(args[1].isInstanceOf(CClosure.class))) {
+			if(!(args[1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException(getName() + " expects a closure to be sent as the second argument", t);
 			}
 			final CClosure c = (CClosure) args[1];
@@ -795,10 +795,10 @@ public class Scheduling {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			//First things first, check the format of the arguments.
-			if(!(args[0].isInstanceOf(CString.class))) {
+			if(!(args[0].isInstanceOf(CString.TYPE))) {
 				throw new CRECastException("Expected string for argument 1 in " + getName(), t);
 			}
-			if(!(args[1].isInstanceOf(CClosure.class))) {
+			if(!(args[1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Expected closure for argument 2 in " + getName(), t);
 			}
 			CronFormat format = validateFormat(args[0].val(), t);
@@ -1117,7 +1117,7 @@ public class Scheduling {
 				List<ParseTree> children, FileOptions fileOptions)
 				throws ConfigCompileException, ConfigRuntimeException {
 			if(children.get(0).isConst()) {
-				if(children.get(0).getData().isInstanceOf(CString.class)) {
+				if(children.get(0).getData().isInstanceOf(CString.TYPE)) {
 					validateFormat(children.get(0).getData().val(), t);
 				}
 			}

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -629,7 +629,7 @@ public class Scoreboards {
 				throw new CREScoreboardException("No objective by that name exists.", t);
 			}
 			CArray dis = CArray.GetAssociativeArray(t);
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				dis = (CArray) args[1];
 			} else {
 				dis.set("displayname", args[1], t);
@@ -709,7 +709,7 @@ public class Scoreboards {
 				throw new CREScoreboardException("No team by that name exists.", t);
 			}
 			CArray dis = CArray.GetAssociativeArray(t);
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				dis = (CArray) args[1];
 			} else {
 				dis.set("displayname", args[1], t);
@@ -1184,7 +1184,7 @@ public class Scoreboards {
 			if(team == null) {
 				throw new CREScoreboardException("No team by that name exists.", t);
 			}
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				CArray options = (CArray) args[1];
 				if(options.containsKey("friendlyfire")) {
 					team.setAllowFriendlyFire(ArgumentValidation.getBoolean(options.get("friendlyfire", t), t));

--- a/src/main/java/com/laytonsmith/core/functions/Statistics.java
+++ b/src/main/java/com/laytonsmith/core/functions/Statistics.java
@@ -69,7 +69,7 @@ public class Statistics {
 		@Override
 		public CNumber exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			long count;
-			if(args.length == 1 && args[0].isInstanceOf(CArray.class)) {
+			if(args.length == 1 && args[0].isInstanceOf(CArray.TYPE)) {
 				CArray c = ArgumentValidation.getArray(args[0], t);
 				count = c.size();
 			} else {
@@ -119,7 +119,7 @@ public class Statistics {
 		@Override
 		public CNumber exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			List<Double> values = new ArrayList<>();
-			if(args.length == 1 && args[0].isInstanceOf(CArray.class)) {
+			if(args.length == 1 && args[0].isInstanceOf(CArray.TYPE)) {
 				CArray c = ArgumentValidation.getArray(args[0], t);
 				for(Mixed m : c.asList()) {
 					values.add(ArgumentValidation.getDouble(m, t));
@@ -175,7 +175,7 @@ public class Statistics {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			List<Double> values = new ArrayList<>();
-			if(args.length == 1 && args[0].isInstanceOf(CArray.class)) {
+			if(args.length == 1 && args[0].isInstanceOf(CArray.TYPE)) {
 				CArray c = ArgumentValidation.getArray(args[0], t);
 				for(Mixed m : c.asList()) {
 					values.add(ArgumentValidation.getDouble(m, t));
@@ -239,7 +239,7 @@ public class Statistics {
 		@Override
 		public CArray exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			List<Double> values = new ArrayList<>();
-			if(args.length == 1 && args[0].isInstanceOf(CArray.class)) {
+			if(args.length == 1 && args[0].isInstanceOf(CArray.TYPE)) {
 				CArray c = ArgumentValidation.getArray(args[0], t);
 				for(Mixed m : c.asList()) {
 					values.add(ArgumentValidation.getDouble(m, t));
@@ -339,7 +339,7 @@ public class Statistics {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			double percentile = ArgumentValidation.getDouble(args[0], t);
 			List<Double> values = new ArrayList<>();
-			if(args.length == 2 && args[1].isInstanceOf(CArray.class)) {
+			if(args.length == 2 && args[1].isInstanceOf(CArray.TYPE)) {
 				CArray c = ArgumentValidation.getArray(args[1], t);
 				for(Mixed m : c.asList()) {
 					values.add(ArgumentValidation.getNumber(m, t));

--- a/src/main/java/com/laytonsmith/core/functions/StringHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/StringHandling.java
@@ -643,7 +643,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(args[0].isInstanceOf(Sizeable.class)) {
+			if(args[0].isInstanceOf(Sizeable.TYPE)) {
 				return new CInt(((Sizeable) args[0]).size(), t);
 			} else {
 				return new CInt(args[0].val().length(), t);
@@ -705,7 +705,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CString.class))) {
+			if(!(args[0].isInstanceOf(CString.TYPE))) {
 				throw new CREFormatException(this.getName() + " expects a string as first argument, but type "
 						+ args[0].typeof() + " was found.", t);
 			}
@@ -768,7 +768,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
-			if(!(args[0].isInstanceOf(CString.class))) {
+			if(!(args[0].isInstanceOf(CString.TYPE))) {
 				throw new CREFormatException(this.getName() + " expects a string as first argument, but type "
 						+ args[0].typeof() + " was found.", t);
 			}
@@ -1410,7 +1410,7 @@ public class StringHandling {
 			}
 
 			List<Mixed> flattenedArgs = new ArrayList<>();
-			if(numArgs == 3 && args[2].isInstanceOf(CArray.class)) {
+			if(numArgs == 3 && args[2].isInstanceOf(CArray.TYPE)) {
 				if(((CArray) args[2]).inAssociativeMode()) {
 					throw new CRECastException("If the second argument to " + getName() + " is an array, it may not be associative.", t);
 				} else {
@@ -2417,7 +2417,7 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray array = Static.getArray(args[0], t);
 				return new CSecureString(array, t);
 			} else {
@@ -2495,10 +2495,10 @@ public class StringHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			if(args[0].isInstanceOf(CSecureString.class)) {
+			if(args[0].isInstanceOf(CSecureString.TYPE)) {
 				CSecureString secure = ArgumentValidation.getObject(args[0], t, CSecureString.class);
 				return secure.getDecryptedCharCArray();
-			} else if(args[0].isInstanceOf(CString.class)) {
+			} else if(args[0].isInstanceOf(CString.TYPE)) {
 				CArray array = new CArray(Target.UNKNOWN, args[0].val().length());
 				for(char c : args[0].val().toCharArray()) {
 					array.push(new CString(c, t), t);

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -72,7 +72,7 @@ public class Threading {
 		@Override
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String id = args[0].val();
-			if(!(args[1].isInstanceOf(CClosure.class))) {
+			if(!(args[1].isInstanceOf(CClosure.TYPE))) {
 				throw new CRECastException("Expected closure for arg 2", t);
 			}
 			final CClosure closure = (CClosure) args[1];
@@ -377,7 +377,7 @@ public class Threading {
 				throw new CRENullPointerException("Synchronization object may not be null in " + getName() + "().", t);
 			}
 			Object syncObject;
-			if(cSyncObject.isInstanceOf(CArray.class)) {
+			if(cSyncObject.isInstanceOf(CArray.TYPE)) {
 				syncObject = cSyncObject;
 			} else {
 				syncObject = cSyncObject.val();

--- a/src/main/java/com/laytonsmith/core/functions/Weather.java
+++ b/src/main/java/com/laytonsmith/core/functions/Weather.java
@@ -67,7 +67,7 @@ public class Weather {
 			MCWorld w = null;
 			boolean safe = false;
 			int safeIndex = 1;
-			if(args[0].isInstanceOf(CArray.class)) {
+			if(args[0].isInstanceOf(CArray.TYPE)) {
 				CArray a = (CArray) args[0];
 				MCPlayer p = env.getEnv(CommandHelperEnvironment.class).GetPlayer();
 				MCLocation l = ObjectGenerator.GetGenerator().location(a, p == null ? null : p.getWorld(), t);
@@ -141,9 +141,9 @@ public class Weather {
 			MCWorld w = null;
 			int duration = -1;
 			if(args.length == 2) {
-				if(args[1].isInstanceOf(CString.class)) {
+				if(args[1].isInstanceOf(CString.TYPE)) {
 					w = Static.getServer().getWorld(args[1].val());
-				} else if(args[1].isInstanceOf(CInt.class)) {
+				} else if(args[1].isInstanceOf(CInt.TYPE)) {
 					duration = Static.getInt32(args[1], t);
 				} else {
 					throw new CREFormatException("", t);

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -231,7 +231,7 @@ public class Web {
 			final boolean binary;
 			final String textEncoding;
 			boolean useDefaultHeaders = true;
-			if(args[1].isInstanceOf(CClosure.class)) {
+			if(args[1].isInstanceOf(CClosure.TYPE)) {
 				success = (CClosure) args[1];
 				error = null;
 				arrayJar = null;
@@ -260,7 +260,7 @@ public class Web {
 					for(String key : headers.stringKeySet()) {
 						List<String> h = new ArrayList<String>();
 						Mixed c = headers.get(key, t);
-						if(c.isInstanceOf(CArray.class)) {
+						if(c.isInstanceOf(CArray.TYPE)) {
 							for(String kkey : ((CArray) c).stringKeySet()) {
 								h.add(((CArray) c).get(kkey, t).val());
 							}
@@ -287,13 +287,13 @@ public class Web {
 					}
 				}
 				if(csettings.containsKey("params") && !(csettings.get("params", t) instanceof CNull)) {
-					if(csettings.get("params", t).isInstanceOf(CArray.class)) {
+					if(csettings.get("params", t).isInstanceOf(CArray.TYPE)) {
 						CArray params = Static.getArray(csettings.get("params", t), t);
 						Map<String, List<String>> mparams = new HashMap<>();
 						for(String key : params.stringKeySet()) {
 							Mixed c = params.get(key, t);
 							List<String> l = new ArrayList<>();
-							if(c.isInstanceOf(CArray.class)) {
+							if(c.isInstanceOf(CArray.TYPE)) {
 								for(String kkey : ((CArray) c).stringKeySet()) {
 									l.add(((ArrayAccess) c).get(kkey, t).val());
 								}
@@ -304,7 +304,7 @@ public class Web {
 						}
 						settings.setComplexParameters(mparams);
 					} else {
-						if(csettings.get("params", t).isInstanceOf(CByteArray.class)) {
+						if(csettings.get("params", t).isInstanceOf(CByteArray.TYPE)) {
 							CByteArray b = (CByteArray) csettings.get("params", t);
 							settings.setRawParameter(b.asByteArrayCopy());
 						} else {
@@ -327,7 +327,7 @@ public class Web {
 				}
 				//Only required parameter
 				if(csettings.containsKey("success")) {
-					if(csettings.get("success", t).isInstanceOf(CClosure.class)) {
+					if(csettings.get("success", t).isInstanceOf(CClosure.TYPE)) {
 						success = (CClosure) csettings.get("success", t);
 					} else {
 						throw new CRECastException("Expecting the success parameter to be a closure.", t);
@@ -336,7 +336,7 @@ public class Web {
 					throw new CRECastException("Missing the success parameter, which is required.", t);
 				}
 				if(csettings.containsKey("error")) {
-					if(csettings.get("error", t).isInstanceOf(CClosure.class)) {
+					if(csettings.get("error", t).isInstanceOf(CClosure.TYPE)) {
 						error = (CClosure) csettings.get("error", t);
 					} else {
 						throw new CRECastException("Expecting the error parameter to be a closure.", t);
@@ -373,9 +373,9 @@ public class Web {
 				}
 				if(csettings.containsKey("trustStore")) {
 					Mixed trustStore = csettings.get("trustStore", t);
-					if(trustStore.isInstanceOf(CBoolean.class) && ArgumentValidation.getBoolean(trustStore, t) == false) {
+					if(trustStore.isInstanceOf(CBoolean.TYPE) && ArgumentValidation.getBoolean(trustStore, t) == false) {
 						settings.setDisableCertChecking(true);
-					} else if(trustStore.isInstanceOf(CArray.class)) {
+					} else if(trustStore.isInstanceOf(CArray.TYPE)) {
 						CArray trustStoreA = ((CArray) trustStore);
 						LinkedHashMap<String, String> trustStoreJ = new LinkedHashMap<>((int) trustStoreA.size());
 						final String noDefault = "no default";
@@ -843,7 +843,7 @@ public class Web {
 			String body = ArgumentValidation.getItemFromArray(options, "body", t, new CString("", t)).val();
 			Mixed cto = ArgumentValidation.getItemFromArray(options, "to", t, null);
 			CArray to;
-			if(cto.isInstanceOf(CString.class)) {
+			if(cto.isInstanceOf(CString.TYPE)) {
 				to = new CArray(t);
 				to.push(cto, t);
 			} else {
@@ -899,7 +899,7 @@ public class Web {
 				for(Mixed c : to.asList()) {
 					Message.RecipientType type = Message.RecipientType.TO;
 					String address;
-					if(c.isInstanceOf(CArray.class)) {
+					if(c.isInstanceOf(CArray.TYPE)) {
 						CArray ca = (CArray) c;
 						String stype = ArgumentValidation.getItemFromArray(ca, "type", t, new CString("TO", t)).val();
 						switch(stype) {
@@ -1029,9 +1029,9 @@ public class Web {
 		 * @return
 		 */
 		private Object getContent(Mixed c, Target t) {
-			if(c.isInstanceOf(CString.class)) {
+			if(c.isInstanceOf(CString.TYPE)) {
 				return c.val();
-			} else if(c.isInstanceOf(CByteArray.class)) {
+			} else if(c.isInstanceOf(CByteArray.TYPE)) {
 				CByteArray cb = (CByteArray) c;
 				return cb.asByteArrayCopy();
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -257,7 +257,7 @@ public class World {
 				z = l.getBlockZ();
 			} else if(args.length == 2) {
 				//Either location array and world provided, or x and z. Test for array at pos 2
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					world = Static.getServer().getWorld(args[0].val());
 					MCLocation l = ObjectGenerator.GetGenerator().location(args[1], null, t);
 					x = l.getBlockX();
@@ -316,7 +316,7 @@ public class World {
 				z = l.getBlockZ();
 			} else if(args.length == 2) {
 				//Either location array and world provided, or x and z. Test for array at pos 2
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					world = Static.getServer().getWorld(args[0].val());
 					if(world == null) {
 						throw new CREInvalidWorldException("The given world (" + args[0].val() + ") does not exist.", t);
@@ -399,7 +399,7 @@ public class World {
 				z = l.getBlockZ();
 			} else if(args.length == 2) {
 				//Either location array and world provided, or x and z. Test for array at pos 2
-				if(args[1].isInstanceOf(CArray.class)) {
+				if(args[1].isInstanceOf(CArray.TYPE)) {
 					world = Static.getServer().getWorld(args[0].val());
 					MCLocation l = ObjectGenerator.GetGenerator().location(args[1], null, t);
 					x = l.getBlockX();
@@ -579,7 +579,7 @@ public class World {
 				z = l.getBlockZ() >> 4;
 			} else if(args.length == 2) {
 				//Either location array and world provided, or x and z. Test for array at pos 1
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					world = Static.getServer().getWorld(args[1].val());
 					if(world == null) {
 						throw new CREInvalidWorldException("World " + args[1].val() + " does not exist.", t);
@@ -670,7 +670,7 @@ public class World {
 				z = l.getBlockZ() >> 4;
 			} else if(args.length == 2) {
 				//Either location array and world provided, or x and z. Test for array at pos 1
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					world = Static.getServer().getWorld(args[1].val());
 					if(world == null) {
 						throw new CREInvalidWorldException("The given world (" + args[1].val() + ") does not exist.", t);
@@ -918,7 +918,7 @@ public class World {
 				creator.type(type).environment(environment);
 			}
 			if((args.length >= 4) && !(args[3] instanceof CNull)) {
-				if(args[3].isInstanceOf(CInt.class)) {
+				if(args[3].isInstanceOf(CInt.TYPE)) {
 					creator.seed(Static.getInt(args[3], t));
 				} else {
 					creator.seed(args[3].val().hashCode());
@@ -1038,7 +1038,7 @@ public class World {
 			}
 
 			if(args.length == 1) {
-				if(args[0].isInstanceOf(CArray.class)) {
+				if(args[0].isInstanceOf(CArray.TYPE)) {
 					l = ObjectGenerator.GetGenerator().location(args[0], w, t);
 				} else {
 					throw new CREFormatException("Expecting argument 1 of get_chunk_loc to be a location array", t);
@@ -1732,7 +1732,7 @@ public class World {
 				distance = Static.getNumber(args[2], t);
 			}
 			Vector3D vector;
-			if(args[1].isInstanceOf(CArray.class)) {
+			if(args[1].isInstanceOf(CArray.TYPE)) {
 				MCLocation to = ObjectGenerator.GetGenerator().location(args[1], loc.getWorld(), t);
 				vector = to.toVector().subtract(loc.toVector()).normalize();
 			} else {
@@ -2170,7 +2170,7 @@ public class World {
 			}
 			MCWorldBorder wb = w.getWorldBorder();
 			Mixed c = args[1];
-			if(!(c.isInstanceOf(CArray.class))) {
+			if(!(c.isInstanceOf(CArray.TYPE))) {
 				throw new CREFormatException("Expected array but given \"" + args[1].val() + "\"", t);
 			}
 			CArray params = (CArray) c;

--- a/src/main/java/com/laytonsmith/core/functions/bash/BashPlatformResolver.java
+++ b/src/main/java/com/laytonsmith/core/functions/bash/BashPlatformResolver.java
@@ -13,9 +13,9 @@ public class BashPlatformResolver implements PlatformResolver {
 
 	@Override
 	public String outputConstant(Mixed c) {
-		if(c.isInstanceOf(CString.class)) {
+		if(c.isInstanceOf(CString.TYPE)) {
 			return "\"" + c.val() + "\"";
-		} else if(c.isInstanceOf(CArray.class)) {
+		} else if(c.isInstanceOf(CArray.TYPE)) {
 			throw new RuntimeException("Not implemented yet");
 		} else {
 			return c.val();

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/AbstractMixedInterfaceRunner.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/AbstractMixedInterfaceRunner.java
@@ -120,7 +120,7 @@ public abstract class AbstractMixedInterfaceRunner implements MixedInterfaceRunn
 	}
 
 	@Override
-	public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+	public boolean isInstanceOf(CClassType type) {
 		return Construct.isInstanceof(this, type);
 	}
 

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/MEnumType.java
@@ -138,7 +138,7 @@ public abstract class MEnumType implements Mixed, com.laytonsmith.core.natives.i
 			}
 
 			@Override
-			public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+			public boolean isInstanceOf(CClassType type) {
 				return Mixed.TYPE.equals(type) || MEnumType.TYPE.equals(type) || this.typeof().equals(type);
 			}
 
@@ -256,7 +256,7 @@ public abstract class MEnumType implements Mixed, com.laytonsmith.core.natives.i
 							}
 
 							@Override
-							public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+							public boolean isInstanceOf(CClassType type) {
 								return Construct.isInstanceof(this, type);
 							}
 
@@ -425,7 +425,7 @@ public abstract class MEnumType implements Mixed, com.laytonsmith.core.natives.i
 	}
 
 	@Override
-	public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+	public boolean isInstanceOf(CClassType type) {
 		return TYPE.equals(type);
 	}
 

--- a/src/main/java/com/laytonsmith/core/natives/interfaces/Mixed.java
+++ b/src/main/java/com/laytonsmith/core/natives/interfaces/Mixed.java
@@ -116,9 +116,8 @@ public interface Mixed extends Cloneable, Documentation {
 	 *
 	 * @param type
 	 * @return
-	 * @throws ClassNotFoundException If the CClassType does not reflect a known type
 	 */
-	public boolean isInstanceOf(CClassType type) throws ClassNotFoundException;
+	public boolean isInstanceOf(CClassType type);
 
 	/**
 	 * Generally speaking, we cannot use Java's instanceof keyword to determine if something is an instanceof, because

--- a/src/main/java/com/laytonsmith/core/objects/UserObject.java
+++ b/src/main/java/com/laytonsmith/core/objects/UserObject.java
@@ -150,7 +150,7 @@ public class UserObject implements Mixed {
 	}
 
 	@Override
-	public boolean isInstanceOf(CClassType type) throws ClassNotFoundException {
+	public boolean isInstanceOf(CClassType type) {
 		return Construct.isInstanceof(this, type);
 	}
 


### PR DESCRIPTION
This avoids getting the FullyQualifiedClassName from the annotation again for known types. This is only one of around 4 or more calls to getAnnotation() when running isInstanceOf(Class). And yet, in one comparison with a large test script it reduced total operation time by ~9%. This is the most straight forward of improvements with my limited knowledge of how all this works, so I started with it.

Aside from .class to .TYPE diffs:

- I removed the checked ClassNotFoundException. As far as I can tell, this is never thrown. Maybe this was planned to be thrown later, but as it is it's not added to the other method that does the same work and more.

- There's a couple places I changed CVoid and CNull checks to be regular Java instanceof. It's the same result and avoids work.