### PR TITLE
Avoid unnecessary hashing when getting list of types

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CClassType.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClassType.java
@@ -17,6 +17,7 @@ import com.laytonsmith.core.objects.ObjectDefinitionNotFoundException;
 import com.laytonsmith.core.objects.ObjectDefinitionTable;
 import com.laytonsmith.core.objects.UserObject;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -455,7 +456,7 @@ public final class CClassType extends Construct implements com.laytonsmith.core.
 	 * @return
 	 */
 	protected Set<CClassType> getTypes() {
-		Set<CClassType> t = new HashSet<>();
+		Set<CClassType> t = new TreeSet<>(Comparator.comparing(CClassType::getFQCN));
 		for(FullyQualifiedClassName type : types) {
 			try {
 				t.add(CClassType.get(type));


### PR DESCRIPTION
ArrayList is much faster here, since we generally want to loop through this list anyway. It also maintains the SortedSet order, if that's useful. It seems intentional to use SortedSet there, though I'm not sure why type unions need an order.

I mentioned this yesterday, but I'm not sure you caught it, since you were focused on caching. I just did some testing today and it looks good. I saw 10-19% reductions in total operation times. (~13% avg)

(BTW, I did 5 runs per build, and the runs are around 30 seconds. It loops through a compilation of various operations I've measured over the years, though I've removed IO to reduce variation. It doesn't count compilation time.)