### PR TITLE
Support executing closures in variables using function syntax.

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -1824,8 +1824,8 @@ public final class MethodScriptCompiler {
 			//Don't care about these
 			return;
 		}
-		if(tree.getData().val().startsWith("_")) {
-			//It's a proc. We need to recurse, but not check this "function"
+		if(!((CFunction) tree.getData()).hasFunction()) {
+			//We need to recurse, but this is not expected to be a function
 			for(ParseTree child : tree.getChildren()) {
 				checkBreaks0(child, currentLoops, lastUnbreakable, compilerErrors);
 			}
@@ -2094,7 +2094,7 @@ public final class MethodScriptCompiler {
 		// Walk the children
 		for(ParseTree child : tree.getChildren()) {
 			if(child.getData() instanceof CFunction) {
-				if(child.getData().val().charAt(0) != '_' || child.getData().val().charAt(1) == '_') {
+				if(((CFunction) child.getData()).hasFunction()) {
 					// This will throw an exception if the function doesn't exist.
 					try {
 						FunctionList.getFunction((CFunction) child.getData(), envs);
@@ -2430,7 +2430,7 @@ public final class MethodScriptCompiler {
 		//For the time being, we will simply say that if a function uses execs, it
 		//is a branch (branches always use execs, though using execs doesn't strictly
 		//mean you are a branch type function).
-		if(tree.getData() instanceof CFunction) {
+		if(tree.getData() instanceof CFunction && ((CFunction) tree.getData()).hasFunction()) {
 			Function f;
 			try {
 				f = (Function) FunctionList.getFunction(((CFunction) tree.getData()), envs);
@@ -2471,6 +2471,9 @@ public final class MethodScriptCompiler {
 				}
 				ParseTree child = children.get(m);
 				if(child.getData() instanceof CFunction) {
+					if(!((CFunction) child.getData()).hasFunction()) {
+						continue;
+					}
 					Function c;
 					try {
 						c = (Function) FunctionList.getFunction(((CFunction) child.getData()), envs);

--- a/src/main/java/com/laytonsmith/core/constructs/CFunction.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CFunction.java
@@ -38,6 +38,33 @@ public class CFunction extends Construct {
 	}
 
 	/**
+	 * Returns true if this CFunction is expected to represent a procedure based on the format.
+	 *
+	 * @return
+	 */
+	public boolean hasProcedure() {
+		return val().charAt(0) == '_' && val().charAt(1) != '_';
+	}
+
+	/**
+	 * Returns true if this CFunction is expected to represent an IVariable based on the format.
+	 *
+	 * @return
+	 */
+	public boolean hasIVariable() {
+		return val().charAt(0) == '@';
+	}
+
+	/**
+	 * Returns true if this CFunction is expected to represent a function based on the format.
+	 *
+	 * @return
+	 */
+	public boolean hasFunction() {
+		return !hasProcedure() && !hasIVariable();
+	}
+
+	/**
 	 * Returns the underlying function for this construct.
 	 *
 	 * @return

--- a/src/main/java/com/laytonsmith/tools/langserv/LangServ.java
+++ b/src/main/java/com/laytonsmith/tools/langserv/LangServ.java
@@ -845,7 +845,7 @@ public class LangServ implements LanguageServer, LanguageClientAware, TextDocume
 			}
 			List<DocumentLink> links = new ArrayList<>();
 			tree.getAllNodes().forEach(node -> {
-				if(node.getData() instanceof CFunction) {
+				if(node.getData() instanceof CFunction && ((CFunction) (node.getData())).hasFunction()) {
 					try {
 						Function f = ((CFunction) (node.getData())).getFunction();
 						if(f instanceof DocumentLinkProvider) {

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -104,6 +104,12 @@ public class OptimizationTest {
 	}
 
 	@Test
+	public void testClosure() throws Exception {
+		assertEquals("sconcat(assign(@c,closure(@target,msg(concat('Hello ',@target,'!')))),@c('world'))",
+				optimize("@c = closure(@target) {msg('Hello '.@target.'!')}; @c('world');"));
+	}
+
+	@Test
 	public void testUnreachableCode() throws Exception {
 		assertEquals("if(dyn(0),sconcat(die()),sconcat(msg('2'),msg('3')))",
 				optimize("if(dyn(0)){ die() msg('1') } else { msg('2') msg('3') }"));

--- a/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
@@ -296,6 +296,26 @@ public class DataHandlingTest {
 		verify(fakePlayer2).sendMessage("newlabel");
 	}
 
+	@Test(timeout = 10000)
+	public void testClosure11() throws Exception {
+		SRun("@c = closure(@msg){msg(@msg)};\n"
+				+ "@c('Hello World');", fakePlayer);
+		verify(fakePlayer).sendMessage("Hello World");
+	}
+
+	@Test(timeout = 10000)
+	public void testClosure12() throws Exception {
+		SRun("@c = closure(@msg = 'Hello World'){msg(@msg)};\n"
+				+ "@c();", fakePlayer);
+		verify(fakePlayer).sendMessage("Hello World");
+	}
+
+	@Test(timeout = 10000, expected = CRECastException.class)
+	public void testClosure13() throws Exception {
+		SRun("@s = 'string';\n"
+				+ "@s();", fakePlayer);
+	}
+
 	@Test
 	public void testToRadix() throws Exception {
 		assertEquals("f", SRun("to_radix(15, 16)", null));

--- a/src/test/java/com/laytonsmith/testing/RandomTests.java
+++ b/src/test/java/com/laytonsmith/testing/RandomTests.java
@@ -196,7 +196,7 @@ public class RandomTests {
 		CArray c1 = C.Array(C.Void(), C.Void()).clone();
 		CBoolean c2 = C.Boolean(true).clone();
 		CDouble c4 = C.Double(1).clone();
-		CFunction c5 = new CFunction("", Target.UNKNOWN).clone();
+		CFunction c5 = new CFunction("__", Target.UNKNOWN).clone();
 		CInt c6 = C.Int(1).clone();
 		CNull c7 = C.Null().clone();
 		CString c8 = C.String("").clone();


### PR DESCRIPTION
This is an early implementation that makes `@closure(@arg1, @arg2)` equivalent to `execute(@arg1, @arg2, @closure)`. Also fixes LangServ incorrectly checking procedures as functions.

While this is obviously not how you eventually plan to add this, this does add initial support for this concept and makes proc checking more clear. This minimal modification implementation should be just as easily updated with whatever you have planned.

This obviously doesn't support `@array['closure'](@arg1, @arg2)`, which will require more work.