### PR TITLE
Check only native types in Construct for isInstanceOf().

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/Construct.java
+++ b/src/main/java/com/laytonsmith/core/constructs/Construct.java
@@ -593,12 +593,15 @@ public abstract class Construct implements Cloneable, Comparable<Construct>, Mix
 
 	@Override
 	public boolean isInstanceOf(CClassType type) {
+		if(type.getNativeType() != null) {
+			return type.getNativeType().isAssignableFrom(this.getClass());
+		}
 		return isInstanceof(this, type);
 	}
 
 	@Override
 	public boolean isInstanceOf(Class<? extends Mixed> type) {
-		return isInstanceof(this, type);
+		return type.isAssignableFrom(this.getClass());
 	}
 
 	/**


### PR DESCRIPTION
This is optimal in cases we can expect it to not be a UserObject. This results in 16-28% reduction in overall operation time in my random scripts I use for profiling, but it depends on the assumption that I understand how UserObject is used here. UserObject will still use the old methodology, thus should still work if extending a native class, I assume.