### PR TITLE
Add affectedBlocks to piston_retract event

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
@@ -93,6 +93,24 @@ public class BukkitBlockEvents {
 		}
 
 		@Override
+		public List<MCBlock> getAffectedBlocks() {
+			List<Block> bukkitBlocks;
+			if(event instanceof BlockPistonExtendEvent) {
+				bukkitBlocks = ((BlockPistonExtendEvent) event).getBlocks();
+			} else if(event instanceof BlockPistonRetractEvent) {
+				bukkitBlocks = ((BlockPistonRetractEvent) event).getBlocks();
+			} else {
+				throw new Error("Unsupported piston event: " + event.getClass().getName());
+			}
+
+			List<MCBlock> blocks = new ArrayList<>(bukkitBlocks.size());
+			for(Block b : bukkitBlocks) {
+				blocks.add(new BukkitMCBlock(b));
+			}
+			return blocks;
+		}
+
+		@Override
 		public boolean isCancelled() {
 			return event.isCancelled();
 		}
@@ -112,17 +130,6 @@ public class BukkitBlockEvents {
 			super(e);
 
 			event = e;
-		}
-
-		@Override
-		public List<MCBlock> getPushedBlocks() {
-			List<MCBlock> blocks = new ArrayList<>();
-
-			for(Block b : event.getBlocks()) {
-				blocks.add(new BukkitMCBlock(b));
-			}
-
-			return blocks;
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonEvent.java
@@ -1,10 +1,23 @@
 package com.laytonsmith.abstraction.events;
 
+import java.util.List;
+
+import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCBlockFace;
 
 public interface MCBlockPistonEvent extends MCBlockEvent {
 
+	/**
+	 * Get the direction in which the pushed or pulled blocks are moved.
+	 * @return The direction.
+	 */
 	MCBlockFace getDirection();
+
+	/**
+	 * Get all blocks that will be moved by the extending or retracting piston.
+	 * @return A {@link List} containing all pushed or pulled blocks.
+	 */
+	List<MCBlock> getAffectedBlocks();
 
 	boolean isSticky();
 

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonExtendEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonExtendEvent.java
@@ -1,9 +1,4 @@
 package com.laytonsmith.abstraction.events;
 
-import com.laytonsmith.abstraction.blocks.MCBlock;
-import java.util.List;
-
 public interface MCBlockPistonExtendEvent extends MCBlockPistonEvent {
-
-	List<MCBlock> getPushedBlocks();
 }

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonRetractEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockPistonRetractEvent.java
@@ -4,5 +4,11 @@ import com.laytonsmith.abstraction.MCLocation;
 
 public interface MCBlockPistonRetractEvent extends MCBlockPistonEvent {
 
+	/**
+	 * Get the location of the block that is being pulled by the retracting piston.
+	 * @return The location.
+	 * @deprecated Use {@link #getPulledBlocks()} to obtain all pulled blocks instead.
+	 */
+	@Deprecated
 	MCLocation getRetractedLocation();
 }


### PR DESCRIPTION
Add affectedBlocks key to the piston_retract event. This is used when slime or honey blocks are pulled, pulling adjacent blocks with them.

Compatibility:
 - Used Bukkit method was added in 2015.
 - Deprecated `retractedLocation` key in `piston_retract` is maintained.