### PR TITLE
Fix NPE in entity_spec for Enderman

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEnderman.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/entities/BukkitMCEnderman.java
@@ -18,7 +18,8 @@ public class BukkitMCEnderman extends BukkitMCLivingEntity implements MCEnderman
 
 	@Override
 	public MCBlockData getCarriedMaterial() {
-		return new BukkitMCBlockData(e.getCarriedBlock());
+		BlockData data = e.getCarriedBlock();
+		return (data == null ? null : new BukkitMCBlockData(data));
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/entities/MCEnderman.java
+++ b/src/main/java/com/laytonsmith/abstraction/entities/MCEnderman.java
@@ -5,6 +5,10 @@ import com.laytonsmith.abstraction.blocks.MCBlockData;
 
 public interface MCEnderman extends MCLivingEntity {
 
+	/**
+	 * Gets the data of the block that the Enderman is carrying.
+	 * @return {@link MCBlockData} containing the carried block, or {@code null} if none.
+	 */
 	MCBlockData getCarriedMaterial();
 
 	void setCarriedMaterial(MCBlockData held);

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -1839,7 +1839,8 @@ public class EntityManagement {
 				case ENDERMAN:
 					MCEnderman enderman = (MCEnderman) entity;
 					MCBlockData carried = enderman.getCarriedMaterial();
-					specArray.set(entity_spec.KEY_ENDERMAN_CARRIED, new CString(carried.getMaterial().getName(), t), t);
+					specArray.set(entity_spec.KEY_ENDERMAN_CARRIED,
+							(carried == null ? CNull.NULL : new CString(carried.getMaterial().getName(), t)), t);
 					break;
 				case EVOKER_FANGS:
 					MCEvokerFangs fangs = (MCEvokerFangs) entity;


### PR DESCRIPTION
Fix calling entity_spec on an Enderman that is not carrying a block resulting in a NullPointerException.