### PR TITLE
fix: Fix bug #1180 misspelled class name

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/ObjectManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/ObjectManagement.java
@@ -34,7 +34,7 @@ import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.natives.interfaces.MAnnotation;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.objects.AccessModifier;
-import com.laytonsmith.core.objects.DuplicateObjectDefintionException;
+import com.laytonsmith.core.objects.DuplicateObjectDefinitionException;
 import com.laytonsmith.core.objects.ElementDefinition;
 import com.laytonsmith.core.objects.ObjectDefinition;
 import com.laytonsmith.core.objects.ObjectDefinitionNotFoundException;
@@ -334,7 +334,7 @@ public class ObjectManagement {
 			ObjectDefinitionTable odt = env.getEnv(CompilerEnvironment.class).getObjectDefinitionTable();
 			try {
 				odt.add(def, t);
-			} catch (DuplicateObjectDefintionException ex) {
+			} catch (DuplicateObjectDefinitionException ex) {
 				throw new CREClassDefinitionError("Class " + name + " already defined, cannot redefine!", t);
 			}
 

--- a/src/main/java/com/laytonsmith/core/objects/DuplicateObjectDefinitionException.java
+++ b/src/main/java/com/laytonsmith/core/objects/DuplicateObjectDefinitionException.java
@@ -7,13 +7,13 @@ import com.laytonsmith.core.exceptions.ConfigCompileException;
  * Thrown if an ObjectDefintion is attempted to be redefined. An ObjectDefinition is uniquely identified by its fully
  * qualified class name, as a String.
  */
-public class DuplicateObjectDefintionException extends ConfigCompileException {
+public class DuplicateObjectDefinitionException extends ConfigCompileException {
 	private final boolean wasCopy;
-	public DuplicateObjectDefintionException(Target t, boolean isCopy) {
+	public DuplicateObjectDefinitionException(Target t, boolean isCopy) {
 		this(null, t, isCopy);
 	}
 
-	public DuplicateObjectDefintionException(String message, Target t, boolean isCopy) {
+	public DuplicateObjectDefinitionException(String message, Target t, boolean isCopy) {
 		super(message, t);
 		this.wasCopy = isCopy;
 	}

--- a/src/main/java/com/laytonsmith/core/objects/ObjectDefinitionTable.java
+++ b/src/main/java/com/laytonsmith/core/objects/ObjectDefinitionTable.java
@@ -199,9 +199,9 @@ public final class ObjectDefinitionTable implements Iterable<ObjectDefinition> {
 	 * Adds a new ObjectDefinition to the ObjectTable.
 	 * @param object The ObjectDefinition to add.
 	 * @param t
-	 * @throws DuplicateObjectDefintionException If an object with this name already exists.
+	 * @throws DuplicateObjectDefinitionException If an object with this name already exists.
 	 */
-	public void add(ObjectDefinition object, Target t) throws DuplicateObjectDefintionException {
+	public void add(ObjectDefinition object, Target t) throws DuplicateObjectDefinitionException {
 		if(this.classList.containsKey(object.getClassName())) {
 			String msg = "The class " + object.getClassName() + " was attempted to be redefined.";
 			boolean isCopy = false;
@@ -209,7 +209,7 @@ public final class ObjectDefinitionTable implements Iterable<ObjectDefinition> {
 				msg += " The object appears to be an identical definition, is code running twice that shouldn't?";
 				isCopy = true;
 			}
-			throw new DuplicateObjectDefintionException(msg, t, isCopy);
+			throw new DuplicateObjectDefinitionException(msg, t, isCopy);
 		}
 		this.classList.put(object.getClassName(), object);
 	}

--- a/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
+++ b/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
@@ -55,7 +55,7 @@ public class ObjectDefinitionTableTest {
 			ObjectDefinition d = table.get(CString.class);
 			table.add(d, Target.UNKNOWN);
 			fail();
-		} catch (DuplicateObjectDefintionException e) {
+		} catch (DuplicateObjectDefinitionException e) {
 			// pass
 		}
 		// Sanity check


### PR DESCRIPTION
The DuplicateObjectDefintionException.java class is misspelled,
it should be DuplicateObjectDefinitionException.java

This commit fixes the class name.

Resolves: #1180