### PR TITLE
Fix cmdline file access security checks

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -1462,7 +1462,7 @@ public class DataHandling {
 									children.get(0).getTarget(), FileOptions.SuppressWarning.IncludedFileNotFound));
 				}
 				try {
-					if(!Security.CheckSecurity(file)) {
+					if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(file)) {
 						throw new ConfigCompileException("Included file is inaccessible due to the base-dir setting",
 								children.get(0).getTarget());
 					}

--- a/src/main/java/com/laytonsmith/core/functions/FileHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/FileHandling.java
@@ -82,12 +82,10 @@ public class FileHandling {
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
 			File location = Static.GetFileFromArgument(args[0].val(), env, t, null);
 			try {
-				if(!Static.InCmdLine(env, true)) {
-					//Verify this file is not above the craftbukkit directory (or whatever directory the user specified
-					//Cmdline mode doesn't currently have this restriction.
-					if(!Security.CheckSecurity(location)) {
-						throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
-					}
+				//Verify this file is not above the craftbukkit directory (or whatever directory the user specified
+				//Cmdline mode doesn't currently have this restriction.
+				if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(location)) {
+					throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
 				}
 				String s = file_get_contents(location.getAbsolutePath());
 				s = s.replaceAll("\n|\r\n", "\n");
@@ -372,7 +370,7 @@ public class FileHandling {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			File location = Static.GetFileFromArgument(args[0].val(), environment, t, null);
 			try {
-				if(!Security.CheckSecurity(location) && !Static.InCmdLine(environment, true)) {
+				if(!Static.InCmdLine(environment, true) && !Security.CheckSecurity(location)) {
 					throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
 				}
 			} catch (IOException ex) {
@@ -488,12 +486,10 @@ public class FileHandling {
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			File location = Static.GetFileFromArgument(args[0].val(), env, t, null);
 			try {
-				if(!Static.InCmdLine(env, true)) {
-					//Verify this file is not above the craftbukkit directory (or whatever directory the user specified
-					//Cmdline mode doesn't currently have this restriction.
-					if(!Security.CheckSecurity(location)) {
-						throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
-					}
+				//Verify this file is not above the craftbukkit directory (or whatever directory the user specified
+				//Cmdline mode doesn't currently have this restriction.
+				if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(location)) {
+					throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
 				}
 				InputStream stream = new BufferedInputStream(new FileInputStream(location));
 				return CByteArray.wrap(StreamUtils.GetBytes(stream), t);

--- a/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
+++ b/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
@@ -6,6 +6,7 @@ import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Security;
+import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
@@ -47,7 +48,7 @@ public class IncludeCache {
 		MSLog.GetLogger().Log(TAG, LogLevel.VERBOSE, "Security check passed", t);
 		Profiler profiler = env.getEnv(GlobalEnv.class).GetProfiler();
 		try {
-			if(!Security.CheckSecurity(file)) {
+			if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(file)) {
 				throw new CRESecurityException("The script cannot access " + file
 						+ " due to restrictions imposed by the base-dir setting.", t);
 			}

--- a/src/main/java/com/laytonsmith/core/functions/Sandbox.java
+++ b/src/main/java/com/laytonsmith/core/functions/Sandbox.java
@@ -523,7 +523,7 @@ public class Sandbox {
 			File file = Static.GetFileFromArgument(args[0].val(), env, t, null);
 			int num = 0;
 			try {
-				if(Security.CheckSecurity(file)) {
+				if(Static.InCmdLine(env, true) || Security.CheckSecurity(file)) {
 					if(file.isDirectory()) {
 						HashMap<File, ParseTree> files = compileDirectory(file, env, t);
 						IncludeCache.addAll(files);


### PR DESCRIPTION
- Bypass Security.CheckSecurity(File) checks in cmdline mode.
- Move existing in-cmdline-mode checks before Security checks, since Security checks can throw an IOEx that shouldn't have to occur in cmdline mode.