### PR TITLE
Add missing CommandHelperEnvironments

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/BossBar.java
+++ b/src/main/java/com/laytonsmith/core/functions/BossBar.java
@@ -17,6 +17,7 @@ import com.laytonsmith.core.constructs.CDouble;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREException;
@@ -59,7 +60,7 @@ public class BossBar {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_bars extends BossBarFunction {
 
 		@Override
@@ -93,7 +94,7 @@ public class BossBar {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_bar extends BossBarFunction {
 
 		@Override
@@ -178,7 +179,7 @@ public class BossBar {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class update_bar extends BossBarFunction {
 
 		@Override
@@ -257,7 +258,7 @@ public class BossBar {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_bar extends BossBarFunction {
 
 		@Override
@@ -298,7 +299,7 @@ public class BossBar {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_bar extends BossBarFunction {
 
 		@Override
@@ -335,7 +336,7 @@ public class BossBar {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class bar_add_player extends BossBarFunction {
 
 		@Override
@@ -369,7 +370,7 @@ public class BossBar {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class bar_remove_player extends BossBarFunction {
 
 		@Override
@@ -403,7 +404,7 @@ public class BossBar {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_bar_players extends BossBarFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
+++ b/src/main/java/com/laytonsmith/core/functions/BukkitMetadata.java
@@ -15,6 +15,7 @@ import com.laytonsmith.core.constructs.CBoolean;
 import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREBadEntityException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
@@ -65,7 +66,7 @@ public class BukkitMetadata {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_metadata extends MetadataFunction {
 
 		@Override
@@ -135,7 +136,7 @@ public class BukkitMetadata {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso(get_metadata.class)
 	public static class has_metadata extends MetadataFunction {
 
@@ -187,7 +188,7 @@ public class BukkitMetadata {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso(get_metadata.class)
 	public static class set_metadata extends MetadataFunction {
 
@@ -237,7 +238,7 @@ public class BukkitMetadata {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso(get_metadata.class)
 	public static class remove_metadata extends MetadataFunction {
 

--- a/src/main/java/com/laytonsmith/core/functions/Commands.java
+++ b/src/main/java/com/laytonsmith/core/functions/Commands.java
@@ -16,6 +16,7 @@ import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CRENotFoundException;
@@ -43,7 +44,7 @@ public class Commands {
 	public static Map<String, CClosure> onCommand = new HashMap<String, CClosure>();
 	public static Map<String, CClosure> onTabComplete = new HashMap<String, CClosure>();
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_tabcompleter extends AbstractFunction {
 
 		@Override
@@ -139,7 +140,7 @@ public class Commands {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class unregister_command extends AbstractFunction {
 
 		@Override
@@ -191,7 +192,7 @@ public class Commands {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class register_command extends AbstractFunction {
 
 		@Override
@@ -328,7 +329,7 @@ public class Commands {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_executor extends AbstractFunction {
 
 		@Override
@@ -401,7 +402,7 @@ public class Commands {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_commands extends AbstractFunction {
 
 		@Override
@@ -472,7 +473,7 @@ public class Commands {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class clear_commands extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -110,7 +110,7 @@ public class Echoes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class tmsg extends AbstractFunction {
 
 		@Override
@@ -241,7 +241,7 @@ public class Echoes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class title extends AbstractFunction {
 
 		@Override
@@ -563,7 +563,7 @@ public class Echoes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class chatas extends AbstractFunction {
 
 		@Override
@@ -611,7 +611,7 @@ public class Echoes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class broadcast extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Enchantments.java
+++ b/src/main/java/com/laytonsmith/core/functions/Enchantments.java
@@ -633,7 +633,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@hide("Deprecated for can_enchant_item()")
 	public static class can_enchant_target extends AbstractFunction implements Optimizable {
 
@@ -699,7 +699,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class can_enchant_item extends AbstractFunction {
 
 		@Override
@@ -748,7 +748,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_enchant_max extends AbstractFunction {
 
 		@Override
@@ -794,7 +794,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_enchants extends AbstractFunction implements Optimizable {
 
 		private static final Map<String, CArray> CACHE = new HashMap<>();
@@ -881,7 +881,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_enchantment extends AbstractFunction {
 
 		@Override
@@ -930,7 +930,7 @@ public class Enchantments {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class enchantment_list extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/EntityManagement.java
@@ -184,7 +184,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class all_entities extends EntityFunction {
 
 		@Override
@@ -281,7 +281,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_exists extends EntityGetterFunction {
 
 		@Override
@@ -311,7 +311,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_entity_living extends EntityGetterFunction {
 
 		@Override
@@ -343,7 +343,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_tameable extends AbstractFunction {
 
 		@Override
@@ -388,7 +388,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_loc extends EntityGetterFunction {
 
 		@Override
@@ -424,7 +424,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_loc extends EntitySetterFunction {
 
 		@Override
@@ -481,7 +481,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_velocity extends EntityGetterFunction {
 
 		@Override
@@ -519,7 +519,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_velocity extends EntitySetterFunction {
 
 		@Override
@@ -570,7 +570,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_remove extends EntityGetterFunction {
 
 		@Override
@@ -605,7 +605,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_type extends EntityGetterFunction {
 
 		@Override
@@ -641,7 +641,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_age extends EntityGetterFunction {
 
 		@Override
@@ -670,7 +670,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_age extends EntitySetterFunction {
 
 		@Override
@@ -945,7 +945,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_onfire extends EntityGetterFunction {
 
 		@Override
@@ -972,7 +972,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_onfire extends EntitySetterFunction {
 
 		@Override
@@ -1007,7 +1007,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class play_entity_effect extends EntitySetterFunction {
 
 		@Override
@@ -1046,7 +1046,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_name extends EntityGetterFunction {
 
 		@Override
@@ -1075,7 +1075,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_name extends EntitySetterFunction {
 
 		@Override
@@ -1235,7 +1235,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_rider extends EntitySetterFunction {
 
 		@Override
@@ -1291,7 +1291,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_rider extends EntityGetterFunction {
 
 		@Override
@@ -1321,7 +1321,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_riders extends EntityGetterFunction {
 
 		@Override
@@ -1351,7 +1351,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_vehicle extends EntityGetterFunction {
 
 		@Override
@@ -1379,7 +1379,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_max_speed extends EntityGetterFunction {
 
 		@Override
@@ -1412,7 +1412,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_max_speed extends EntitySetterFunction {
 
 		@Override
@@ -1449,7 +1449,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_name_visible extends EntityGetterFunction {
 
 		@Override
@@ -1479,7 +1479,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_name_visible extends EntitySetterFunction {
 
 		@Override
@@ -1510,7 +1510,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_art_at extends AbstractFunction {
 
 		@Override
@@ -1567,7 +1567,7 @@ public class EntityManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_art_at extends AbstractFunction {
 
 		@Override
@@ -1639,7 +1639,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_grounded extends EntityGetterFunction {
 
 		@Override
@@ -1663,7 +1663,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso(set_entity_spec.class)
 	public static class entity_spec extends EntityGetterFunction {
 
@@ -2206,7 +2206,7 @@ public class EntityManagement {
 		private static final String KEY_ZOMBIE_BABY = "baby";
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso(entity_spec.class)
 	public static class set_entity_spec extends EntitySetterFunction {
 
@@ -3535,7 +3535,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_projectile_shooter extends EntityGetterFunction {
 
 		@Override
@@ -3574,7 +3574,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_projectile_shooter extends EntitySetterFunction {
 
 		@Override
@@ -3616,7 +3616,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_projectile_bounce extends EntityGetterFunction {
 
 		@Override
@@ -3645,7 +3645,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_projectile_bounce extends EntitySetterFunction {
 
 		@Override
@@ -3675,7 +3675,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_fall_distance extends EntityGetterFunction {
 
 		@Override
@@ -3699,7 +3699,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_fall_distance extends EntitySetterFunction {
 
 		@Override
@@ -3724,7 +3724,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_glowing extends EntitySetterFunction {
 
 		@Override
@@ -3749,7 +3749,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_glowing extends EntityGetterFunction {
 
 		@Override
@@ -3774,7 +3774,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_silent extends EntityGetterFunction {
 
 		@Override
@@ -3798,7 +3798,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_silent extends EntitySetterFunction {
 
 		@Override
@@ -3824,7 +3824,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_gravity extends EntityGetterFunction {
 
 		@Override
@@ -3848,7 +3848,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_gravity extends EntitySetterFunction {
 
 		@Override
@@ -3874,7 +3874,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_invulnerable extends EntityGetterFunction {
 
 		@Override
@@ -3898,7 +3898,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_invulnerable extends EntitySetterFunction {
 
 		@Override
@@ -3925,7 +3925,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_scoreboard_tags extends EntityGetterFunction {
 
 		@Override
@@ -3954,7 +3954,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class add_scoreboard_tag extends EntitySetterFunction {
 
 		@Override
@@ -3979,7 +3979,7 @@ public class EntityManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_scoreboard_tag extends EntitySetterFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Environment.java
+++ b/src/main/java/com/laytonsmith/core/functions/Environment.java
@@ -71,7 +71,7 @@ public class Environment {
 		return "Allows you to manipulate the environment around the player";
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_block extends AbstractFunction {
 
 		@Override
@@ -123,7 +123,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_block extends AbstractFunction {
 
 		@Override
@@ -180,7 +180,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_blockdata_string extends AbstractFunction {
 
 		@Override
@@ -232,7 +232,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_blockdata_string extends AbstractFunction {
 
 		@Override
@@ -295,7 +295,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_blockdata extends AbstractFunction {
 
 		@Override
@@ -346,7 +346,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_blockdata extends AbstractFunction {
 
 		@Override
@@ -1515,7 +1515,7 @@ public class Environment {
 	}
 
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class spawn_particle extends AbstractFunction {
 
 		@Override
@@ -1673,7 +1673,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class play_sound extends AbstractFunction implements Optimizable {
 
 		@Override
@@ -1825,7 +1825,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class play_named_sound extends AbstractFunction {
 
 		@Override
@@ -2316,7 +2316,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class generate_tree extends AbstractFunction {
 
 		@Override
@@ -2375,7 +2375,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_block_lockable extends AbstractFunction {
 
 		@Override
@@ -2423,7 +2423,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_block_locked extends AbstractFunction {
 
 		@Override
@@ -2477,7 +2477,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_block_lock extends AbstractFunction {
 
 		@Override
@@ -2531,7 +2531,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_block_lock extends AbstractFunction {
 
 		@Override
@@ -2587,7 +2587,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_block_command extends AbstractFunction {
 
 		@Override
@@ -2638,7 +2638,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_block_command extends AbstractFunction {
 
 		@Override
@@ -2699,7 +2699,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_command_block_name extends AbstractFunction {
 
 		@Override
@@ -2750,7 +2750,7 @@ public class Environment {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_command_block_name extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/InventoryManagement.java
@@ -2549,7 +2549,7 @@ public class InventoryManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_inventory_viewers extends AbstractFunction {
 
 		@Override
@@ -2600,7 +2600,7 @@ public class InventoryManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_virtual_inventories extends AbstractFunction {
 
 		@Override
@@ -2648,7 +2648,7 @@ public class InventoryManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_virtual_inventory extends AbstractFunction {
 
 		@Override
@@ -2773,7 +2773,7 @@ public class InventoryManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class delete_virtual_inventory extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -86,7 +86,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class data_values extends AbstractFunction implements Optimizable {
 
 		@Override
@@ -172,7 +172,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class data_name extends AbstractFunction {
 
 		@Override
@@ -256,7 +256,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class convert_legacy_item extends AbstractFunction {
 
 		@Override
@@ -310,7 +310,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class max_stack_size extends AbstractFunction implements Optimizable {
 
 		@Override
@@ -923,7 +923,7 @@ public class Minecraft {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class send_resourcepack extends AbstractFunction {
 
 		@Override
@@ -973,7 +973,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_ip_bans extends AbstractFunction {
 
 		@Override
@@ -1022,7 +1022,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_ip_banned extends AbstractFunction {
 
 		@Override
@@ -1074,7 +1074,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class material_info extends AbstractFunction implements Optimizable {
 
 		@Override
@@ -1209,7 +1209,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class shutdown_server extends AbstractFunction implements Optimizable {
 
 		@Override
@@ -1261,7 +1261,7 @@ public class Minecraft {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class monitor_redstone extends AbstractFunction {
 
 		@Override
@@ -1325,7 +1325,7 @@ public class Minecraft {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class all_materials extends AbstractFunction {
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {

--- a/src/main/java/com/laytonsmith/core/functions/MobManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/MobManagement.java
@@ -294,7 +294,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_owner extends AbstractFunction {
 
 		@Override
@@ -349,7 +349,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_owner extends AbstractFunction {
 
 		@Override
@@ -407,7 +407,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_health extends AbstractFunction {
 
 		@Override
@@ -461,7 +461,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_health extends AbstractFunction {
 
 		@Override
@@ -507,7 +507,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_breedable extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -537,7 +537,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_breedable extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -571,7 +571,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_age extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -610,7 +610,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_age extends EntityManagement.EntityFunction {
 
 		@Override
@@ -662,7 +662,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_effects extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -696,7 +696,7 @@ public class MobManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_effect extends EntityManagement.EntityFunction {
 
 		@Override
@@ -792,7 +792,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_target extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -822,7 +822,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_target extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -858,7 +858,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_mob_equipment extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -904,7 +904,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_equipment extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -963,7 +963,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_max_health extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -988,7 +988,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_max_health extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1022,7 +1022,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_equipment_droprates extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1055,7 +1055,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_equipment_droprates extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1103,7 +1103,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class can_pickup_items extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1127,7 +1127,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_can_pickup_items extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1152,7 +1152,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_persistence extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1177,7 +1177,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_persistence extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1202,7 +1202,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_leashholder extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1231,7 +1231,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_leashholder extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1267,7 +1267,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_air extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1291,7 +1291,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_air extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1316,7 +1316,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_max_air extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1340,7 +1340,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_max_air extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1365,7 +1365,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_line_of_sight extends EntityManagement.EntityFunction {
 
 		@Override
@@ -1439,7 +1439,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_can_see extends EntityManagement.EntityFunction {
 
 		@Override
@@ -1477,7 +1477,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class damage_entity extends EntityManagement.EntityFunction {
 
 		@Override
@@ -1530,7 +1530,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_gliding extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1559,7 +1559,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_gliding extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1583,7 +1583,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_entity_ai extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1607,7 +1607,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_ai extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1636,7 +1636,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_mob_collidable extends EntityManagement.EntityGetterFunction {
 
 		@Override
@@ -1660,7 +1660,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_mob_collidable extends EntityManagement.EntitySetterFunction {
 
 		@Override
@@ -1687,7 +1687,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_attribute_value extends AbstractFunction {
 
 		@Override
@@ -1745,7 +1745,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_attribute_base extends AbstractFunction {
 
 		@Override
@@ -1802,7 +1802,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_attribute_default extends AbstractFunction {
 
 		@Override
@@ -1859,7 +1859,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class entity_attribute_modifiers extends AbstractFunction {
 
 		@Override
@@ -1920,7 +1920,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_entity_attribute_base extends AbstractFunction {
 
 		@Override
@@ -1980,7 +1980,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class reset_entity_attribute_base extends AbstractFunction {
 
 		@Override
@@ -2038,7 +2038,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class add_entity_attribute_modifier extends AbstractFunction {
 
 		@Override
@@ -2092,7 +2092,7 @@ public class MobManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_entity_attribute_modifier extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -666,7 +666,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class ptarget_space extends AbstractFunction {
 
 		@Override
@@ -4943,7 +4943,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class plast_known_name extends AbstractFunction {
 
 		@Override
@@ -4997,7 +4997,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class save_players extends AbstractFunction {
 
 		@Override
@@ -5042,7 +5042,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso({set_pflight.class})
 	public static class set_pflying extends AbstractFunction {
 
@@ -5111,7 +5111,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class pspectator_target extends AbstractFunction {
 
 		@Override
@@ -5171,7 +5171,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_pspectator_target extends AbstractFunction {
 
 		@Override
@@ -5235,7 +5235,7 @@ public class PlayerManagement {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso({com.laytonsmith.core.functions.Environment.play_sound.class})
 	public static class stop_sound extends AbstractFunction {
 
@@ -5305,7 +5305,7 @@ public class PlayerManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	@seealso({com.laytonsmith.core.functions.Environment.play_named_sound.class})
 	public static class stop_named_sound extends AbstractFunction {
 
@@ -5368,7 +5368,7 @@ public class PlayerManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class pcooldown extends AbstractFunction {
 
 		@Override
@@ -5431,7 +5431,7 @@ public class PlayerManagement {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_pcooldown extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/PluginMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/PluginMeta.java
@@ -34,7 +34,7 @@ public class PluginMeta {
 		return "This class contains the functions use to communicate with other plugins and the server in general.";
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class fake_incoming_plugin_message extends AbstractFunction {
 
 		@Override
@@ -97,7 +97,7 @@ public class PluginMeta {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class send_plugin_message extends AbstractFunction {
 
 		@Override
@@ -162,7 +162,7 @@ public class PluginMeta {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class register_channel extends AbstractFunction {
 
 		@Override
@@ -227,7 +227,7 @@ public class PluginMeta {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class unregister_channel extends AbstractFunction {
 
 		@Override
@@ -289,7 +289,7 @@ public class PluginMeta {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class is_channel_registered extends AbstractFunction {
 
 		@Override
@@ -343,7 +343,7 @@ public class PluginMeta {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_registered_channels extends AbstractFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Recipes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Recipes.java
@@ -11,6 +11,7 @@ import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
@@ -46,7 +47,7 @@ public class Recipes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class add_recipe extends recipeFunction {
 
 		@Override
@@ -145,7 +146,7 @@ public class Recipes {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_recipes_for extends recipeFunction {
 
 		@Override
@@ -189,7 +190,7 @@ public class Recipes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_all_recipes extends recipeFunction {
 
 		@Override
@@ -230,7 +231,7 @@ public class Recipes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class clear_recipes extends recipeFunction {
 
 		@Override
@@ -266,7 +267,7 @@ public class Recipes {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class reset_recipes extends recipeFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -25,6 +25,7 @@ import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
@@ -240,7 +241,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_pscoreboard extends SBFunction {
 
 		@Override
@@ -284,7 +285,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_pscoreboard extends SBFunction {
 
 		@Override
@@ -322,7 +323,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_scoreboards extends SBFunction {
 
 		@Override
@@ -362,7 +363,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_objectives extends SBFunction {
 
 		@Override
@@ -426,7 +427,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_teams extends SBFunction {
 
 		@Override
@@ -468,7 +469,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_scoreboard extends SBFunction {
 
 		@Override
@@ -510,7 +511,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_objective extends SBFunction {
 
 		@Override
@@ -567,7 +568,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_team extends SBFunction {
 
 		@Override
@@ -613,7 +614,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_objective_display extends SBFunction {
 
 		@Override
@@ -692,7 +693,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_team_display extends SBFunction {
 
 		@Override
@@ -799,7 +800,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class team_add_player extends SBFunction {
 
 		@Override
@@ -844,7 +845,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class team_remove_player extends SBFunction {
 
 		@Override
@@ -879,7 +880,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_pteam extends SBFunction {
 
 		@Override
@@ -915,7 +916,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_scoreboard extends SBFunction {
 
 		@Override
@@ -972,7 +973,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_objective extends SBFunction {
 
 		@Override
@@ -1010,7 +1011,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class remove_team extends SBFunction {
 
 		@Override
@@ -1048,7 +1049,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_pscore extends SBFunction {
 
 		@Override
@@ -1092,7 +1093,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_pscore extends SBFunction {
 
 		@Override
@@ -1138,7 +1139,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class reset_all_pscores extends SBFunction {
 
 		@Override
@@ -1169,7 +1170,7 @@ public class Scoreboards {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_team_options extends SBFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Trades.java
+++ b/src/main/java/com/laytonsmith/core/functions/Trades.java
@@ -21,6 +21,7 @@ import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREBadEntityException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
@@ -47,7 +48,7 @@ public class Trades {
 				+ " which may or may not be attached to a Villager or Wandering Trader.";
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_merchant_trades extends Recipes.recipeFunction {
 
 		@Override
@@ -86,7 +87,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_merchant_trades extends Recipes.recipeFunction {
 
 		@Override
@@ -159,7 +160,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_virtual_merchants extends Recipes.recipeFunction {
 
 		@Override
@@ -202,7 +203,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_virtual_merchant extends Recipes.recipeFunction {
 
 		@Override
@@ -245,7 +246,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class delete_virtual_merchant extends Recipes.recipeFunction {
 
 		@Override
@@ -280,7 +281,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class popen_trading extends Recipes.recipeFunction {
 
 		@Override
@@ -334,7 +335,7 @@ public class Trades {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class merchant_trader extends Recipes.recipeFunction {
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -285,7 +285,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class load_chunk extends AbstractFunction {
 
 		@Override
@@ -448,7 +448,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_loaded_chunks extends AbstractFunction {
 
 		@Override
@@ -1170,7 +1170,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class world_info extends AbstractFunction {
 
 		@Override
@@ -1227,7 +1227,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class unload_world extends AbstractFunction {
 
 		@Override
@@ -1280,7 +1280,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_difficulty extends AbstractFunction {
 
 		@Override
@@ -1329,7 +1329,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_difficulty extends AbstractFunction {
 
 		@Override
@@ -1397,7 +1397,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_pvp extends AbstractFunction {
 
 		@Override
@@ -1445,7 +1445,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_pvp extends AbstractFunction {
 
 		@Override
@@ -1502,7 +1502,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_gamerule extends AbstractFunction {
 
 		@Override
@@ -1572,7 +1572,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_gamerule extends AbstractFunction {
 
 		@Override
@@ -1634,7 +1634,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_keep_spawn_loaded extends AbstractFunction {
 
 		@Override
@@ -1683,7 +1683,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class location_shift extends AbstractFunction {
 
 		@Override
@@ -1761,7 +1761,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_yaw extends AbstractFunction {
 
 		@Override
@@ -1829,7 +1829,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_pitch extends AbstractFunction {
 
 		@Override
@@ -1940,7 +1940,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class distance extends AbstractFunction {
 
 		@Override
@@ -1991,7 +1991,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class save_world extends AbstractFunction {
 
 		@Override
@@ -2038,7 +2038,7 @@ public class World {
 
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_temperature extends AbstractFunction {
 
 		@Override
@@ -2088,7 +2088,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class get_world_border extends AbstractFunction {
 
 		@Override
@@ -2145,7 +2145,7 @@ public class World {
 		}
 	}
 
-	@api
+	@api(environments = {CommandHelperEnvironment.class})
 	public static class set_world_border extends AbstractFunction {
 
 		@Override


### PR DESCRIPTION
Add CommandHelperEnvironment `@api` annotation arguments for Minecraft dependent functions, such that these functions can no longer be used in cmdline mode (and crash due to NoClassFoundDefErrors).