### PR TITLE
pass current MCCommandSender on null for executeas

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -2375,7 +2375,7 @@ public class DataHandling {
 			MCCommandSender sender;
 			if(args[0].val().equals(Static.getConsoleName())) {
 				sender = Static.getServer().getConsole();
-			}else if(args[0] instanceof CNull) {
+			} else if(args[0] instanceof CNull) {
 				sender = originalSender;
 			} else {
 				sender = Static.GetPlayer(args[0].val(), t);

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -2376,7 +2376,7 @@ public class DataHandling {
 			if(args[0].val().equals(Static.getConsoleName())) {
 				sender = Static.getServer().getConsole();
 			} else if(args[0] instanceof CNull) {
-				sender = originalSender;
+				sender = environment.getEnv(CommandHelperEnvironment.class).GetCommandSender();
 			} else {
 				sender = Static.GetPlayer(args[0].val(), t);
 			}

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -2375,6 +2375,8 @@ public class DataHandling {
 			MCCommandSender sender;
 			if(args[0].val().equals(Static.getConsoleName())) {
 				sender = Static.getServer().getConsole();
+			}else if(args[0] instanceof CNull) {
+				sender = originalSender;
 			} else {
 				sender = Static.GetPlayer(args[0].val(), t);
 			}


### PR DESCRIPTION
this allows for:
`executeas(null, null, @closure)`