### PR TITLE
Use cache instead of FunctionList lookups

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CFunction.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CFunction.java
@@ -1,8 +1,14 @@
 package com.laytonsmith.core.constructs;
 
 import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
+import com.laytonsmith.annotations.api;
+
+import java.util.Set;
+
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.functions.Function;
 import com.laytonsmith.core.functions.FunctionBase;
@@ -17,6 +23,7 @@ public class CFunction extends Construct {
 
 	public static final long serialVersionUID = 1L;
 	private transient Function function = null;
+	private transient Class<? extends EnvironmentImpl>[] envImpls = null;
 
 	public CFunction(String name, Target t) {
 		super(name, ConstructType.FUNCTION, t);
@@ -78,11 +85,40 @@ public class CFunction extends Construct {
 	}
 
 	/**
-	 * Returns the underlying function for this construct from the cache (which occurs on calling
+	 * Returns the underlying function for this construct from the cache (which is cached on calling
 	 * {@link #getFunction()} or {@link #setFunction(FunctionBase)}).
 	 * @return The cached {@link Function} or {@code null} when the function has not yet been cached or doesn't exist.
 	 */
 	public Function getCachedFunction() {
+		return this.function;
+	}
+
+	/**
+	 * Returns the underlying function for this construct from the cache (which is cached on calling
+	 * {@link #getFunction()} or {@link #setFunction(FunctionBase)}) if the function is known given the passed
+	 * environments.
+	 * @param envs - The environments.
+	 * @return The cached {@link Function} or {@code null} when the function has not yet been cached or doesn't exist.
+	 */
+	public Function getCachedFunction(Set<Class<? extends Environment.EnvironmentImpl>> envs) {
+
+		// Return null if the function has not yet been cached or does not exist.
+		if(this.function == null) {
+			return null;
+		}
+
+		// Cache the environments from the @api annotation if they have not yet been cached.
+		if(this.envImpls == null) {
+			api api = this.function.getClass().getAnnotation(api.class);
+			this.envImpls = api.environments();
+		}
+
+		// Return the cached function if it is known given the passed environments.
+		for(Class<? extends Environment.EnvironmentImpl> envImpl : this.envImpls) {
+			if(!envs.contains(envImpl)) {
+				return null;
+			}
+		}
 		return this.function;
 	}
 


### PR DESCRIPTION
Cache the required environments for each function in CFunction and use that for lookups where possible. Also don't do FunctionList lookups where the function is already cached. This makes the flow as follows:
1. postParseRewrite() caches all existing functions.
2. Other compiler steps use the cached functions, or get null when they don't exist.
3. checkFunctionsExist() does a lookup in the FunctionList if the function is not cached, and generates the compile exception if it doesn't exist.