### PR TITLE
Static Analysis patch

### DIFF
--- a/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
+++ b/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
@@ -471,9 +471,20 @@ public class StaticAnalysis {
 	public static IVariable requireIVariable(Mixed node, Target t, Set<ConfigCompileException> exceptions) {
 		if(node instanceof IVariable) {
 			return (IVariable) node;
+		} else if(node instanceof Variable) {
+			exceptions.add(new ConfigCompileException("Expected ivariable, but received variable instead.", t));
+			return null;
 		}
-		exceptions.add(new ConfigCompileException("Expected ivariable "
-				+ ", but received type " + node.getName() + " instead.", t));
+
+		// The node can be anything. If it has a type, get that. If it doesn't, use the node's class name.
+		// TODO - Remove this try catch when syntax errors are caught by the parser and terminate compilation there.
+		try {
+			exceptions.add(new ConfigCompileException(
+					"Expected ivariable, but received type " + node.getName() + " instead.", t));
+		} catch (NullPointerException e) {
+			exceptions.add(new ConfigCompileException(
+					"Expected ivariable, but received " + node.getClass().getSimpleName() + " instead.", t));
+		}
 		return null;
 	}
 
@@ -489,8 +500,16 @@ public class StaticAnalysis {
 		if(node instanceof CClassType) {
 			return (CClassType) node;
 		}
-		exceptions.add(new ConfigCompileException(
-				"Expected classtype, but received type " + node.getName() + " instead.", t));
+
+		// The node can be anything. If it has a type, get that. If it doesn't, use the node's class name.
+		// TODO - Remove this try catch when syntax errors are caught by the parser and terminate compilation there.
+		try {
+			exceptions.add(new ConfigCompileException(
+					"Expected classtype, but received type " + node.getName() + " instead.", t));
+		} catch (NullPointerException e) {
+			exceptions.add(new ConfigCompileException(
+					"Expected classtype, but received " + node.getClass().getSimpleName() + " instead.", t));
+		}
 		return null;
 	}
 

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -391,10 +391,13 @@ public class DataHandling {
 											valType, decl.getType(), valNode.getTarget(), env, exceptions);
 								}
 								return valType;
-							} else {
-								declaredType = CClassType.AUTO;
 							}
 						}
+					}
+
+					// If a variable is declared as AUTO or unknown, then its value should actually be any mixed.
+					if(declaredType == null || declaredType == CClassType.AUTO) {
+						declaredType = Mixed.TYPE;
 					}
 
 					// Type check assigned value.


### PR DESCRIPTION
- Fix NPE in StaticAnalysis.requireIVariable() and StaticAnalysis.requireClassType() that occurs when passing in invalid syntax. Eventually, the parse has to catch these errors and halt compilation such that the AST in further steps only contains valid terms. For now, catch possible NPEs in the later stage and print invalid term classes instead such that it doesn't crash.
- Fix exception during scope graph generation for assign(var, val) with an invalid variable type.
- For default or AUTO declarations, still require the value to be instanceof Mixed to prevent things such as void assigns.