### PR TITLE
Re-use environment for compilation

### DIFF
--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperInterpreterListener.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperInterpreterListener.java
@@ -13,6 +13,7 @@ import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
@@ -139,15 +140,17 @@ public class CommandHelperInterpreterListener implements Listener {
 	 */
 	public void execute(String script, final MCPlayer p) throws ConfigCompileException, ConfigCompileGroupException {
 		TokenStream stream = MethodScriptCompiler.lex(script, null, new File("Interpreter"), true);
-		GlobalEnv gEnv = new GlobalEnv(plugin.executionQueue, plugin.profiler, plugin.persistenceNetwork,
+		GlobalEnv gEnv = new GlobalEnv(plugin.executionQueue,
 				CommandHelperFileLocations.getDefault().getConfigDirectory(),
-				plugin.profiles, new TaskManagerImpl(), EnumSet.of(RuntimeMode.EMBEDDED, RuntimeMode.INTERPRETER));
+				EnumSet.of(RuntimeMode.EMBEDDED, RuntimeMode.INTERPRETER));
+		StaticRuntimeEnv staticRuntimeEnv = new StaticRuntimeEnv(plugin.profiler,
+				plugin.persistenceNetwork, plugin.profiles, new TaskManagerImpl());
 		gEnv.SetDynamicScriptingMode(true);
 		CommandHelperEnvironment cEnv = new CommandHelperEnvironment();
 		cEnv.SetPlayer(p);
 		CompilerEnvironment compilerEnv = new CompilerEnvironment();
 		compilerEnv.setLogCompilerWarnings(false);
-		Environment env = Environment.createEnvironment(gEnv, cEnv, compilerEnv);
+		Environment env = Environment.createEnvironment(gEnv, staticRuntimeEnv, cEnv, compilerEnv);
 		ParseTree tree = MethodScriptCompiler.compile(stream, env, env.getEnvClasses());
 		final boolean isInterpeterMode = interpreterMode.remove(p.getName());
 		try {

--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -385,7 +385,7 @@ public class AliasCore {
 				}
 				ProfilePoint compilerMSA = parent.profiler.start("Compilation of MSA files in Local Packages", LogLevel.VERBOSE);
 				try {
-					localPackages.compileMSA(scripts, player, env.getEnvClasses());
+					localPackages.compileMSA(scripts, player, env, env.getEnvClasses());
 				} finally {
 					compilerMSA.stop();
 				}
@@ -671,7 +671,7 @@ public class AliasCore {
 		}
 
 		public void compileMSA(List<Script> scripts, MCPlayer player,
-				Set<Class<? extends Environment.EnvironmentImpl>> envs) {
+				Environment env, Set<Class<? extends Environment.EnvironmentImpl>> envs) {
 			for(FileInfo fi : msa) {
 				List<Script> tempScripts;
 				try {
@@ -685,7 +685,7 @@ public class AliasCore {
 					for(Script s : tempScripts) {
 						try {
 							try {
-								s.compile();
+								s.compile(env);
 								s.checkAmbiguous(scripts);
 								scripts.add(s);
 							} catch (ConfigCompileException e) {

--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -688,7 +688,7 @@ public class AliasCore {
 					for(Script s : tempScripts) {
 						try {
 							try {
-								s.compile(env);
+								s.compile(env.clone());
 								s.checkAmbiguous(scripts);
 								scripts.add(s);
 							} catch (ConfigCompileException e) {
@@ -699,6 +699,8 @@ public class AliasCore {
 									ConfigRuntimeException.HandleUncaughtException(e, "Compile error in script."
 											+ " Compilation will attempt to continue, however.", player);
 								}
+							} catch (CloneNotSupportedException e) {
+								throw new Error("Environment wasn't clonable, while it should be.", e);
 							}
 						} catch (RuntimeException ee) {
 							throw new RuntimeException("While processing a script, "

--- a/src/main/java/com/laytonsmith/core/Script.java
+++ b/src/main/java/com/laytonsmith/core/Script.java
@@ -26,6 +26,7 @@ import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.InvalidEnvironmentException;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.AbstractCREException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREInsufficientPermissionException;
@@ -307,7 +308,7 @@ public class Script {
 				if(p == null) {
 					throw new CREInvalidProcedureException("Unknown procedure \"" + m.val() + "\"", m.getTarget());
 				}
-				ProfilePoint pp = env.getEnv(GlobalEnv.class).GetProfiler().start(m.val() + " execution", LogLevel.INFO);
+				ProfilePoint pp = env.getEnv(StaticRuntimeEnv.class).GetProfiler().start(m.val() + " execution", LogLevel.INFO);
 				Mixed ret;
 				try {
 					if(debugOutput) {
@@ -355,9 +356,10 @@ public class Script {
 				}
 				if(f.useSpecialExec()) {
 					ProfilePoint p = null;
-					if(f.shouldProfile() && env.getEnv(GlobalEnv.class).GetProfiler() != null
-							&& env.getEnv(GlobalEnv.class).GetProfiler().isLoggable(f.profileAt())) {
-						p = env.getEnv(GlobalEnv.class).GetProfiler().start(f.profileMessageS(c.getChildren()), f.profileAt());
+					if(f.shouldProfile() && env.getEnv(StaticRuntimeEnv.class).GetProfiler() != null
+							&& env.getEnv(StaticRuntimeEnv.class).GetProfiler().isLoggable(f.profileAt())) {
+						p = env.getEnv(StaticRuntimeEnv.class)
+								.GetProfiler().start(f.profileMessageS(c.getChildren()), f.profileAt());
 					}
 					Mixed ret;
 					try {
@@ -399,9 +401,9 @@ public class Script {
 					//It takes a moment to generate the toString of some things, so lets not do it
 					//if we actually aren't going to profile
 					ProfilePoint p = null;
-					if(f.shouldProfile() && env.getEnv(GlobalEnv.class).GetProfiler() != null
-							&& env.getEnv(GlobalEnv.class).GetProfiler().isLoggable(f.profileAt())) {
-						p = env.getEnv(GlobalEnv.class).GetProfiler().start(f.profileMessage(ca), f.profileAt());
+					if(f.shouldProfile() && env.getEnv(StaticRuntimeEnv.class).GetProfiler() != null
+							&& env.getEnv(StaticRuntimeEnv.class).GetProfiler().isLoggable(f.profileAt())) {
+						p = env.getEnv(StaticRuntimeEnv.class).GetProfiler().start(f.profileMessage(ca), f.profileAt());
 					}
 					Mixed ret;
 					try {

--- a/src/main/java/com/laytonsmith/core/Script.java
+++ b/src/main/java/com/laytonsmith/core/Script.java
@@ -672,11 +672,11 @@ public class Script {
 		return vars;
 	}
 
-	public Script compile() throws ConfigCompileException, ConfigCompileGroupException {
+	public Script compile(Environment env) throws ConfigCompileException, ConfigCompileGroupException {
 		try {
 			verifyLeft();
 			compileLeft();
-			compileRight();
+			compileRight(env);
 		} catch (ConfigCompileException e) {
 			compilerError = true;
 			throw e;
@@ -885,7 +885,7 @@ public class Script {
 		return true;
 	}
 
-	public void compileRight() throws ConfigCompileException, ConfigCompileGroupException {
+	public void compileRight(Environment env) throws ConfigCompileException, ConfigCompileGroupException {
 		List<Token> temp = new ArrayList<>();
 		right = new ArrayList<>();
 		for(Token t : fullRight) {
@@ -903,7 +903,7 @@ public class Script {
 		cright = new ArrayList<>();
 		for(List<Token> l : right) {
 			StaticAnalysis analysis = new StaticAnalysis(true);
-			cright.add(MethodScriptCompiler.compile(new TokenStream(l, fileOptions), null, envs, analysis));
+			cright.add(MethodScriptCompiler.compile(new TokenStream(l, fileOptions), env, envs, analysis));
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -47,6 +47,7 @@ import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREBadEntityException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
@@ -1329,10 +1330,12 @@ public final class Static {
 		PersistenceNetwork persistenceNetwork = new PersistenceNetworkImpl(MethodScriptFileLocations.getDefault().getPersistenceConfig(),
 				new URI(URLEncoder.encode("sqlite://" + new File(platformFolder, "persistence.db").getCanonicalPath().replace('\\', '/'), "UTF-8")), options);
 		GlobalEnv gEnv = new GlobalEnv(new MethodScriptExecutionQueue("MethodScriptExecutionQueue", "default"),
-				new Profiler(MethodScriptFileLocations.getDefault().getProfilerConfigFile()), persistenceNetwork,
-				platformFolder, profiles, new TaskManagerImpl(), runtimeModes);
+				platformFolder, runtimeModes);
 		gEnv.SetLabel(GLOBAL_PERMISSION);
-		return Environment.createEnvironment(gEnv, new CompilerEnvironment());
+		StaticRuntimeEnv staticRuntimeEnv = new StaticRuntimeEnv(
+				new Profiler(MethodScriptFileLocations.getDefault().getProfilerConfigFile()),
+				persistenceNetwork, profiles, new TaskManagerImpl());
+		return Environment.createEnvironment(gEnv, staticRuntimeEnv, new CompilerEnvironment());
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
+++ b/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
@@ -592,8 +592,7 @@ public class StaticAnalysis {
 				if(includeAnalysis == null) {
 					includeAnalysis = new StaticAnalysis(false);
 					IncludeCache.get(file, env, envs, includeAnalysis, includeRef.getTarget());
-					assert IncludeCache.getStaticAnalysis(file) != null
-							: "Failed to cache include analysis.";
+					assert IncludeCache.getStaticAnalysis(file) != null : "Failed to cache include analysis.";
 				}
 			} catch (CREException e) {
 

--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -1,13 +1,11 @@
 package com.laytonsmith.core.environments;
 
 import com.laytonsmith.PureUtilities.Common.MutableObject;
-import com.laytonsmith.PureUtilities.DaemonManager;
 import com.laytonsmith.PureUtilities.ExecutionQueue;
 import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSLog;
 import com.laytonsmith.core.MethodScriptExecutionQueue;
 import com.laytonsmith.core.Procedure;
-import com.laytonsmith.core.Profiles;
 import com.laytonsmith.core.Script;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.compiler.FileOptions;
@@ -23,10 +21,6 @@ import com.laytonsmith.core.exceptions.StackTraceManager;
 import com.laytonsmith.core.natives.interfaces.ArrayAccess;
 import com.laytonsmith.core.natives.interfaces.Iterator;
 import com.laytonsmith.core.natives.interfaces.Mixed;
-import com.laytonsmith.core.profiler.Profiler;
-import com.laytonsmith.core.taskmanager.TaskManager;
-import com.laytonsmith.persistence.PersistenceNetwork;
-
 import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -53,9 +47,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	//that field. Note that lists, maps, and other reference based objects don't
 	//need to use MutableObjects, as they are inherently Mutable themselves.
 	private ExecutionQueue executionQueue = null;
-	private Profiler profiler = null;
-	//This is changed reflectively in a test, please don't rename.
-	private PersistenceNetwork persistenceNetwork = null;
 	private final Map<String, Boolean> flags = new HashMap<>();
 	private final Map<String, Object> custom = new HashMap<>();
 	private Script script = null;
@@ -65,13 +56,10 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	private IVariableList iVariableList = null;
 	private String label = null;
 	private final EnumSet<RuntimeMode> runtimeModes;
-	private final DaemonManager daemonManager = new DaemonManager();
 	private boolean dynamicScriptingMode = false;
-	private final Profiles profiles;
 	private BoundEvent.ActiveEvent event = null;
 	private boolean interrupt = false;
 	private final List<Iterator> arrayAccessList = Collections.synchronizedList(new ArrayList<>());
-	private final MutableObject<TaskManager> taskManager = new MutableObject<>();
 	private final WeakHashMap<Thread, StackTraceManager> stackTraceManagers = new WeakHashMap<>();
 	private final MutableObject<Map<String, Mixed>> runtimeSettings
 			= new MutableObject<>(new ConcurrentHashMap<>());
@@ -81,30 +69,18 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	 * Creates a new GlobalEnvironment. All fields in the constructor are required, and cannot be null.
 	 *
 	 * @param queue The ExecutionQueue object to use
-	 * @param profiler The Profiler to use
-	 * @param network The pre-configured PersistenceNetwork object to use
 	 * @param root The root working directory to use
-	 * @param profiles The Profiles object to use
-	 * @param taskManager The TaskManager object to use
 	 * @param runtimeModes The {@link RuntimeMode}s for this environment.
 	 */
-	public GlobalEnv(ExecutionQueue queue, Profiler profiler, PersistenceNetwork network,
-			File root, Profiles profiles, TaskManager taskManager, EnumSet<RuntimeMode> runtimeModes) {
+	public GlobalEnv(ExecutionQueue queue, File root, EnumSet<RuntimeMode> runtimeModes) {
 		Static.AssertNonNull(queue, "ExecutionQueue cannot be null");
-		Static.AssertNonNull(profiler, "Profiler cannot be null");
-		Static.AssertNonNull(network, "PersistenceNetwork cannot be null");
 		Static.AssertNonNull(root, "Root file cannot be null");
-		Static.AssertNonNull(taskManager, "TaskManager cannot be null");
 		RuntimeMode.validate(runtimeModes);
 		this.executionQueue = queue;
-		this.profiler = profiler;
-		this.persistenceNetwork = network;
 		this.root = new MutableObject(root);
 		if(this.executionQueue instanceof MethodScriptExecutionQueue) {
 			((MethodScriptExecutionQueue) executionQueue).setEnvironment(this);
 		}
-		this.profiles = profiles;
-		this.taskManager.setObject(taskManager);
 		this.runtimeModes = runtimeModes;
 	}
 
@@ -127,40 +103,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	public static final ExecutionQueue NO_OP_EXECUTION_QUEUE
 			= GetErrorNoOp(ExecutionQueue.class, "NO_OP_EXECUTION_QUEUE");
 
-	/**
-	 * When constructing a GlobalEnv in meta circumstances, it may be helpful to provide
-	 * a no-op profiler. This value is set up for that purpose. It is
-	 * truly no-op, and no exception is thrown if a method in the interface is
-	 * used.
-	 */
-	public static final Profiler NO_OP_PROFILER = Profiler.FakeProfiler();
-
-	/**
-	 * When constructing a GlobalEnv in meta circumstances, it may be helpful to provide
-	 * a no-op persistence network. This value is set up for that purpose. However, it's
-	 * not truly no-op, as an exception is thrown if any method in the interface are
-	 * used, as this points to a situation where something is being called that isn't
-	 * compatible with a no op execution.
-	 */
-	public static final PersistenceNetwork NO_OP_PN = GetErrorNoOp(PersistenceNetwork.class, "NO_OP_PN");
-
-	/**
-	 * When constructing a GlobalEnv in meta circumstances, it may be helpful to provide
-	 * a no-op Profiles object. This value is set up for that purpose. However, it's
-	 * not truly no-op, as an exception is thrown if any method in the interface are
-	 * used, as this points to a situation where something is being called that isn't
-	 * compatible with a no op execution.
-	 */
-	public static final Profiles NO_OP_PROFILES = GetErrorNoOp(Profiles.class, "NO_OP_PROFILES");
-
-	/**
-	 * When constructing a GlobalEnv in meta circumstances, it may be helpful to provide
-	 * a no-op profiler. This value is set up for that purpose. It is
-	 * truly no-op, and no exception is thrown if a method in the interface is
-	 * used.
-	 */
-	public static final TaskManager NO_OP_TASK_MANAGER = GetNoOp(TaskManager.class);
-
+	@SuppressWarnings("unchecked")
 	private static <T> T GetErrorNoOp(Class<T> iface, String identifier) {
 		return (T) Proxy.newProxyInstance(GlobalEnv.class.getClassLoader(),
 				new Class[]{iface}, (Object proxy, Method method, Object[] args) -> {
@@ -168,6 +111,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 				});
 	}
 
+	@SuppressWarnings("unchecked")
 	private static <T> T GetNoOp(Class<T> iface) {
 		return (T) Proxy.newProxyInstance(GlobalEnv.class.getClassLoader(),
 				new Class[]{iface}, (Object proxy, Method method, Object[] args) -> null);
@@ -175,18 +119,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 
 	public ExecutionQueue GetExecutionQueue() {
 		return executionQueue;
-	}
-
-	public Profiler GetProfiler() {
-		return profiler;
-	}
-
-	public PersistenceNetwork GetPersistenceNetwork() {
-		return persistenceNetwork;
-	}
-
-	public TaskManager GetTaskManager() {
-		return taskManager.getObject();
 	}
 
 	/**
@@ -372,10 +304,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 		return this.runtimeModes.contains(RuntimeMode.INTERPRETER);
 	}
 
-	public DaemonManager GetDaemonManager() {
-		return daemonManager;
-	}
-
 	/**
 	 * Turns dynamic scripting mode on or off. If this is true, that means that the script came from a dynamic source,
 	 * such as eval, or other sources other than the file system.
@@ -394,10 +322,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	 */
 	public boolean GetDynamicScriptingMode() {
 		return this.dynamicScriptingMode;
-	}
-
-	public Profiles getProfiles() {
-		return this.profiles;
 	}
 
 	public void SetEvent(BoundEvent.ActiveEvent e) {

--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -22,8 +22,6 @@ import com.laytonsmith.core.natives.interfaces.ArrayAccess;
 import com.laytonsmith.core.natives.interfaces.Iterator;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import java.io.File;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -82,39 +80,6 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 			((MethodScriptExecutionQueue) executionQueue).setEnvironment(this);
 		}
 		this.runtimeModes = runtimeModes;
-	}
-
-	/**
-	 * Thrown if one of the no-op classes is used.
-	 */
-	public static class GlobalEnvNoOpException extends RuntimeException {
-		public GlobalEnvNoOpException(String message) {
-			super(message);
-		}
-	}
-
-	/**
-	 * When constructing a GlobalEnv in meta circumstances, it may be helpful to provide
-	 * a no-op execution queue. This value is set up for that purpose. However, it's
-	 * not truly no-op, as an exception is thrown if any method in the interface are
-	 * used, as this points to a situation where something is being called that isn't
-	 * compatible with a no op execution.
-	 */
-	public static final ExecutionQueue NO_OP_EXECUTION_QUEUE
-			= GetErrorNoOp(ExecutionQueue.class, "NO_OP_EXECUTION_QUEUE");
-
-	@SuppressWarnings("unchecked")
-	private static <T> T GetErrorNoOp(Class<T> iface, String identifier) {
-		return (T) Proxy.newProxyInstance(GlobalEnv.class.getClassLoader(),
-				new Class[]{iface}, (Object proxy, Method method, Object[] args) -> {
-					throw new GlobalEnvNoOpException(identifier);
-				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T> T GetNoOp(Class<T> iface) {
-		return (T) Proxy.newProxyInstance(GlobalEnv.class.getClassLoader(),
-				new Class[]{iface}, (Object proxy, Method method, Object[] args) -> null);
 	}
 
 	public ExecutionQueue GetExecutionQueue() {

--- a/src/main/java/com/laytonsmith/core/environments/StaticRuntimeEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/StaticRuntimeEnv.java
@@ -1,0 +1,115 @@
+package com.laytonsmith.core.environments;
+
+import com.laytonsmith.PureUtilities.DaemonManager;
+import com.laytonsmith.core.Profiles;
+import com.laytonsmith.core.Static;
+import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
+import com.laytonsmith.core.environments.GlobalEnv.GlobalEnvNoOpException;
+import com.laytonsmith.core.profiler.Profiler;
+import com.laytonsmith.core.taskmanager.TaskManager;
+import com.laytonsmith.persistence.PersistenceNetwork;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * This environment contains 'static final' functionality and data that is available at runtime,
+ * and that does not differ between compile units. This is the perfect environment to store configuration files
+ * or truely global managers in.
+ */
+public class StaticRuntimeEnv implements Environment.EnvironmentImpl, Cloneable {
+
+	private final Profiler profiler;
+	private final PersistenceNetwork persistenceNetwork;
+	private final Profiles profiles;
+	private final TaskManager taskManager;
+	private final DaemonManager daemonManager = new DaemonManager();
+
+	/**
+	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
+	 * profiler. This value is set up for that purpose.
+	 * It is truly no-op, and no exception is thrown if a method in the interface is used.
+	 */
+	public static final Profiler NO_OP_PROFILER = Profiler.FakeProfiler();
+
+	/**
+	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
+	 * persistence network. This value is set up for that purpose.
+	 * However, it's not truly no-op, as an exception is thrown if any method in the interface are used, as this points
+	 * to a situation where something is being called that isn't compatible with a no op execution.
+	 */
+	public static final PersistenceNetwork NO_OP_PN = GetErrorNoOp(PersistenceNetwork.class, "NO_OP_PN");
+
+	/**
+	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
+	 * Profiles object. This value is set up for that purpose.
+	 * However, it's not truly no-op, as an exception is thrown if any method in the interface are used, as this points
+	 * to a situation where something is being called that isn't compatible with a no op execution.
+	 */
+	public static final Profiles NO_OP_PROFILES = GetErrorNoOp(Profiles.class, "NO_OP_PROFILES");
+
+	/**
+	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
+	 * profiler. This value is set up for that purpose.
+	 * It is truly no-op, and no exception is thrown if a method in the interface is used.
+	 */
+	public static final TaskManager NO_OP_TASK_MANAGER = GetNoOp(TaskManager.class);
+
+	/**
+	 * Creates a new {@link StaticRuntimeEnv}. All fields in the constructor are required, and must not be null.
+	 * @param profiler - The Profiler to use.
+	 * @param network - The pre-configured PersistenceNetwork object to use.
+	 * @param profiles - The Profiles object to use.
+	 * @param taskManager - The TaskManager object to use.
+	 */
+	public StaticRuntimeEnv(Profiler profiler, PersistenceNetwork network, Profiles profiles, TaskManager taskManager) {
+		Static.AssertNonNull(profiler, "Profiler must not be null");
+		Static.AssertNonNull(network, "PersistenceNetwork must not be null");
+		Static.AssertNonNull(profiles, "Profiles must not be null");
+		Static.AssertNonNull(taskManager, "TaskManager must not be null");
+		this.profiler = profiler;
+		this.persistenceNetwork = network;
+		this.profiles = profiles;
+		this.taskManager = taskManager;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T GetErrorNoOp(Class<T> iface, String identifier) {
+		return (T) Proxy.newProxyInstance(StaticRuntimeEnv.class.getClassLoader(),
+				new Class[] {iface}, (Object proxy, Method method, Object[] args) -> {
+					throw new GlobalEnvNoOpException(identifier);
+				});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T GetNoOp(Class<T> iface) {
+		return (T) Proxy.newProxyInstance(StaticRuntimeEnv.class.getClassLoader(),
+				new Class[] {iface}, (Object proxy, Method method, Object[] args) -> null);
+	}
+
+	public Profiler GetProfiler() {
+		return this.profiler;
+	}
+
+	public PersistenceNetwork GetPersistenceNetwork() {
+		return this.persistenceNetwork;
+	}
+
+	public Profiles getProfiles() {
+		return this.profiles;
+	}
+
+	public TaskManager GetTaskManager() {
+		return this.taskManager;
+	}
+
+	public DaemonManager GetDaemonManager() {
+		return this.daemonManager;
+	}
+
+	@Override
+	public EnvironmentImpl clone() throws CloneNotSupportedException {
+		// This is a static final environment, a clone would be identical.
+		return this;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/environments/StaticRuntimeEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/StaticRuntimeEnv.java
@@ -4,13 +4,9 @@ import com.laytonsmith.PureUtilities.DaemonManager;
 import com.laytonsmith.core.Profiles;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
-import com.laytonsmith.core.environments.GlobalEnv.GlobalEnvNoOpException;
 import com.laytonsmith.core.profiler.Profiler;
 import com.laytonsmith.core.taskmanager.TaskManager;
 import com.laytonsmith.persistence.PersistenceNetwork;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 
 /**
  * This environment contains 'static final' functionality and data that is available at runtime,
@@ -24,36 +20,6 @@ public class StaticRuntimeEnv implements Environment.EnvironmentImpl, Cloneable 
 	private final Profiles profiles;
 	private final TaskManager taskManager;
 	private final DaemonManager daemonManager = new DaemonManager();
-
-	/**
-	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
-	 * profiler. This value is set up for that purpose.
-	 * It is truly no-op, and no exception is thrown if a method in the interface is used.
-	 */
-	public static final Profiler NO_OP_PROFILER = Profiler.FakeProfiler();
-
-	/**
-	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
-	 * persistence network. This value is set up for that purpose.
-	 * However, it's not truly no-op, as an exception is thrown if any method in the interface are used, as this points
-	 * to a situation where something is being called that isn't compatible with a no op execution.
-	 */
-	public static final PersistenceNetwork NO_OP_PN = GetErrorNoOp(PersistenceNetwork.class, "NO_OP_PN");
-
-	/**
-	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
-	 * Profiles object. This value is set up for that purpose.
-	 * However, it's not truly no-op, as an exception is thrown if any method in the interface are used, as this points
-	 * to a situation where something is being called that isn't compatible with a no op execution.
-	 */
-	public static final Profiles NO_OP_PROFILES = GetErrorNoOp(Profiles.class, "NO_OP_PROFILES");
-
-	/**
-	 * When constructing a {@link StaticRuntimeEnv} in meta circumstances, it may be helpful to provide a no-op
-	 * profiler. This value is set up for that purpose.
-	 * It is truly no-op, and no exception is thrown if a method in the interface is used.
-	 */
-	public static final TaskManager NO_OP_TASK_MANAGER = GetNoOp(TaskManager.class);
 
 	/**
 	 * Creates a new {@link StaticRuntimeEnv}. All fields in the constructor are required, and must not be null.
@@ -71,20 +37,6 @@ public class StaticRuntimeEnv implements Environment.EnvironmentImpl, Cloneable 
 		this.persistenceNetwork = network;
 		this.profiles = profiles;
 		this.taskManager = taskManager;
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T> T GetErrorNoOp(Class<T> iface, String identifier) {
-		return (T) Proxy.newProxyInstance(StaticRuntimeEnv.class.getClassLoader(),
-				new Class[] {iface}, (Object proxy, Method method, Object[] args) -> {
-					throw new GlobalEnvNoOpException(identifier);
-				});
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T> T GetNoOp(Class<T> iface) {
-		return (T) Proxy.newProxyInstance(StaticRuntimeEnv.class.getClassLoader(),
-				new Class[] {iface}, (Object proxy, Method method, Object[] args) -> null);
 	}
 
 	public Profiler GetProfiler() {

--- a/src/main/java/com/laytonsmith/core/events/AbstractEvent.java
+++ b/src/main/java/com/laytonsmith/core/events/AbstractEvent.java
@@ -17,6 +17,7 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -124,8 +125,9 @@ public abstract class AbstractEvent implements Event, Comparable<Event> {
 			}
 		}
 		ProfilePoint event = null;
-		if(env.getEnv(GlobalEnv.class).GetProfiler() != null) {
-			event = env.getEnv(GlobalEnv.class).GetProfiler().start("Event " + b.getEventName() + " (defined at " + b.getTarget().toString() + ")", LogLevel.ERROR);
+		if(env.getEnv(StaticRuntimeEnv.class).GetProfiler() != null) {
+			event = env.getEnv(StaticRuntimeEnv.class).GetProfiler().start(
+					"Event " + b.getEventName() + " (defined at " + b.getTarget().toString() + ")", LogLevel.ERROR);
 		}
 		try {
 			try {

--- a/src/main/java/com/laytonsmith/core/events/BoundEvent.java
+++ b/src/main/java/com/laytonsmith/core/events/BoundEvent.java
@@ -12,6 +12,7 @@ import com.laytonsmith.core.constructs.IVariable;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.EventException;
 import com.laytonsmith.core.natives.interfaces.Mixed;
@@ -254,7 +255,7 @@ public class BoundEvent implements Comparable<BoundEvent> {
 			env.getEnv(GlobalEnv.class).SetEvent(activeEvent);
 			activeEvent.addHistory("Triggering bound event: " + this);
 			try {
-				ProfilePoint p = env.getEnv(GlobalEnv.class).GetProfiler().start("Executing event handler for "
+				ProfilePoint p = env.getEnv(StaticRuntimeEnv.class).GetProfiler().start("Executing event handler for "
 						+ this.getEventName() + " defined at " + this.getTarget(), LogLevel.ERROR);
 				try {
 					this.execute(env, activeEvent);

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -32,6 +32,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
@@ -1958,7 +1959,7 @@ public class ArrayHandling {
 			final CArray array = ArgumentValidation.getArray(args[0], t);
 			final CString sortType = new CString(args.length > 2 ? args[1].val() : CArray.ArraySortType.REGULAR.name(), t);
 			final CClosure callback = ArgumentValidation.getObject((args.length == 2 ? args[1] : args[2]), t, CClosure.class);
-			queue.invokeLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+			queue.invokeLater(environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 				@Override
 				public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -35,6 +35,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
@@ -1065,7 +1066,7 @@ public class Cmdline {
 			}
 
 			Runnable run = () -> {
-				environment.getEnv(GlobalEnv.class).GetDaemonManager().activateThread(null);
+				environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager().activateThread(null);
 				try {
 					final int exitCode = cmd.waitFor();
 					try {
@@ -1097,7 +1098,7 @@ public class Cmdline {
 				} catch (InterruptedException ex) {
 					throw ConfigRuntimeException.CreateUncatchableException(ex.getMessage(), t);
 				} finally {
-					environment.getEnv(GlobalEnv.class).GetDaemonManager().deactivateThread(null);
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager().deactivateThread(null);
 				}
 			};
 			if(subshell) {

--- a/src/main/java/com/laytonsmith/core/functions/EventBinding.java
+++ b/src/main/java/com/laytonsmith/core/functions/EventBinding.java
@@ -27,6 +27,7 @@ import com.laytonsmith.core.constructs.IVariableList;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.events.BoundEvent;
 import com.laytonsmith.core.events.BoundEvent.ActiveEvent;
 import com.laytonsmith.core.events.BoundEvent.Priority;
@@ -169,7 +170,7 @@ public class EventBinding {
 			if(event.addCounter()) {
 				synchronized(BIND_COUNTER) {
 					if(BIND_COUNTER.get() == 0) {
-						env.getEnv(GlobalEnv.class).GetDaemonManager().activateThread(null);
+						env.getEnv(StaticRuntimeEnv.class).GetDaemonManager().activateThread(null);
 						StaticLayer.GetConvertor().addShutdownHook(() -> {
 							synchronized(BIND_COUNTER) {
 								BIND_COUNTER.set(0);
@@ -384,7 +385,7 @@ public class EventBinding {
 				synchronized(BIND_COUNTER) {
 					BIND_COUNTER.decrementAndGet();
 					if(BIND_COUNTER.get() == 0) {
-						environment.getEnv(GlobalEnv.class).GetDaemonManager().deactivateThread(null);
+						environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager().deactivateThread(null);
 					}
 				}
 			}

--- a/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExecutionQueue.java
@@ -11,6 +11,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -65,7 +66,8 @@ public class ExecutionQueue {
 				queue = Construct.nval(args[1]);
 			}
 
-			environment.getEnv(GlobalEnv.class).GetExecutionQueue().push(environment.getEnv(GlobalEnv.class).GetDaemonManager(), queue, new Runnable() {
+			environment.getEnv(GlobalEnv.class).GetExecutionQueue().push(
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), queue, new Runnable() {
 
 				@Override
 				public void run() {
@@ -147,7 +149,8 @@ public class ExecutionQueue {
 				queue = Construct.nval(args[1]);
 			}
 
-			environment.getEnv(GlobalEnv.class).GetExecutionQueue().pushFront(environment.getEnv(GlobalEnv.class).GetDaemonManager(), queue, new Runnable() {
+			environment.getEnv(GlobalEnv.class).GetExecutionQueue().pushFront(
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), queue, new Runnable() {
 
 				@Override
 				public void run() {
@@ -425,7 +428,8 @@ public class ExecutionQueue {
 				queue = Construct.nval(args[1]);
 			}
 			final long delay = ArgumentValidation.getInt(args[0], t);
-			environment.getEnv(GlobalEnv.class).GetExecutionQueue().push(environment.getEnv(GlobalEnv.class).GetDaemonManager(), queue, new Runnable() {
+			environment.getEnv(GlobalEnv.class).GetExecutionQueue().push(
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), queue, new Runnable() {
 
 				@Override
 				public void run() {
@@ -487,7 +491,8 @@ public class ExecutionQueue {
 				queue = Construct.nval(args[1]);
 			}
 			final long delay = ArgumentValidation.getInt(args[0], t);
-			environment.getEnv(GlobalEnv.class).GetExecutionQueue().pushFront(environment.getEnv(GlobalEnv.class).GetDaemonManager(), queue, new Runnable() {
+			environment.getEnv(GlobalEnv.class).GetExecutionQueue().pushFront(
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), queue, new Runnable() {
 
 				@Override
 				public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/FileHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/FileHandling.java
@@ -88,7 +88,7 @@ public class FileHandling {
 					throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
 				}
 				String s = file_get_contents(location.getAbsolutePath());
-				s = s.replaceAll("\n|\r\n", "\n");
+				s = s.replace("\r\n", "\n");
 				return new CString(s, t);
 			} catch (Exception ex) {
 				MSLog.GetLogger().Log(MSLog.Tags.GENERAL, LogLevel.INFO, "Could not read in file while attempting to find "

--- a/src/main/java/com/laytonsmith/core/functions/FileHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/FileHandling.java
@@ -28,7 +28,7 @@ import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CRESecurityException;
@@ -82,8 +82,8 @@ public class FileHandling {
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
 			File location = Static.GetFileFromArgument(args[0].val(), env, t, null);
 			try {
-				//Verify this file is not above the craftbukkit directory (or whatever directory the user specified
-				//Cmdline mode doesn't currently have this restriction.
+				// Verify this file is not above the craftbukkit directory (or whatever directory the user specified).
+				// Cmdline mode doesn't currently have this restriction.
 				if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(location)) {
 					throw new CRESecurityException("You do not have permission to access the file '" + location + "'", t);
 				}
@@ -267,7 +267,7 @@ public class FileHandling {
 					throw new CREIOException(ex.getMessage(), t, ex);
 				}
 			}
-			queue.invokeLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+			queue.invokeLater(environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 				@Override
 				public void run() {
@@ -302,7 +302,8 @@ public class FileHandling {
 					} else {
 						cex = ObjectGenerator.GetGenerator().exception(exception, environment, t);
 					}
-					StaticLayer.GetConvertor().runOnMainThreadLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+					StaticLayer.GetConvertor().runOnMainThreadLater(
+							environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 						@Override
 						public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
+++ b/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
@@ -11,7 +11,7 @@ import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CREIncludeException;
 import com.laytonsmith.core.exceptions.CRE.CRESecurityException;
@@ -59,7 +59,7 @@ public class IncludeCache {
 		MSLog.GetLogger().Log(TAG, LogLevel.VERBOSE, "Cache does not already contain file. Compiling and caching.", t);
 		//We have to pull the file from the FS, and compile it.
 		MSLog.GetLogger().Log(TAG, LogLevel.VERBOSE, "Security check passed", t);
-		Profiler profiler = env.getEnv(GlobalEnv.class).GetProfiler();
+		Profiler profiler = env.getEnv(StaticRuntimeEnv.class).GetProfiler();
 		try {
 			if(!Static.InCmdLine(env, true) && !Security.CheckSecurity(file)) {
 				throw new CRESecurityException("The script cannot access " + file

--- a/src/main/java/com/laytonsmith/core/functions/OAuth.java
+++ b/src/main/java/com/laytonsmith/core/functions/OAuth.java
@@ -22,6 +22,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CREOAuthException;
@@ -301,19 +302,19 @@ public class OAuth {
 		}
 
 		private static boolean hasRefreshToken(Environment env, String clientId) throws DataSourceException {
-			PersistenceNetwork pn = env.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork pn = env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			return pn.hasKey(new String[]{"oauth", getFormattedClientId(clientId), "refreshToken"});
 		}
 
 		private static void storeRefreshToken(Environment env, String clientId, String refreshToken) throws DataSourceException, ReadOnlyException, IOException {
-			PersistenceNetwork pn = env.getEnv(GlobalEnv.class).GetPersistenceNetwork();
-			DaemonManager dm = env.getEnv(GlobalEnv.class).GetDaemonManager();
+			PersistenceNetwork pn = env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
+			DaemonManager dm = env.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
 			pn.set(dm, new String[]{"oauth", getFormattedClientId(clientId), "refreshToken"}, formatValue(refreshToken));
 		}
 
 		private static void storeAccessToken(Environment env, String clientId, AccessToken token) throws DataSourceException, ReadOnlyException, IOException {
-			PersistenceNetwork pn = env.getEnv(GlobalEnv.class).GetPersistenceNetwork();
-			DaemonManager dm = env.getEnv(GlobalEnv.class).GetDaemonManager();
+			PersistenceNetwork pn = env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
+			DaemonManager dm = env.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
 			pn.set(dm, new String[]{"oauth", getFormattedClientId(clientId), "accessToken"},
 					formatValue(token.getExpiry().getTime() + "," + token.getAccessToken()));
 		}
@@ -325,7 +326,7 @@ public class OAuth {
 		 * @return
 		 */
 		private String getAccessToken(Environment env, String clientId) throws DataSourceException {
-			PersistenceNetwork pn = env.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork pn = env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			AccessToken aT = null;
 			String aTS = pn.get(new String[]{"oauth", getFormattedClientId(clientId), "accessToken"});
 			if(aTS != null) {
@@ -346,7 +347,7 @@ public class OAuth {
 		}
 
 		private static String getRefreshToken(Environment env, String clientId) throws DataSourceException {
-			PersistenceNetwork pn = env.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork pn = env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			String v = pn.get(new String[]{"oauth", getFormattedClientId(clientId), "refreshToken"});
 			if(v == null) {
 				return v;
@@ -522,12 +523,12 @@ public class OAuth {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			PersistenceNetwork pn = environment.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork pn = environment.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			String namespace = "oauth";
 			if(args.length >= 1) {
 				namespace += "." + x_get_oauth_token.getFormattedClientId(args[0].val());
 			}
-			DaemonManager dm = environment.getEnv(GlobalEnv.class).GetDaemonManager();
+			DaemonManager dm = environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
 			try {
 				Map<String[], String> list = pn.getNamespace(namespace.split("\\."));
 				for(String[] key : list.keySet()) {

--- a/src/main/java/com/laytonsmith/core/functions/Persistence.java
+++ b/src/main/java/com/laytonsmith/core/functions/Persistence.java
@@ -17,6 +17,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CREInsufficientArgumentsException;
@@ -113,7 +114,8 @@ public class Persistence {
 			}
 			MSLog.GetLogger().Log(MSLog.Tags.PERSISTENCE, LogLevel.DEBUG, "Storing: " + key + " -> " + value, t);
 			try {
-				env.getEnv(GlobalEnv.class).GetPersistenceNetwork().set(env.getEnv(GlobalEnv.class).GetDaemonManager(), ("storage." + key).split("\\."), value);
+				env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork().set(
+						env.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), ("storage." + key).split("\\."), value);
 			} catch (IllegalArgumentException e) {
 				throw new CREFormatException(e.getMessage(), t);
 			} catch (Exception ex) {
@@ -179,7 +181,8 @@ public class Persistence {
 			try {
 				Object obj;
 				try {
-					obj = env.getEnv(GlobalEnv.class).GetPersistenceNetwork().get(("storage." + namespace).split("\\."));
+					obj = env.getEnv(StaticRuntimeEnv.class)
+							.GetPersistenceNetwork().get(("storage." + namespace).split("\\."));
 				} catch (DataSourceException ex) {
 					throw new CREIOException(ex.getMessage(), t, ex);
 				} catch (IllegalArgumentException e) {
@@ -262,7 +265,7 @@ public class Persistence {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			PersistenceNetwork p = environment.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork p = environment.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			List<String> keyChain = new ArrayList<String>();
 			keyChain.add("storage");
 			String namespace = GetNamespace(args, null, getName(), t);
@@ -344,7 +347,8 @@ public class Persistence {
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws ConfigRuntimeException {
 			try {
-				return CBoolean.get(env.getEnv(GlobalEnv.class).GetPersistenceNetwork().hasKey(("storage." + GetNamespace(args, null, getName(), t)).split("\\.")));
+				return CBoolean.get(env.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork()
+						.hasKey(("storage." + GetNamespace(args, null, getName(), t)).split("\\.")));
 			} catch (DataSourceException ex) {
 				throw new CREIOException(ex.getMessage(), t, ex);
 			} catch (IllegalArgumentException e) {
@@ -403,7 +407,9 @@ public class Persistence {
 			String namespace = GetNamespace(args, null, getName(), t);
 			MSLog.GetLogger().Log(MSLog.Tags.PERSISTENCE, LogLevel.DEBUG, "Clearing value: " + namespace, t);
 			try {
-				environment.getEnv(GlobalEnv.class).GetPersistenceNetwork().clearKey(environment.getEnv(GlobalEnv.class).GetDaemonManager(), ("storage." + namespace).split("\\."));
+				environment.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork().clearKey(
+						environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(),
+						("storage." + namespace).split("\\."));
 			} catch (DataSourceException | ReadOnlyException | IOException ex) {
 				throw new CREIOException(ex.getMessage(), t, ex);
 			} catch (IllegalArgumentException e) {

--- a/src/main/java/com/laytonsmith/core/functions/Reflection.java
+++ b/src/main/java/com/laytonsmith/core/functions/Reflection.java
@@ -33,6 +33,7 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.events.Event;
 import com.laytonsmith.core.events.EventList;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
@@ -756,7 +757,7 @@ public class Reflection {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			PersistenceNetwork pn = environment.getEnv(GlobalEnv.class).GetPersistenceNetwork();
+			PersistenceNetwork pn = environment.getEnv(StaticRuntimeEnv.class).GetPersistenceNetwork();
 			return new CString(pn.getKeySource(args[0].val().split("\\.")).toString(), t);
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/SQL.java
+++ b/src/main/java/com/laytonsmith/core/functions/SQL.java
@@ -29,7 +29,7 @@ import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.Profiles;
@@ -158,7 +158,7 @@ public class SQL {
 					}
 					profile = ProfilesImpl.getProfile(data);
 				} else {
-					Profiles profiles = environment.getEnv(GlobalEnv.class).getProfiles();
+					Profiles profiles = environment.getEnv(StaticRuntimeEnv.class).getProfiles();
 					profile = profiles.getProfileById(args[0].val());
 				}
 				if(!(profile instanceof SQLProfile)) {
@@ -491,7 +491,7 @@ public class SQL {
 			final Mixed[] newArgs = new Mixed[args.length - 1];
 			//Make a new array minus the closure
 			System.arraycopy(args, 0, newArgs, 0, newArgs.length);
-			queue.invokeLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+			queue.invokeLater(environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 				@Override
 				public void run() {
@@ -504,7 +504,8 @@ public class SQL {
 					}
 					final Mixed cret = returnValue;
 					final Mixed cex = exception;
-					StaticLayer.GetConvertor().runOnMainThreadLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+					StaticLayer.GetConvertor().runOnMainThreadLater(
+							environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 						@Override
 						public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/TaskHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/TaskHandling.java
@@ -11,7 +11,7 @@ import com.laytonsmith.core.constructs.CInt;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -51,7 +51,7 @@ public class TaskHandling {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			TaskManager tm = environment.getEnv(GlobalEnv.class).GetTaskManager();
+			TaskManager tm = environment.getEnv(StaticRuntimeEnv.class).GetTaskManager();
 			CArray ret = new CArray(t);
 			for(TaskHandler task : tm.getTasks()) {
 				CArray tt = CArray.GetAssociativeArray(t);
@@ -137,7 +137,7 @@ public class TaskHandling {
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String type = args[0].val();
 			int id = ArgumentValidation.getInt32(args[1], t);
-			TaskManager tm = environment.getEnv(GlobalEnv.class).GetTaskManager();
+			TaskManager tm = environment.getEnv(StaticRuntimeEnv.class).GetTaskManager();
 			tm.killTask(type, id);
 			return CVoid.VOID;
 		}

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -21,7 +21,7 @@ import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
 import com.laytonsmith.core.exceptions.CRE.CREInterruptedException;
@@ -85,7 +85,7 @@ public class Threading {
 
 				@Override
 				public void run() {
-					DaemonManager dm = environment.getEnv(GlobalEnv.class).GetDaemonManager();
+					DaemonManager dm = environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
 					dm.activateThread(Thread.currentThread());
 					try {
 						closure.executeCallable();
@@ -226,7 +226,8 @@ public class Threading {
 		@Override
 		public Mixed exec(final Target t, final Environment environment, Mixed... args) throws ConfigRuntimeException {
 			final CClosure closure = ArgumentValidation.getObject(args[0], t, CClosure.class);
-			StaticLayer.GetConvertor().runOnMainThreadLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+			StaticLayer.GetConvertor().runOnMainThreadLater(
+					environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 				@Override
 				public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/Web.java
+++ b/src/main/java/com/laytonsmith/core/functions/Web.java
@@ -38,6 +38,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
@@ -447,7 +448,7 @@ public class Web {
 
 			List<ConfigRuntimeException.StackTraceElement> st
 					= environment.getEnv(GlobalEnv.class).GetStackTraceManager().getCurrentStackTrace();
-			environment.getEnv(GlobalEnv.class).GetDaemonManager().activateThread(null);
+			environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager().activateThread(null);
 			Runnable task = new Runnable() {
 
 				@Override
@@ -482,7 +483,8 @@ public class Web {
 						if(arrayJar != null) {
 							getCookieJar(arrayJar, settings.getCookieJar(), t);
 						}
-						StaticLayer.GetConvertor().runOnMainThreadLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+						StaticLayer.GetConvertor().runOnMainThreadLater(
+								environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 
 							@Override
 							public void run() {
@@ -494,7 +496,8 @@ public class Web {
 							+ e.getMessage(), t);
 						ex.setStackTraceElements(st);
 						if(error != null) {
-							StaticLayer.GetConvertor().runOnMainThreadLater(environment.getEnv(GlobalEnv.class).GetDaemonManager(), new Runnable() {
+							StaticLayer.GetConvertor().runOnMainThreadLater(
+									environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager(), new Runnable() {
 								@Override
 								public void run() {
 									executeFinish(error, ObjectGenerator.GetGenerator().exception(ex, environment, t), t, environment);
@@ -506,7 +509,7 @@ public class Web {
 					} catch (Exception e) {
 						e.printStackTrace();
 					} finally {
-						environment.getEnv(GlobalEnv.class).GetDaemonManager().deactivateThread(null);
+						environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager().deactivateThread(null);
 					}
 				}
 			};
@@ -809,7 +812,7 @@ public class Web {
 				options = CArray.GetAssociativeArray(t);
 				Profiles.Profile p;
 				try {
-					p = environment.getEnv(GlobalEnv.class).getProfiles().getProfileById(profileName);
+					p = environment.getEnv(StaticRuntimeEnv.class).getProfiles().getProfileById(profileName);
 				} catch (Profiles.InvalidProfileException ex) {
 					throw new CREFormatException(ex.getMessage(), t, ex);
 				}

--- a/src/main/java/com/laytonsmith/tools/Interpreter.java
+++ b/src/main/java/com/laytonsmith/tools/Interpreter.java
@@ -76,6 +76,7 @@ import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.InvalidEnvironmentException;
 import com.laytonsmith.core.environments.RuntimeMode;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
 import com.laytonsmith.core.events.drivers.CmdlineEvents;
@@ -369,7 +370,7 @@ public final class Interpreter {
 					if(scriptThread != null) {
 						scriptThread.interrupt();
 					}
-					for(Thread t : env.getEnv(GlobalEnv.class).GetDaemonManager().getActiveThreads()) {
+					for(Thread t : env.getEnv(StaticRuntimeEnv.class).GetDaemonManager().getActiveThreads()) {
 						t.interrupt();
 					}
 				} else {
@@ -774,7 +775,7 @@ public final class Interpreter {
 					+ ");";
 		}
 		isExecuting = true;
-		ProfilePoint compile = env.getEnv(GlobalEnv.class).GetProfiler().start("Compilation", LogLevel.VERBOSE);
+		ProfilePoint compile = env.getEnv(StaticRuntimeEnv.class).GetProfiler().start("Compilation", LogLevel.VERBOSE);
 		final ParseTree tree;
 		try {
 			TokenStream stream = MethodScriptCompiler.lex(script, env, fromFile, true);
@@ -819,7 +820,8 @@ public final class Interpreter {
 					Target.UNKNOWN));
 		}
 		try {
-			ProfilePoint p = this.env.getEnv(GlobalEnv.class).GetProfiler().start("Interpreter Script", LogLevel.ERROR);
+			ProfilePoint p = this.env.getEnv(StaticRuntimeEnv.class)
+					.GetProfiler().start("Interpreter Script", LogLevel.ERROR);
 			try {
 				final MutableObject<Throwable> wasThrown = new MutableObject<>();
 				scriptThread = new Thread(new Runnable() {
@@ -835,13 +837,13 @@ public final class Interpreter {
 									}
 								}
 							}, null, vars);
-							env.getEnv(GlobalEnv.class).GetDaemonManager().waitForThreads();
+							env.getEnv(StaticRuntimeEnv.class).GetDaemonManager().waitForThreads();
 						} catch (CancelCommandException | InterruptedException e) {
 							// Nothing, though we could have been Ctrl+C cancelled, so we need to reset
 							// the interrupt flag. But we do that unconditionally below, in the finally,
 							// in the other thread.
 							// However, interrupt all the underlying threads
-							for(Thread t : env.getEnv(GlobalEnv.class).GetDaemonManager().getActiveThreads()) {
+							for(Thread t : env.getEnv(StaticRuntimeEnv.class).GetDaemonManager().getActiveThreads()) {
 								t.interrupt();
 							}
 						} catch (ConfigRuntimeException e) {

--- a/src/main/java/com/laytonsmith/tools/MSLPMaker.java
+++ b/src/main/java/com/laytonsmith/tools/MSLPMaker.java
@@ -75,7 +75,7 @@ public class MSLPMaker {
 				}
 				for(Script s : tempScripts) {
 					try {
-						s.compile(env);
+						s.compile(env.clone());
 						s.checkAmbiguous(allScripts);
 						allScripts.add(s);
 					} catch (ConfigCompileException e) {
@@ -84,6 +84,8 @@ public class MSLPMaker {
 					} catch (ConfigCompileGroupException e) {
 						error = true;
 						ConfigRuntimeException.HandleUncaughtException(e, "Compile errors in script. Compilation will attempt to continue, however.", null);
+					} catch (CloneNotSupportedException e) {
+						throw new Error("Environment wasn't clonable, while it should be.", e);
 					}
 				}
 			} catch (ConfigCompileException e) {

--- a/src/main/java/com/laytonsmith/tools/MSLPMaker.java
+++ b/src/main/java/com/laytonsmith/tools/MSLPMaker.java
@@ -9,13 +9,18 @@ import static com.laytonsmith.PureUtilities.TermColors.reset;
 import com.laytonsmith.PureUtilities.ZipMaker;
 import com.laytonsmith.core.AliasCore;
 import com.laytonsmith.core.MethodScriptCompiler;
+import com.laytonsmith.core.Profiles;
 import com.laytonsmith.core.Script;
+import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.persistence.DataSourceException;
+
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -62,9 +67,15 @@ public class MSLPMaker {
 			List<Script> tempScripts;
 			try {
 				tempScripts = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(fi.contents(), null, fi.file(), false), envs);
+				Environment env;
+				try {
+					env = Static.GenerateStandaloneEnvironment();
+				} catch (IOException | DataSourceException | URISyntaxException | Profiles.InvalidProfileException ex) {
+					throw new RuntimeException(ex);
+				}
 				for(Script s : tempScripts) {
 					try {
-						s.compile();
+						s.compile(env);
 						s.checkAmbiguous(allScripts);
 						allScripts.add(s);
 					} catch (ConfigCompileException e) {

--- a/src/main/java/com/laytonsmith/tools/docgen/localization/LocalizationUI.java
+++ b/src/main/java/com/laytonsmith/tools/docgen/localization/LocalizationUI.java
@@ -19,6 +19,7 @@ import com.laytonsmith.core.ProfilesImpl;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.functions.OAuth;
 import com.laytonsmith.core.profiler.Profiler;
 import com.laytonsmith.core.taskmanager.TaskManagerImpl;
@@ -76,6 +77,7 @@ public final class LocalizationUI extends javax.swing.JFrame {
 	private String storedLocation = null;
 	private final DaemonManager dm = new DaemonManager();
 	private GlobalEnv gEnv;
+	private StaticRuntimeEnv staticRuntimeEnv;
 
 	private List<TranslationMemory> currentSegments;
 	private TranslationMemory currentMemory;
@@ -1346,17 +1348,16 @@ public final class LocalizationUI extends javax.swing.JFrame {
 
 		try {
 			Static.GenerateStandaloneEnvironment(true);
-			pn = getPersistenceNetwork(MethodScriptFileLocations.getDefault().getPersistenceConfig());
-			if(pn != null) {
-				storedLocation = pn.get(new String[]{"l10n", "lastLoadedDb"});
-				azureKey = pn.get(new String[]{"l10n", "azureKey"});
+			this.pn = getPersistenceNetwork(MethodScriptFileLocations.getDefault().getPersistenceConfig());
+			if(this.pn != null) {
+				storedLocation = this.pn.get(new String[]{"l10n", "lastLoadedDb"});
+				azureKey = this.pn.get(new String[]{"l10n", "azureKey"});
 			}
-			gEnv = new GlobalEnv(new MethodScriptExecutionQueue("L10N-UI", "default"),
-					new Profiler(CommandHelperFileLocations.getDefault().getProfilerConfigFile()),
-					pn,
-					MethodScriptFileLocations.getDefault().getTempDir(),
-					new ProfilesImpl(MethodScriptFileLocations.getDefault().getProfilesFile()),
-					new TaskManagerImpl(), EnumSet.of(RuntimeMode.CMDLINE));
+			this.gEnv = new GlobalEnv(new MethodScriptExecutionQueue("L10N-UI", "default"),
+					MethodScriptFileLocations.getDefault().getTempDir(), EnumSet.of(RuntimeMode.CMDLINE));
+			this.staticRuntimeEnv = new StaticRuntimeEnv(
+					new Profiler(CommandHelperFileLocations.getDefault().getProfilerConfigFile()), this.pn,
+					new ProfilesImpl(MethodScriptFileLocations.getDefault().getProfilesFile()), new TaskManagerImpl());
 		} catch(URISyntaxException | IOException | DataSourceException | Profiles.InvalidProfileException ex) {
 			showError("Could not load Persistence Database! " + ex.getMessage());
 		}

--- a/src/main/java/com/laytonsmith/tools/langserv/LangServ.java
+++ b/src/main/java/com/laytonsmith/tools/langserv/LangServ.java
@@ -680,9 +680,10 @@ public class LangServ implements LanguageServer, LanguageClientAware, TextDocume
 					if(f.getName().endsWith(".msa")) {
 						tokens = MethodScriptCompiler.lex(code, env, f, false);
 						fTree = new ParseTree(null);
+						final Environment finalEnv = env;
 						MethodScriptCompiler.preprocess(tokens, envs).forEach((script) -> {
 							try {
-								script.compile();
+								script.compile(finalEnv);
 							} catch (ConfigCompileException ex) {
 								exceptions.add(ex);
 							} catch (ConfigCompileGroupException ex) {

--- a/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
+++ b/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
@@ -117,31 +117,31 @@ public class MethodScriptCompilerTest {
 	@Test
 	public void testCompile() throws Exception {
 		MethodScriptCompiler.preprocess(
-				MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function')", null, null, false), envs).get(0).compileRight();
+				MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function')", null, null, false), envs).get(0).compileRight(env);
 		try {
 			//extra parameter
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another', 'oops') 'function')", null, null, false), envs).get(0).compileRight();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another', 'oops') 'function')", null, null, false), envs).get(0).compileRight(env);
 			fail("Did not expect test to pass");
 		} catch (ConfigCompileException e) {
 			//passed
 		}
 		try {
 			//missing parenthesis
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function'", null, null, false), envs).get(0).compileRight();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function'", null, null, false), envs).get(0).compileRight(env);
 			fail("Did not expect test to pass");
 		} catch (ConfigCompileException e) {
 			//passed
 		}
 		try {
 			//extra parenthesis
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function')))))", null, null, false), envs).get(0).compileRight();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function')))))", null, null, false), envs).get(0).compileRight(env);
 			fail("Did not expect test to pass");
 		} catch (ConfigCompileException e) {
 			//passed
 		}
 		try {
 			//extra multiline end construct
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function') <<<", null, null, false), envs).get(0).compileRight();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = msg('this is a string', if(true, 'and', 'another') 'function') <<<", null, null, false), envs).get(0).compileRight(env);
 			fail("Did not expect test to pass");
 		} catch (ConfigCompileException e) {
 			//passed
@@ -149,7 +149,7 @@ public class MethodScriptCompilerTest {
 
 		try {
 			//no multiline end construct
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = >>>\nmsg('hi')\n", null, null, false), envs).get(0).compileRight();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("/cmd = >>>\nmsg('hi')\n", null, null, false), envs).get(0).compileRight(env);
 			fail("Did not expect no multiline end construct to pass");
 		} catch (ConfigCompileException e) {
 			//passed
@@ -161,9 +161,9 @@ public class MethodScriptCompilerTest {
 
 	@Test
 	public void testLabel() throws Exception {
-		assertEquals(Static.GLOBAL_PERMISSION, MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("*:/cmd = die()", null, null, false), envs).get(0).compile().getLabel());
-		assertEquals(Static.GLOBAL_PERMISSION, MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("* : /cmd = die()", null, null, false), envs).get(0).compile().getLabel());
-		assertEquals("~lol/fun", MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("~lol/fun: /cmd = die()", null, null, false), envs).get(0).compile().getLabel());
+		assertEquals(Static.GLOBAL_PERMISSION, MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("*:/cmd = die()", null, null, false), envs).get(0).compile(env).getLabel());
+		assertEquals(Static.GLOBAL_PERMISSION, MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("* : /cmd = die()", null, null, false), envs).get(0).compile(env).getLabel());
+		assertEquals("~lol/fun", MethodScriptCompiler.preprocess(MethodScriptCompiler.lex("~lol/fun: /cmd = die()", null, null, false), envs).get(0).compile(env).getLabel());
 	}
 
 	@Test
@@ -432,7 +432,7 @@ public class MethodScriptCompilerTest {
 	public void testCompile1() {
 		try {
 			String config = "/cmd [$p] $q = msg('')";
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0).compile();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0).compile(env);
 			fail("Test passed, but wasn't supposed to");
 		} catch (ConfigCompileException | ConfigCompileGroupException ex) {
 			//Passed
@@ -448,7 +448,7 @@ public class MethodScriptCompilerTest {
 //		assertEquals(ac, CommandHelperPlugin.getCore());
 //		String config = "//cmd blah = msg('success')";
 //		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, false)).get(0);
-//		s.compile();
+//		s.compile(env);
 //		env.getEnv(CommandHelperEnvironment.class).SetPlayer(fakePlayer);
 //		s.run(Arrays.asList(new Variable("$var", "hello", Target.UNKNOWN)), env, null);
 //		verify(fakePlayer).sendMessage("success");
@@ -466,10 +466,10 @@ public class MethodScriptCompilerTest {
 //				+ "/cmd2 = msg('success')";
 //		env.getEnv(CommandHelperEnvironment.class).SetPlayer(fakePlayer);
 //		Script s1 = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, false)).get(0);
-//		s1.compile();
+//		s1.compile(env);
 //		s1.run(Arrays.asList(new Variable("$var", "hello", Target.UNKNOWN)), env, null);
 //		Script s2 = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, false)).get(1);
-//		s2.compile();
+//		s2.compile(env);
 //		s2.run(Arrays.asList(new Variable("$var", "hello", Target.UNKNOWN)), env, null);
 //		verify(fakePlayer, times(2)).sendMessage("success");
 //	}
@@ -477,7 +477,7 @@ public class MethodScriptCompilerTest {
 	public void testCompile2() {
 		try {
 			String config = "/cmd [$p=player()] = msg('')";
-			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0).compile();
+			MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0).compile(env);
 			fail("Test passed, but wasn't supposed to");
 		} catch (ConfigCompileException | ConfigCompileGroupException ex) {
 			//Passed
@@ -498,7 +498,7 @@ public class MethodScriptCompilerTest {
 				+ "msg('hello') #This is a comment too invalid()'\"'' function\n"
 				+ "<<<";
 		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0);
-		s.compile();
+		s.compile(env);
 		assertEquals("label", s.getLabel());
 	}
 
@@ -531,7 +531,7 @@ public class MethodScriptCompilerTest {
 //		RunVars(Arrays.asList(new Variable[]{new Variable("$one", "first", false, false, Target.UNKNOWN),
 //			new Variable("$", "several variables", false, true, Target.UNKNOWN)}), config, fakePlayer);
 //		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null), env).get(0);
-//		s.compile();
+//		s.compile(env);
 //		s.run(Arrays.asList(new Variable[]{new Variable("$one", "first", false, false, Target.UNKNOWN),
 //			new Variable("$", "several variables", false, true, Target.UNKNOWN)}), env, null);
 //		verify(fakePlayer).sendMessage("first");
@@ -544,7 +544,7 @@ public class MethodScriptCompilerTest {
 //				+ "msg($var)"
 //				+ "<<<";
 //		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null), env).get(0);
-//		s.compile();
+//		s.compile(env);
 //		assertTrue(s.match("/test 2"));
 //		s.run(Arrays.asList(new Variable[]{new Variable("$var", "2", true, false, Target.UNKNOWN)}), env, null);
 //		verify(fakePlayer).sendMessage("2");
@@ -558,7 +558,7 @@ public class MethodScriptCompilerTest {
 				+ "msg($var)"
 				+ "<<<";
 		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0);
-		s.compile();
+		s.compile(env);
 		assertTrue(s.match("/test 2"));
 		assertFalse(s.match("/test"));
 		s.run(Arrays.asList(new Variable[]{new Variable("$var", "2", true, false, Target.UNKNOWN)}), env, null);
@@ -576,7 +576,7 @@ public class MethodScriptCompilerTest {
 //				+ "msg($var)\n"
 //				+ "<<<";
 //		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null), env).get(0);
-//		s.compile();
+//		s.compile(env);
 //		assertEquals("safe", s.getLabel());
 //		assertTrue(s.match("/test 2"));
 //		s.run(Arrays.asList(new Variable[]{new Variable("$var", "2", true, false, Target.UNKNOWN)}), env, null);
@@ -588,7 +588,7 @@ public class MethodScriptCompilerTest {
 		String config = "/*/one = bad()*/\n"
 				+ "/two = msg('Good')\n";
 		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0);
-		s.compile();
+		s.compile(env);
 		assertFalse(s.match("/one"));
 		assertTrue(s.match("/two"));
 	}
@@ -597,7 +597,7 @@ public class MethodScriptCompilerTest {
 	public void testSmartCommentBeforeCommand() throws Exception {
 		String config = "/** sc */\n/cmd = msg('');";
 		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0);
-		s.compile();
+		s.compile(env);
 		assertTrue(s.match("/cmd"));
 	}
 
@@ -1074,8 +1074,8 @@ public class MethodScriptCompilerTest {
 					MethodScriptCompiler.lex(cmd1 + "\n" + cmd2, null, null, false), envs);
 			s1 = scripts.get(0);
 			s2 = scripts.get(1);
-			s1.compile();
-			s2.compile();
+			s1.compile(env);
+			s2.compile(env);
 		} catch (ConfigCompileGroupException | ConfigCompileException | IndexOutOfBoundsException e) {
 			fail("Encountered unexpected " + e.getClass().getSimpleName() + " with message: " + e.getMessage());
 			return;

--- a/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
+++ b/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
@@ -11,6 +11,7 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.testing.StaticTest;
 import java.io.File;
@@ -50,9 +51,9 @@ public class ObjectDefinitionTableTest {
 	public void Before() {
 		StaticTest.InstallFakeServerFrontend();
 		env = Environment.createEnvironment(new CompilerEnvironment(),
-			new GlobalEnv(GlobalEnv.NO_OP_EXECUTION_QUEUE, GlobalEnv.NO_OP_PROFILER, GlobalEnv.NO_OP_PN,
-					new File("."), GlobalEnv.NO_OP_PROFILES, GlobalEnv.NO_OP_TASK_MANAGER,
-					EnumSet.of(RuntimeMode.CMDLINE)));
+			new GlobalEnv(GlobalEnv.NO_OP_EXECUTION_QUEUE, new File("."), EnumSet.of(RuntimeMode.CMDLINE)),
+			new StaticRuntimeEnv(StaticRuntimeEnv.NO_OP_PROFILER,
+					StaticRuntimeEnv.NO_OP_PN, StaticRuntimeEnv.NO_OP_PROFILES, StaticRuntimeEnv.NO_OP_TASK_MANAGER));
 	}
 
 	@Test

--- a/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
+++ b/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
@@ -1,7 +1,9 @@
 package com.laytonsmith.core.objects;
 
+import com.laytonsmith.PureUtilities.ExecutionQueue;
 import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.MethodScriptCompiler;
+import com.laytonsmith.core.Profiles;
 import com.laytonsmith.core.compiler.CompilerEnvironment;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CPrimitive;
@@ -13,6 +15,9 @@ import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
 import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.core.profiler.Profiler;
+import com.laytonsmith.core.taskmanager.TaskManager;
+import com.laytonsmith.persistence.PersistenceNetwork;
 import com.laytonsmith.testing.StaticTest;
 import java.io.File;
 import java.util.ArrayList;
@@ -21,6 +26,8 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
+import org.mockito.Mockito;
+
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -50,10 +57,21 @@ public class ObjectDefinitionTableTest {
 	@Before
 	public void Before() {
 		StaticTest.InstallFakeServerFrontend();
+
+		ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class, (invocation) -> {
+			throw new AssertionError("Interaction with the execution queue is not supported in this test.");
+		});
+		PersistenceNetwork persistenceNetwork = Mockito.mock(PersistenceNetwork.class, (invocation) -> {
+			throw new AssertionError("Interaction with the persistence network is not supported in this test.");
+		});
+		Profiles profiles = Mockito.mock(Profiles.class, (invocation) -> {
+			throw new AssertionError("Interaction with profiles is not supported in this test.");
+		});
+		TaskManager taskManager = Mockito.mock(TaskManager.class);
+
 		env = Environment.createEnvironment(new CompilerEnvironment(),
-			new GlobalEnv(GlobalEnv.NO_OP_EXECUTION_QUEUE, new File("."), EnumSet.of(RuntimeMode.CMDLINE)),
-			new StaticRuntimeEnv(StaticRuntimeEnv.NO_OP_PROFILER,
-					StaticRuntimeEnv.NO_OP_PN, StaticRuntimeEnv.NO_OP_PROFILES, StaticRuntimeEnv.NO_OP_TASK_MANAGER));
+			new GlobalEnv(executionQueue, new File("."), EnumSet.of(RuntimeMode.CMDLINE)),
+			new StaticRuntimeEnv(Profiler.FakeProfiler(), persistenceNetwork, profiles, taskManager));
 	}
 
 	@Test

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -546,7 +546,7 @@ public class StaticTest {
 		env.getEnv(CommandHelperEnvironment.class).SetCommandSender(player);
 		List<Script> scripts = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(combinedScript, env, null, false), env.getEnvClasses());
 		for(Script s : scripts) {
-			s.compile();
+			s.compile(env);
 			if(s.match(command)) {
 				s.run(s.getVariables(command), env, null);
 			}


### PR DESCRIPTION
This is an optimization which uses the same environment to compile multiple msa scripts, rather than creating a new environment every time. Environment creation reads and parses a few files, so this is an expensive operation.