### PR TITLE
Allow keywords to be part of other syntax

### DIFF
--- a/src/main/java/com/laytonsmith/core/compiler/CompilerEnvironment.java
+++ b/src/main/java/com/laytonsmith/core/compiler/CompilerEnvironment.java
@@ -8,6 +8,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.environments.Environment.EnvironmentImpl;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.objects.ObjectDefinitionTable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,6 +54,13 @@ public class CompilerEnvironment implements Environment.EnvironmentImpl {
 	private final ObjectDefinitionTable objectDefinitionTable = ObjectDefinitionTable.GetBlankInstance();
 
 	private final List<CompilerWarning> compilerWarnings = new ArrayList<>();
+
+	/**
+	 * When keyword processing causes a compile error, it is stored by Target in this map. If the keyword is still
+	 * present after parsing is fully completed, we know that the keyword is not part of some other syntax and the
+	 * exception from this map can be thrown after all.
+	 */
+	public final Map<Target, ConfigCompileException> potentialKeywordCompileErrors = new HashMap<>();
 
 	private boolean logCompilerWarnings = true;
 

--- a/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
+++ b/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Static;
+import com.laytonsmith.core.compiler.CompilerEnvironment;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.CKeyword;
@@ -393,7 +394,12 @@ public class StaticAnalysis {
 		} else if(node instanceof Variable) {
 			return CString.TYPE; // $vars can only be strings.
 		} else if(node instanceof CKeyword) {
-			exceptions.add(new ConfigCompileException("Unexpected keyword: " + node.val(), node.getTarget()));
+
+			// Use the more specific compile error caused during keyword processing if available.
+			ConfigCompileException ex =
+					env.getEnv(CompilerEnvironment.class).potentialKeywordCompileErrors.get(node.getTarget());
+			exceptions.add(ex != null ? ex
+					: new ConfigCompileException("Unexpected keyword: " + node.val(), node.getTarget()));
 			return CClassType.AUTO;
 		} else if(node instanceof CLabel) {
 			exceptions.add(new ConfigCompileException(

--- a/src/main/java/com/laytonsmith/core/compiler/keywords/IfKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/keywords/IfKeyword.java
@@ -39,7 +39,6 @@ public class IfKeyword extends Keyword {
 						// It is, convert this into an ifelse
 						ParseTree newNode = new ParseTree(new CFunction(IFELSE, t), node.getFileOptions());
 						newNode.setChildren(node.getChildren());
-						list.set(keywordPosition, newNode);
 						node = newNode;
 					}
 				} catch (IndexOutOfBoundsException ex) {
@@ -94,6 +93,10 @@ public class IfKeyword extends Keyword {
 				}
 			}
 		}
+
+		// Set the new node, which might have changed to 'ifelse()'.
+		list.set(keywordPosition, node);
+
 		return keywordPosition;
 	}
 

--- a/src/main/java/com/laytonsmith/core/exceptions/AbstractCompileException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/AbstractCompileException.java
@@ -1,0 +1,24 @@
+package com.laytonsmith.core.exceptions;
+
+/**
+ * This abstract {@link Exception} should be used as super class for exceptions that are thrown to indicate that
+ * compilation has failed.
+ */
+@SuppressWarnings("serial")
+public abstract class AbstractCompileException extends Exception {
+
+	public AbstractCompileException() {
+	}
+
+	public AbstractCompileException(String message) {
+		super(message);
+	}
+
+	public AbstractCompileException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AbstractCompileException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/laytonsmith/core/exceptions/ConfigCompileException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/ConfigCompileException.java
@@ -5,10 +5,10 @@ import java.io.File;
 import java.util.Objects;
 
 /**
- *
- *
+ * This {@link Exception} can be thrown when a problem occurs during compilation.
  */
-public class ConfigCompileException extends Exception implements Comparable<ConfigCompileException> {
+@SuppressWarnings("serial")
+public class ConfigCompileException extends AbstractCompileException implements Comparable<ConfigCompileException> {
 
 	final String message;
 	final int lineNum;
@@ -40,28 +40,28 @@ public class ConfigCompileException extends Exception implements Comparable<Conf
 
 	@Override
 	public String getMessage() {
-		return message;
+		return this.message;
 	}
 
 	public String getLineNum() {
-		return Integer.toString(lineNum);
+		return Integer.toString(this.lineNum);
 	}
 
 	public int getColumn() {
-		return col;
+		return this.col;
 	}
 
 	public Target getTarget() {
-		return t;
+		return this.t;
 	}
 
 	@Override
 	public String toString() {
-		if(lineNum != 0) {
-			return "Configuration Compile Exception: " + message + " near line " + lineNum + ". Please "
+		if(this.lineNum != 0) {
+			return "Configuration Compile Exception: " + this.message + " near line " + lineNum + ". Please "
 					+ "check your code and try again. " + (file != null ? "(" + file.getAbsolutePath() + ")" : "");
 		} else {
-			return "Configuration Compile Exception: " + message + ". Please check your code and try again. "
+			return "Configuration Compile Exception: " + this.message + ". Please check your code and try again. "
 					+ (file != null ? "(" + file.getAbsolutePath() + ")" : "");
 		}
 	}

--- a/src/main/java/com/laytonsmith/core/exceptions/ConfigCompileGroupException.java
+++ b/src/main/java/com/laytonsmith/core/exceptions/ConfigCompileGroupException.java
@@ -4,17 +4,20 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- *
+ * This {@link Exception} can be used to bundle multiple {@link ConfigCompileException}s together for cases were
+ * multiple compile exceptions have occurred during compilation.
  */
-public class ConfigCompileGroupException extends Exception {
+@SuppressWarnings("serial")
+public class ConfigCompileGroupException extends AbstractCompileException {
 
 	private final Set<ConfigCompileException> list;
 
 	public ConfigCompileGroupException(Set<ConfigCompileException> group) {
+		super();
 		this.list = new TreeSet<>(group);
 	}
 
 	public Set<ConfigCompileException> getList() {
-		return new TreeSet<>(list);
+		return new TreeSet<>(this.list);
 	}
 }

--- a/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
+++ b/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
@@ -8,6 +8,7 @@ import com.laytonsmith.core.constructs.Variable;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
+import com.laytonsmith.core.exceptions.AbstractCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
@@ -272,7 +273,7 @@ public class MethodScriptCompilerTest {
 		verify(fakePlayer).sendMessage("hello");
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testExecute10() throws Exception {
 		String script
 				= "msg('hello') /* This is a comment too invalid()'\"'' function\n"
@@ -280,7 +281,7 @@ public class MethodScriptCompilerTest {
 		MethodScriptCompiler.execute(MethodScriptCompiler.compile(MethodScriptCompiler.lex(script, null, null, true), null, envs), env, null, null);
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testExecute11() throws Exception {
 		String script
 				= "msg('hello') 'unended string";
@@ -714,7 +715,7 @@ public class MethodScriptCompilerTest {
 		assertEquals("2 + 2 is 4", SRun("'2 + 2 is' (2 + 2)", fakePlayer));
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testCompileErrorOfStaticConstructOptimization() throws Exception {
 		MethodScriptCompiler.compile(MethodScriptCompiler.lex("2 / 0", null, null, true), null, envs);
 	}
@@ -773,7 +774,7 @@ public class MethodScriptCompilerTest {
 		}
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testSpuriousSymbols() throws Exception {
 		SRun("2 +", fakePlayer);
 	}
@@ -811,12 +812,12 @@ public class MethodScriptCompilerTest {
 		verify(fakePlayer).sendMessage("success!");
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testFailureOfBraces() throws Exception {
 		SRun("and(1){ 1 }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testInnerElseInElseIf() throws Exception {
 		SRun("if(true){"
 				+ "msg('fail')"

--- a/src/test/java/com/laytonsmith/core/NewExceptionHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/NewExceptionHandlingTest.java
@@ -5,8 +5,7 @@ import com.laytonsmith.core.compiler.OptimizationUtilities;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
-import com.laytonsmith.core.exceptions.ConfigCompileException;
-import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
+import com.laytonsmith.core.exceptions.AbstractCompileException;
 import com.laytonsmith.core.functions.Exceptions;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.BeforeClass;
@@ -174,7 +173,7 @@ public class NewExceptionHandlingTest {
 		verify(log).Log(eq(MSLog.Tags.RUNTIME), eq(LogLevel.WARNING), anyString(), any(Target.class));
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testDuplicateExceptionTypeThrowsException() throws Exception {
 		SRun("try { } catch (CastException @e){ } catch (CastException @e){ }", fakePlayer);
 	}
@@ -200,37 +199,37 @@ public class NewExceptionHandlingTest {
 		verify(fakePlayer).sendMessage("run");
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testFinallyMustBeLast() throws Exception {
 		SRun("try { } finally { } catch (Exception @e){ }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testFinallyErrors() throws Exception {
 		SRun("finally { }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testCatchErrors() throws Exception {
 		SRun("catch (Exception @e) { }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testCatchErrors2() throws Exception {
 		SRun("catch { }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testCatchOnlyAllows1Parameter1() throws Exception {
 		SRun("try { } catch (Exception @e, IOException @b) { }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileGroupException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testCatchOnlyAllows1Parameter2() throws Exception {
 		SRun("catch (){ }", fakePlayer);
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testTryAloneFails() throws Exception {
 		SRun("try { }", fakePlayer);
 	}
@@ -292,7 +291,7 @@ public class NewExceptionHandlingTest {
 				+ "}");
 	}
 
-	@Test(expected = ConfigCompileException.class)
+	@Test(expected = AbstractCompileException.class)
 	public void testUnknownExceptionType() throws Exception {
 		SRun("try { } catch (NoTaReAlExCePtIoNtYpE @e){ }", fakePlayer);
 	}


### PR DESCRIPTION
Allow keywords to be part of other syntax than their keyword processing code is written for. An example is code `array(static: 1)`, which generates a compile error when attempting to process the keyword `static`, while it is actually part of valid `array()` syntax.
Fixes #1220 (but not yet for non-keywords such as `array(int: 1)`, which still results in `{ms.lang.int: 1}`).
