### PR TITLE
Fix '@' escaping in smart strings

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -49,7 +49,7 @@ import com.laytonsmith.core.functions.Compiler;
 import com.laytonsmith.core.functions.Compiler.__autoconcat__;
 import com.laytonsmith.core.functions.Compiler.__cbrace__;
 import com.laytonsmith.core.functions.Compiler.p;
-import com.laytonsmith.core.functions.Compiler.smart_string;
+import com.laytonsmith.core.functions.Compiler.__smart_string__;
 import com.laytonsmith.core.functions.Math.neg;
 import com.laytonsmith.core.functions.ControlFlow;
 import com.laytonsmith.core.functions.DataHandling;
@@ -708,6 +708,12 @@ public final class MethodScriptCompiler {
 					// Handle an escape sign in a quote.
 					switch(c2) {
 						case '\\':
+							if(inSmartQuote) {
+								// Escaping of '@' and '\' is handled within __smart_string__.
+								buf.append('\\');
+							}
+							buf.append('\\');
+							break;
 						case '\'':
 						case '"':
 							buf.append(c2);
@@ -1467,7 +1473,7 @@ public final class MethodScriptCompiler {
 			if(t.type == TType.SMART_STRING) {
 				if(t.val().contains("@")) {
 					ParseTree function = new ParseTree(fileOptions);
-					function.setData(new CFunction(smart_string.NAME, t.target));
+					function.setData(new CFunction(__smart_string__.NAME, t.target));
 					ParseTree string = new ParseTree(fileOptions);
 					string.setData(new CString(t.value, t.target));
 					function.addChild(string);

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -667,9 +667,9 @@ public class Compiler {
 	@api
 	@hide("This is more of a compiler feature, rather than a function, and so it is hidden from normal"
 			+ " documentation.")
-	public static class smart_string extends AbstractFunction {
+	public static class __smart_string__ extends AbstractFunction {
 
-		public static final String NAME = "smart_string";
+		public static final String NAME = "__smart_string__";
 
 		@Override
 		public String getName() {
@@ -734,11 +734,21 @@ public class Compiler {
 				for(int i = 0; i < value.length(); i++) {
 					char c = value.charAt(i);
 					char c2 = (i + 1 < value.length() ? value.charAt(i + 1) : '\0');
-					if(c == '\\' && c2 == '@') {
-						b.append("@");
+
+					// The parser passes '\' as '\\' and literal '@' as '\@' for disambiguation in parsing here.
+					if(c == '\\') {
+						if(c2 == '@') {
+							b.append('@');
+						} else if(c2 == '\\') {
+							b.append('\\');
+						} else {
+							throw new ConfigCompileException(
+									"Invalid unhandled escape sequence passed to " + this.getName() + ": \\" + c2, t);
+						}
 						i++;
 						continue;
 					}
+
 					if(c == '@') {
 						if(c2 == '{') {
 							//Start of a complex variable


### PR DESCRIPTION
Pass literal `\` as literal `\\` to `__smart_string__`, so that `__smart_string__` can disambiguate between `"\@"` and `"\\@"`, rather than getting the same input for both.
As this function is an internal compiler function, and users that do use it would now have to pass double escaped `\` into the function to make it work properly, the function has also been renamed to `__smart_string__` to fit the other compiler functions.
Fixes #1229.

This is the new behavior of smart strings how users would use them, and how `__smart_string__` now receives its arguments. Note that it is not possible to fix this without either moving the `\\` escape handling to `__smart_string__` (which is what I did), or moving `\@` handling to the parser itself, removing the need for `__smart_string__`.
![afbeelding](https://user-images.githubusercontent.com/9693840/89092644-c838e500-d3b3-11ea-8b7a-f6e6c0659566.png)

@LadyCailin The only concern I have with this change is that users actually use `smart_string` in their code, as this was public API for a while due to a bug. If you don't have trouble requireing them to replace their `smart_string(...)` with `"..."`, then this solution should be fine.
