### PR TITLE
Fix NPE in LangServ while generating environment

### DIFF
--- a/src/main/java/com/laytonsmith/core/ProfilesImpl.java
+++ b/src/main/java/com/laytonsmith/core/ProfilesImpl.java
@@ -25,7 +25,14 @@ public class ProfilesImpl implements Profiles {
 	private static Map<String, Class<? extends Profile>> profileTypes = null;
 
 	/**
-	 *
+	 * Creates a new empty {@link Profiles}.
+	 */
+	public ProfilesImpl() {
+		this.document = null;
+	}
+
+	/**
+	 * Creates a new {@link Profiles}, initialized with profiles present in the given xml string.
 	 * @param xml
 	 * @throws InvalidProfileException
 	 */
@@ -39,7 +46,7 @@ public class ProfilesImpl implements Profiles {
 	}
 
 	/**
-	 *
+	 * Creates a new {@link Profiles}, initialized with profiles present in the given xml file.
 	 * @param profileFile
 	 * @throws IOException
 	 * @throws InvalidProfileException
@@ -49,7 +56,7 @@ public class ProfilesImpl implements Profiles {
 	}
 
 	/**
-	 *
+	 * Creates a new {@link Profiles}, initialized with profiles present in the given xml stream.
 	 * @param profileData
 	 * @throws IOException
 	 * @throws InvalidProfileException

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -1323,10 +1323,9 @@ public final class Static {
 		}
 		ConnectionMixinFactory.ConnectionMixinOptions options = new ConnectionMixinFactory.ConnectionMixinOptions();
 		options.setWorkingDirectory(platformFolder);
-		Profiles profiles = null;
-		if(MethodScriptFileLocations.getDefault().getProfilesFile().exists()) {
-			profiles = new ProfilesImpl(MethodScriptFileLocations.getDefault().getProfilesFile());
-		}
+		Profiles profiles = (MethodScriptFileLocations.getDefault().getProfilesFile().exists()
+				? new ProfilesImpl(MethodScriptFileLocations.getDefault().getProfilesFile())
+				: new ProfilesImpl());
 		PersistenceNetwork persistenceNetwork = new PersistenceNetworkImpl(MethodScriptFileLocations.getDefault().getPersistenceConfig(),
 				new URI(URLEncoder.encode("sqlite://" + new File(platformFolder, "persistence.db").getCanonicalPath().replace('\\', '/'), "UTF-8")), options);
 		GlobalEnv gEnv = new GlobalEnv(new MethodScriptExecutionQueue("MethodScriptExecutionQueue", "default"),


### PR DESCRIPTION
Fix NPE in LangServ while generating the environment without having a profiles file in the MethodScript directory. This fix creates an empty ProfilesImpl, such that any usage of the Profiles object will simply be like if the profiles file were empty.