### PR TITLE
Add get/set functions for world day

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCWorld.java
@@ -136,6 +136,8 @@ public interface MCWorld extends MCMetadatable {
 
 	void setFullTime(long time);
 
+	long getFullTime();
+
 	CArray spawnMob(MCMobs name, String subClass, int qty, MCLocation location, Target t);
 
 	MCFallingBlock spawnFallingBlock(MCLocation loc, MCBlockData data);

--- a/src/main/java/com/laytonsmith/abstraction/MCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCWorld.java
@@ -134,6 +134,8 @@ public interface MCWorld extends MCMetadatable {
 
 	long getTime();
 
+	void setFullTime(long time);
+
 	CArray spawnMob(MCMobs name, String subClass, int qty, MCLocation location, Target t);
 
 	MCFallingBlock spawnFallingBlock(MCLocation loc, MCBlockData data);

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
@@ -475,6 +475,11 @@ public class BukkitMCWorld extends BukkitMCMetadatable implements MCWorld {
 	}
 
 	@Override
+	public void setFullTime(long time) {
+		w.setFullTime(time);
+	}
+
+	@Override
 	public MCBiomeType getBiome(int x, int z) {
 		return BukkitMCBiomeType.valueOfConcrete(w.getBiome(x, z));
 	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCWorld.java
@@ -480,6 +480,11 @@ public class BukkitMCWorld extends BukkitMCMetadatable implements MCWorld {
 	}
 
 	@Override
+	public long getFullTime() {
+		return w.getFullTime();
+	}
+
+	@Override
 	public MCBiomeType getBiome(int x, int z) {
 		return BukkitMCBiomeType.valueOfConcrete(w.getBiome(x, z));
 	}

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -880,6 +880,66 @@ public class World {
 		}
 	}
 
+	@api(environments = CommandHelperEnvironment.class)
+	public static class set_world_day extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "set_world_day";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1, 2};
+		}
+
+		@Override
+		public String docs() {
+			return "void {[world], day} Set the current day number of a given world";
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CREInvalidWorldException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public MSVersion since() {
+			return MSVersion.V3_3_4;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return false;
+		}
+
+		@Override
+		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
+			MCWorld w = null;
+			if(environment.getEnv(CommandHelperEnvironment.class).GetPlayer() != null) {
+				w = environment.getEnv(CommandHelperEnvironment.class).GetPlayer().getWorld();
+			}
+			if(args.length == 2) {
+				w = Static.getServer().getWorld(args[0].val());
+			}
+			if(w == null) {
+				throw new CREInvalidWorldException("No world specified", t);
+			}
+
+			int day = ArgumentValidation.getInt32((args.length == 1 ? args[0] : args[1]), t);
+			if(day < 0) {
+				throw new CRERangeException("Day cannot be negative.", t);
+			}
+
+			w.setFullTime((day * 24000) + w.getTime());
+			return CVoid.VOID;
+		}
+	}
 	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_world extends AbstractFunction {
 

--- a/src/main/java/com/laytonsmith/core/functions/World.java
+++ b/src/main/java/com/laytonsmith/core/functions/World.java
@@ -940,6 +940,61 @@ public class World {
 			return CVoid.VOID;
 		}
 	}
+
+	@api(environments = CommandHelperEnvironment.class)
+	public static class get_world_day extends AbstractFunction {
+
+		@Override
+		public String getName() {
+			return "get_world_day";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{0, 1};
+		}
+
+		@Override
+		public String docs() {
+			return "int {[world]} Returns the current day number of the specified world";
+		}
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{CREInvalidWorldException.class};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public MSVersion since() {
+			return MSVersion.V3_3_4;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return false;
+		}
+
+		@Override
+		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
+			MCWorld w = null;
+			if(environment.getEnv(CommandHelperEnvironment.class).GetPlayer() != null) {
+				w = environment.getEnv(CommandHelperEnvironment.class).GetPlayer().getWorld();
+			}
+			if(args.length == 1) {
+				w = Static.getServer().getWorld(args[0].val());
+			}
+			if(w == null) {
+				throw new CREInvalidWorldException("No world specified", t);
+			}
+			return new CInt((long) java.lang.Math.floor(w.getFullTime() / 24000), t);
+		}
+	}
+
 	@api(environments = {CommandHelperEnvironment.class})
 	public static class create_world extends AbstractFunction {
 


### PR DESCRIPTION
Adding `get_world_day()` and `set_world_day()` for accessing a world's day counter. Useful for changing/checking the phase of the moon.

Essentially the same as the vanilla `/time query day` and `/time set 1d`