### PR TITLE
Support RGB colours

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
@@ -125,9 +125,15 @@ public enum MCChatColor {
 	}
 
 	public static String fromRGBValue(String hexString) {
-		if(hexString.startsWith("#")) hexString = hexString.split("#")[1];
-		if(hexString.length() > 6) hexString = hexString.substring(0, 6);
-		if(!hexString.matches("(?i)^[0-9A-F]{6}$")) hexString = "ffffff";
+		if(hexString.startsWith("#")) {
+			hexString = hexString.split("#")[1];
+		}
+		if(hexString.length() > 6) {
+			hexString = hexString.substring(0, 6);
+		}
+		if(!hexString.matches("(?i)^[0-9A-F]{6}$")) {
+			hexString = "ffffff";
+		}
 		return "\u00A7x\u00A7" + String.join("\u00A7", hexString.split(""));
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
@@ -124,6 +124,13 @@ public enum MCChatColor {
 		return CHAR_COLORS.get(code);
 	}
 
+	public static String fromRGBValue(String hexString) {
+		if(hexString.startsWith("#")) hexString = hexString.split("#")[1];
+		if(hexString.length() > 6) hexString = hexString.substring(0, 6);
+		if(!hexString.matches("(?i)^[0-9A-F]{6}$")) hexString = "ffffff";
+		return "\u00A7x\u00A7" + String.join("\u00A7", hexString.split(""));
+	}
+
 	/**
 	 * Strips the given message of all color codes
 	 *

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
@@ -126,7 +126,7 @@ public enum MCChatColor {
 
 	public static String fromRGBValue(String hexString) {
 		if(hexString.startsWith("#")) {
-			hexString = hexString.split("#")[1];
+			hexString = hexString.substring(1, hexString.length());
 		}
 		if(hexString.length() > 6) {
 			hexString = hexString.substring(0, 6);

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCChatColor.java
@@ -125,16 +125,14 @@ public enum MCChatColor {
 	}
 
 	public static String fromRGBValue(String hexString) {
-		if(hexString.startsWith("#")) {
-			hexString = hexString.substring(1, hexString.length());
+		if(hexString.length() > 7) {
+			hexString = hexString.substring(0, 7);
 		}
-		if(hexString.length() > 6) {
-			hexString = hexString.substring(0, 6);
+		if(!hexString.matches("(?i)^#[0-9A-F]{6}$")) {
+			return null;
 		}
-		if(!hexString.matches("(?i)^[0-9A-F]{6}$")) {
-			hexString = "ffffff";
-		}
-		return "\u00A7x\u00A7" + String.join("\u00A7", hexString.split(""));
+
+		return "\u00A7x\u00A7" + String.join("\u00A7", hexString.substring(1).split(""));
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -1229,7 +1229,8 @@ public final class Static {
 				.replaceAll("§m", TermColors.STRIKE)
 				.replaceAll("§n", TermColors.UNDERLINE)
 				.replaceAll("§o", TermColors.ITALIC)
-				.replaceAll("§r", TermColors.RESET);
+				.replaceAll("§r", TermColors.RESET)
+				.replaceAll("(?i)§x(§[a-f0-9]){6}", "");
 
 	}
 

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -402,7 +402,7 @@ public class Echoes {
 				color = MCChatColor.WHITE.toString();
 			}
 
-			if(a.matches("(?i)^#[0-9A-F]{6}$")) {
+			if(a.startsWith("#")) {
 				color = MCChatColor.fromRGBValue(a);
 			}
 
@@ -845,8 +845,9 @@ public class Echoes {
 							if(c.equals('#')) {
 								try {
 									String subsequence2 = stext.substring(i + sl, i + sl + 7);
-									if(subsequence2.matches("(?i)^#[0-9A-F]{6}$")) {
-										b.append(color.exec(t, environment, new CString(subsequence2, t)));
+									String rgbColor = MCChatColor.fromRGBValue(subsequence2);
+									if(rgbColor != null) {
+										b.append(rgbColor);
 										i += sl + 6;
 										continue;
 									}

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -842,6 +842,19 @@ public class Echoes {
 							b.append(color.exec(t, environment, new CString(c, t)));
 							i += sl;
 						} else {
+							if (c.equals('#')) {
+								try {
+									String subsequence2 = stext.substring(i + sl, i + sl + 7);
+									if (subsequence2.matches("(?i)^#[0-9A-F]{6}$")) {
+										b.append(color.exec(t, environment, new CString(subsequence2, t)));
+										i += sl + 6;
+										continue;
+									}
+								} catch (IndexOutOfBoundsException e) {
+									// Not enough characters left for a full hex code
+								}
+							}
+
 							b.append(subsequence1);
 							i += sl - 1;
 						}

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -401,6 +401,11 @@ public class Echoes {
 				//If the value is empty string, set the color to white.
 				color = MCChatColor.WHITE.toString();
 			}
+
+			if(a.matches("(?i)^#[0-9A-F]{6}$")) {
+				color = MCChatColor.fromRGBValue(a);
+			}
+
 			if(color == null) {
 				try {
 					Character p = String.valueOf(a).charAt(0);
@@ -435,7 +440,8 @@ public class Echoes {
 			return "string {name} Returns the color modifier given a color name. If the given color name isn't valid,"
 					+ " white is used instead. The list of valid colors is: " + StringUtils.Join(colors, ", ", ", or ")
 					+ ", in addition the integers 0-15 will work, or the hex numbers from 0-F, and k, l, m, n, o, and r,"
-					+ " which represent styles. Unlike manually putting in the color symbol, using this function will"
+					+ " which represent styles. Additionally, any RGB colour can be used in the hex format '#rrggbb'."
+					+ " Unlike manually putting in the color symbol, using this function will"
 					+ " return the platform's color code, so if you are wanting to keep your scripts platform independent,"
 					+ " it is a much better idea to use this function as opposed to hard coding your own color codes.";
 		}

--- a/src/main/java/com/laytonsmith/core/functions/Echoes.java
+++ b/src/main/java/com/laytonsmith/core/functions/Echoes.java
@@ -842,10 +842,10 @@ public class Echoes {
 							b.append(color.exec(t, environment, new CString(c, t)));
 							i += sl;
 						} else {
-							if (c.equals('#')) {
+							if(c.equals('#')) {
 								try {
 									String subsequence2 = stext.substring(i + sl, i + sl + 7);
-									if (subsequence2.matches("(?i)^#[0-9A-F]{6}$")) {
+									if(subsequence2.matches("(?i)^#[0-9A-F]{6}$")) {
 										b.append(color.exec(t, environment, new CString(subsequence2, t)));
 										i += sl + 6;
 										continue;

--- a/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
@@ -121,11 +121,11 @@ public class EchoesTest {
 	@Test
 	public void testRGBColor() throws Exception {
 		String encodedColor = String.format("\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s", "x", "f", "f", "1", "1", "a", "a");
-		String encodedWhite = String.format("\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s", "x", "f", "f", "f", "f", "f", "f");
+		String encodedWhite = "\u00A7f";
 		assertEquals(encodedColor, SRun("color('#ff11aa')", fakePlayer)); // Translates
 		assertEquals(encodedColor, SRun("color('#ff11aabbccddee')", fakePlayer)); // Truncates
-		assertEquals(encodedColor, SRun("color('#ff11zz')", fakePlayer)); // Defaults to white if invalid hex
-		assertEquals(encodedColor, SRun("color('#55')", fakePlayer)); // Defaults to white if invalid hex
+		assertEquals(encodedWhite, SRun("color('#ff11zz')", fakePlayer)); // Defaults to white if invalid hex
+		assertEquals(encodedWhite, SRun("color('#55')", fakePlayer)); // Defaults to white if invalid hex
 	}
 
 	private static final String LOWERCASE_A =

--- a/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
@@ -160,4 +160,15 @@ public class EchoesTest {
 	public void testColorize6() throws Exception {
 		assertEquals("&&" + LOWERCASE_A + "Hi", SRun("colorize('&&&&&&aHi', '&&')", fakePlayer));
 	}
+
+	@Test
+	public void testColorizeRGB() throws Exception {
+		String expectedColor = new color().exec(Target.UNKNOWN, null, new CString("#ff11aa", Target.UNKNOWN)).val();
+		assertEquals(expectedColor + "Hi", SRun("colorize('&#ff11aaHi', '&')", fakePlayer));
+	}
+
+	@Test
+	public void testColorizeInvalidRGB() throws Exception {
+		assertEquals("&#ff Hi", SRun("colorize('&#ff Hi', '&')", fakePlayer));
+	}
 }

--- a/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
@@ -118,6 +118,16 @@ public class EchoesTest {
 		assertEquals(String.format("\u00A7%s", "a"), SRun("color('a')", fakePlayer));
 	}
 
+	@Test
+	public void testRGBColor() throws Exception {
+		String encodedColor = String.format("\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s", "x", "f", "f", "1", "1", "a", "a");
+		String encodedWhite = String.format("\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s\u00A7%s", "x", "f", "f", "f", "f", "f", "f");
+		assertEquals(encodedColor, SRun("color('#ff11aa')", fakePlayer)); // Translates
+		assertEquals(encodedColor, SRun("color('#ff11aabbccddee')", fakePlayer)); // Truncates
+		assertEquals(encodedColor, SRun("color('#ff11zz')", fakePlayer)); // Defaults to white if invalid hex
+		assertEquals(encodedColor, SRun("color('#55')", fakePlayer)); // Defaults to white if invalid hex
+	}
+
 	private static final String LOWERCASE_A =
 			new color().exec(Target.UNKNOWN, null, new CString("a", Target.UNKNOWN)).val();
 


### PR DESCRIPTION
Adding support for any RGB colours in `color()`, using the 1.16 `§x§r§r§g§g§b§b` format. Detects any arg that starts with a # and splits it up accordingly. Won't do anything if it's invalid hex, or not long enough.

Also added support for it to `colorize()`, given an & before the #.