### PR TITLE
Use function signatures for typechecking

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/Common/StringUtils.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/Common/StringUtils.java
@@ -346,7 +346,7 @@ public final class StringUtils {
 	 * which is useful for lists that are being read by a human, to have a proper conjunction at the end.
 	 * @param list The list to concatenate
 	 * @param glue The glue to use
-	 * @param lastGlue The glue for the last two elements
+	 * @param lastGlue The glue for the last two elements. If it is null, then glue is used instead.
 	 * @param glueForTwoItems If only two items are in the list, then this glue is used instead. If it is null, then
 	 * lastGlue is used instead.
 	 * @param empty If the list is completely empty, this string is simply returned. If null, an empty string is used.

--- a/src/main/java/com/laytonsmith/core/asm/LLVMFunction.java
+++ b/src/main/java/com/laytonsmith/core/asm/LLVMFunction.java
@@ -10,6 +10,7 @@ import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Script;
 import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.Target;
@@ -92,6 +93,11 @@ public abstract class LLVMFunction implements FunctionBase, Function {
 	@Override
 	public final Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 		throw new UnsupportedOperationException("Not supported.");
+	}
+
+	@Override
+	public FunctionSignatures getSignatures() {
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
+++ b/src/main/java/com/laytonsmith/core/compiler/analysis/StaticAnalysis.java
@@ -18,9 +18,7 @@ import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.CKeyword;
 import com.laytonsmith.core.constructs.CLabel;
-import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
-import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.IVariable;
 import com.laytonsmith.core.constructs.InstanceofUtil;
 import com.laytonsmith.core.constructs.Target;
@@ -446,17 +444,7 @@ public class StaticAnalysis {
 	public static void requireType(CClassType type, CClassType expected,
 			Target t, Environment env, Set<ConfigCompileException> exceptions) {
 
-		// Handle types that cause exceptions in the InstanceofUtil isInstanceof check.
-		if(type == expected || type == CClassType.AUTO || type == CNull.TYPE) {
-			return;
-		}
-		if(type == CVoid.TYPE || expected == CVoid.TYPE || expected == CNull.TYPE) {
-			exceptions.add(new ConfigCompileException("Expected type " + expected.getSimpleName()
-					+ ", but received type " + type.getSimpleName() + " instead.", t));
-			return;
-		}
-
-		// Handle 'normal' types.
+		// Generate an exception if the given type is not instanceof the expected type.
 		if(!InstanceofUtil.isInstanceof(type, expected, env)) {
 			exceptions.add(new ConfigCompileException("Expected type " + expected.getSimpleName()
 				+ ", but received type " + type.getSimpleName() + " instead.", t));
@@ -477,9 +465,7 @@ public class StaticAnalysis {
 
 		// Return if the type is instanceof any expected type.
 		for(CClassType exp : expected) {
-			if(type == exp || type == CClassType.AUTO || type == CNull.TYPE
-					|| (type != CVoid.TYPE && exp != CVoid.TYPE && exp != CNull.TYPE)
-					|| InstanceofUtil.isInstanceof(type, exp, env)) {
+			if(InstanceofUtil.isInstanceof(type, exp, env)) {
 				return;
 			}
 		}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
@@ -1,0 +1,69 @@
+package com.laytonsmith.core.compiler.signature;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a single function, procedure or closure signature.
+ * @author P.J.S. Kools
+ */
+public class FunctionSignature {
+
+	private final ReturnType returnType;
+	private final List<Param> params;
+	private final List<Throws> throwsList;
+
+	/**
+	 * Creates a new {@link FunctionSignature} with the given properties.
+	 * @param returnType - The function return type.
+	 * @param params - The function parameters.
+	 * @param throwsList - The list of possibly thrown exceptions by the function.
+	 */
+	public FunctionSignature(ReturnType returnType, List<Param> params, List<Throws> throwsList) {
+		this.returnType = returnType;
+		this.params = params;
+		this.throwsList = throwsList;
+	}
+
+	/**
+	 * Creates a new {@link FunctionSignature} with the given return type and no parameters
+	 * and possibly thrown exceptions.
+	 * @param returnType - The function return type.
+	 */
+	public FunctionSignature(ReturnType returnType) {
+		this(returnType, new ArrayList<>(), new ArrayList<>());
+	}
+
+	protected void addParam(Param param) {
+		this.params.add(param);
+	}
+
+	protected void addThrows(Throws throwsObj) {
+		this.throwsList.add(throwsObj);
+	}
+
+	/**
+	 * Gets the function's return type.
+	 * @return The return type.
+	 */
+	public ReturnType getReturnType() {
+		return this.returnType;
+	}
+
+	/**
+	 * Gets the function's parameters.
+	 * @return The parameters.
+	 */
+	public List<Param> getParams() {
+		return Collections.unmodifiableList(this.params);
+	}
+
+	/**
+	 * Gets the function's possibly thrown exceptions.
+	 * @return The possibly thrown exceptions.
+	 */
+	public List<Throws> getThrows() {
+		return Collections.unmodifiableList(this.throwsList);
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
@@ -9,7 +9,6 @@ import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.InstanceofUtil;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.natives.interfaces.Mixed;
 
 /**
  * Represents a single function, procedure or closure signature.
@@ -157,12 +156,6 @@ public class FunctionSignature {
 	public String getParamTypesString() {
 		return "(" + StringUtils.Join(this.params, ", ", null, null, null, (Param param) -> {
 			String ret = (param.getType() == null ? "any" : param.getType().getSimpleName());
-			if(param.getGenericIdentifier() != null) {
-				ret = param.getGenericIdentifier();
-				if(param.getType() != Mixed.TYPE) {
-					ret += " extends " + ret;
-				}
-			}
 			if(param.isVarParam()) {
 				ret += "...";
 			}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
@@ -3,6 +3,13 @@ package com.laytonsmith.core.compiler.signature;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Stack;
+
+import com.laytonsmith.PureUtilities.Common.StringUtils;
+import com.laytonsmith.core.constructs.CClassType;
+import com.laytonsmith.core.constructs.InstanceofUtil;
+import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.natives.interfaces.Mixed;
 
 /**
  * Represents a single function, procedure or closure signature.
@@ -65,5 +72,104 @@ public class FunctionSignature {
 	 */
 	public List<Throws> getThrows() {
 		return Collections.unmodifiableList(this.throwsList);
+	}
+
+	/**
+	 * Matches the given argument types against this signature.
+	 * @param argTypes - The argument types.
+	 * @param env - The environment.
+	 * @param allowUnmatchedArgs - Whether or not to allow more arguments than the signature prescribes.
+	 * This should be {@code false} for normal functions, and {@code true} for procedures and closures.
+	 * @return {@code true} if the arguments match the signature, {@code false} otherwise.
+	 */
+	public boolean matches(List<CClassType> argTypes, Environment env, boolean allowUnmatchedArgs) {
+		int argIndex = 0;
+		Stack<Integer> numArgMatchStack = new Stack<>();
+		matchLoop:
+		for(int paramIndex = 0; paramIndex < this.params.size(); paramIndex++) {
+			Param param = this.params.get(paramIndex);
+
+			// Match parameter.
+			if(!param.isVarParam()) {
+
+				// Match normal or optional parameter.
+				if(argIndex < argTypes.size()
+						&& InstanceofUtil.isInstanceof(argTypes.get(argIndex), param.getType(), env)) {
+
+					// Keep track of the optional parameter match.
+					if(param.isOptional()) {
+						numArgMatchStack.push(1);
+					}
+
+					// Normal param match, continue with next param.
+					argIndex++;
+					continue;
+				} else if(param.isOptional()) {
+
+					// Mark as optional parameter match and continue with the next param.
+					numArgMatchStack.push(0);
+					continue;
+				}
+			} else {
+
+				// Match as many arguments as possible with this varparam.
+				int numMatches = 0;
+				while(argIndex < argTypes.size()
+						&& InstanceofUtil.isInstanceof(argTypes.get(argIndex), param.getType(), env)) {
+					argIndex++;
+					numMatches++;
+				}
+				numArgMatchStack.push(numMatches);
+				continue;
+			}
+
+			// Param didn't match. Make the last varparam or optional match with matches match one less term.
+			paramIndex--; // The current parameter doesn't have a match.
+			while(!numArgMatchStack.empty()) {
+				while(!this.params.get(paramIndex).isVarParam() && !this.params.get(paramIndex).isOptional()) {
+
+					// Undo normal parameter match.
+					paramIndex--;
+					argIndex--;
+				}
+				int numArgMatches = numArgMatchStack.pop();
+				if(numArgMatches > 0) {
+
+					// Undo last argument match of the varparam.
+					numArgMatchStack.push(numArgMatches - 1);
+					argIndex--;
+
+					// Retry matching.
+					continue matchLoop;
+				}
+			}
+			return false; // No varparams with matches remaining in the signature, so it's no match.
+		}
+
+		// All parameters are matched. Return true only if all arguments were also matched, or if this is not required.
+		return allowUnmatchedArgs || argIndex >= argTypes.size();
+	}
+
+	/**
+	 * Gets the parameter types string.
+	 * @return The string in format "([firstArgType], secondArgType..., ...)".
+	 */
+	public String getParamTypesString() {
+		return "(" + StringUtils.Join(this.params, ", ", null, null, null, (Param param) -> {
+			String ret = param.getType().getSimpleName();
+			if(param.getGenericIdentifier() != null) {
+				ret = param.getGenericIdentifier();
+				if(param.getType() != Mixed.TYPE) {
+					ret += " extends " + ret;
+				}
+			}
+			if(param.isVarParam()) {
+				ret += "...";
+			}
+			if(param.isOptional()) {
+				ret = "[" + ret + "]";
+			}
+			return ret;
+		}) + ")";
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignature.java
@@ -156,7 +156,7 @@ public class FunctionSignature {
 	 */
 	public String getParamTypesString() {
 		return "(" + StringUtils.Join(this.params, ", ", null, null, null, (Param param) -> {
-			String ret = param.getType().getSimpleName();
+			String ret = (param.getType() == null ? "any" : param.getType().getSimpleName());
 			if(param.getGenericIdentifier() != null) {
 				ret = param.getGenericIdentifier();
 				if(param.getType() != Mixed.TYPE) {

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
@@ -74,8 +74,8 @@ public final class FunctionSignatures {
 		switch(matches.size()) {
 			case 0: {
 				// No matches. Generate a compile error and return AUTO to prevent further typechecking errors.
-				String argTypesStr = "(" + StringUtils.Join(
-						argTypes, ", ", null, null, null, (CClassType type) -> type.getSimpleName()) + ")";
+				String argTypesStr = "(" + StringUtils.Join(argTypes, ", ", null, null, null,
+						(CClassType type) -> (type == null ? "none" : type.getSimpleName())) + ")";
 				exceptions.add(new ConfigCompileException("Arguments " + argTypesStr
 						+ " do not match required " + this.getSignaturesParamTypesString() + ".", t));
 				return CClassType.AUTO;
@@ -89,8 +89,9 @@ public final class FunctionSignatures {
 
 				// Return the return type of all matching signatures if they are the same.
 				CClassType type = matches.get(0).getReturnType().getType();
-				for(FunctionSignature match : matches) {
-					if(!match.getReturnType().getType().equals(type)) {
+				for(int i = 1; i < matches.size(); i++) {
+					CClassType retType = matches.get(i).getReturnType().getType();
+					if((retType == null ? retType != type : !retType.equals(type))) {
 						return CClassType.AUTO;
 					}
 				}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
@@ -3,6 +3,13 @@ package com.laytonsmith.core.compiler.signature;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+
+import com.laytonsmith.PureUtilities.Common.StringUtils;
+import com.laytonsmith.core.constructs.CClassType;
+import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
 
 /**
  * Represents a collection of signatures for a single function, procedure or closure.
@@ -25,5 +32,65 @@ public final class FunctionSignatures {
 	 */
 	public List<FunctionSignature> getSignatures() {
 		return Collections.unmodifiableList(this.signatures);
+	}
+
+	/**
+	 * Gets the parameter types string of all signatures.
+	 * @return The string in format "(firstArgType, secondArgType, ...)|(...)|...".
+	 */
+	public String getSignaturesParamTypesString() {
+		return StringUtils.Join(this.signatures, " | ", null, null, null,
+				(FunctionSignature signature) -> signature.getParamTypesString());
+	}
+
+	/**
+	 * Gets the return {@link CClassType} based on this {@link FunctionSignatures}.
+	 * If none of the signatures match, a compile error is generated.
+	 * If multiple signatures match, then the most specific shared type is returned.
+	 * @param t - The code target, used for setting the code target in thrown exceptions.
+	 * @param argTypes - The types of the passed arguments.
+	 * @param argTargets - The {@link Target}s belonging to the argTypes (in the same order).
+	 * @param env - The {@link Environment}, used for instanceof checks on types.
+	 * @param exceptions - A set to which all type errors will be added.
+	 * @return The return type.
+	 */
+	public CClassType getReturnType(Target t, List<CClassType> argTypes,
+			List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
+
+		// List all matching signatures.
+		List<FunctionSignature> matches = new ArrayList<>();
+		for(FunctionSignature signature : this.getSignatures()) {
+			if(signature.matches(argTypes, env, false)) {
+				matches.add(signature);
+			}
+		}
+
+		// Select the return type based on the matches.
+		switch(matches.size()) {
+			case 0: {
+				// No matches. Generate a compile error and return AUTO to prevent further typechecking errors.
+				String argTypesStr = "(" + StringUtils.Join(
+						argTypes, ", ", null, null, null, (CClassType type) -> type.getSimpleName()) + ")";
+				exceptions.add(new ConfigCompileException("Arguments " + argTypesStr
+						+ " do not match required " + this.getSignaturesParamTypesString() + ".", t));
+				return CClassType.AUTO;
+			}
+			case 1: {
+				// Exactly one signature matches, so return the return type.
+				return matches.get(0).getReturnType().getType();
+			}
+			default: {
+				// TODO - Ideally, we'd either return a multi-type or the most specific super type of the signatures.
+
+				// Return the return type of all matching signatures if they are the same.
+				CClassType type = matches.get(0).getReturnType().getType();
+				for(FunctionSignature match : matches) {
+					if(!match.getReturnType().getType().equals(type)) {
+						return CClassType.AUTO;
+					}
+				}
+				return type;
+			}
+		}
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
@@ -18,8 +18,10 @@ import com.laytonsmith.core.exceptions.ConfigCompileException;
 public final class FunctionSignatures {
 
 	private final List<FunctionSignature> signatures = new ArrayList<>();
+	private MatchType matchType;
 
-	protected FunctionSignatures() {
+	protected FunctionSignatures(MatchType matchType) {
+		this.matchType = matchType;
 	}
 
 	protected void addSignature(FunctionSignature signature) {
@@ -57,10 +59,13 @@ public final class FunctionSignatures {
 	public CClassType getReturnType(Target t, List<CClassType> argTypes,
 			List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
 
-		// List all matching signatures.
+		// List all matching signatures, or return the return type of the first match when MatchType MATCH_FIRST is set.
 		List<FunctionSignature> matches = new ArrayList<>();
 		for(FunctionSignature signature : this.getSignatures()) {
 			if(signature.matches(argTypes, env, false)) {
+				if(this.matchType == MatchType.MATCH_FIRST) {
+					return signature.getReturnType().getType();
+				}
 				matches.add(signature);
 			}
 		}
@@ -92,5 +97,24 @@ public final class FunctionSignatures {
 				return type;
 			}
 		}
+	}
+
+	/**
+	 * Represents how {@link FunctionSignature}s within {@link FunctionSignatures} should be matched with given
+	 * argument types.
+	 * @author P.J.S. Kools
+	 */
+	public static enum MatchType {
+
+		/**
+		 * Indicates that all signatures within a {@link FunctionSignatures} should be matched when possible.
+		 */
+		MATCH_ALL,
+
+		/**
+		 * Indicates that signatures within a {@link FunctionSignatures} should be matched from first to last,
+		 * terminating as soon as a match is found.
+		 */
+		MATCH_FIRST;
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/FunctionSignatures.java
@@ -1,0 +1,29 @@
+package com.laytonsmith.core.compiler.signature;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a collection of signatures for a single function, procedure or closure.
+ * @author P.J.S. Kools
+ */
+public final class FunctionSignatures {
+
+	private final List<FunctionSignature> signatures = new ArrayList<>();
+
+	protected FunctionSignatures() {
+	}
+
+	protected void addSignature(FunctionSignature signature) {
+		this.signatures.add(signature);
+	}
+
+	/**
+	 * Gets all signatures in this {@link FunctionSignatures}.
+	 * @return A {@link List} containing all signatures.
+	 */
+	public List<FunctionSignature> getSignatures() {
+		return Collections.unmodifiableList(this.signatures);
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
@@ -10,6 +10,7 @@ public class Param {
 
 	private final CClassType type;
 	private final String name;
+	private final String desc;
 	private final boolean isVarParam;
 	private final boolean isOptional;
 
@@ -18,15 +19,17 @@ public class Param {
 	 * Parameters cannot be variadic and optional at the same time, as varparams already imply optionality.
 	 * @param type - The (parent) type of the parameter.
 	 * @param name - The name of the parameter.
+	 * @param desc - The description of the parameter.
 	 * @param isVarParam - {@code true} if the parameter is a varparam, meaning that it matches zero or more arguments
 	 * of the given type, or one argument of type {@code array<type>}. {@code false} otherwise.
 	 * Note that a varparam is only usable as type {@code array<type>}.
 	 * @param isOptional - {@code true} if the parameter is optional, {@code false} otherwise.
 	 */
-	public Param(CClassType type, String name, boolean isVarParam, boolean isOptional) {
+	public Param(CClassType type, String name, String desc, boolean isVarParam, boolean isOptional) {
 		assert !isVarParam || !isOptional : "A parameter cannot be variadic and optional at the same time.";
 		this.type = type;
 		this.name = name;
+		this.desc = desc;
 		this.isVarParam = isVarParam;
 		this.isOptional = isOptional;
 	}
@@ -35,9 +38,10 @@ public class Param {
 	 * Creates a new non-varparam {@link Param} with the given properties.
 	 * @param type - The type of the parameter.
 	 * @param name - The name of the parameter.
+	 * @param desc - The description of the parameter.
 	 */
-	public Param(CClassType type, String name) {
-		this(type, name, false, false);
+	public Param(CClassType type, String name, String desc) {
+		this(type, name, desc, false, false);
 	}
 
 	/**
@@ -55,6 +59,14 @@ public class Param {
 	 */
 	public String getName() {
 		return this.name;
+	}
+
+	/**
+	 * Gets the description of the parameter.
+	 * @return The description.
+	 */
+	public String getDesc() {
+		return this.desc;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
@@ -10,15 +10,12 @@ public class Param {
 
 	private final CClassType type;
 	private final String name;
-	private final String genericIdentifier;
 	private final boolean isVarParam;
 	private final boolean isOptional;
 
 	/**
 	 * Creates a new {@link Param} with the given properties.
-	 * If geneticIdentifier is non-null, then the parameter type is 'geneticIdentifier extends type'.
 	 * Parameters cannot be variable and optional at the same time, as varparams already imply optionality.
-	 * @param genericIdentifier - The generic identifier, which can be used to link generic types.
 	 * @param type - The (parent) type of the parameter.
 	 * @param name - The name of the parameter.
 	 * @param isVarParam - {@code true} if the parameter is a varparam, meaning that it matches zero or more arguments
@@ -26,9 +23,8 @@ public class Param {
 	 * Note that a varparam is only usable as type {@code array<type>}.
 	 * @param isOptional - {@code true} if the parameter is optional, {@code false} otherwise.
 	 */
-	public Param(String genericIdentifier, CClassType type, String name, boolean isVarParam, boolean isOptional) {
+	public Param(CClassType type, String name, boolean isVarParam, boolean isOptional) {
 		assert !isVarParam || !isOptional : "A parameter cannot be variable and optional at the same time.";
-		this.genericIdentifier = genericIdentifier;
 		this.type = type;
 		this.name = name;
 		this.isVarParam = isVarParam;
@@ -36,17 +32,16 @@ public class Param {
 	}
 
 	/**
-	 * Creates a new non-generic non-varparam {@link Param} with the given properties.
+	 * Creates a new non-varparam {@link Param} with the given properties.
 	 * @param type - The type of the parameter.
 	 * @param name - The name of the parameter.
 	 */
 	public Param(CClassType type, String name) {
-		this(null, type, name, false, false);
+		this(type, name, false, false);
 	}
 
 	/**
 	 * Gets the parameter {@link CClassType}.
-	 * If this {@link Param} is generic, then the type in 'genericIdentifier extends type' is returned.
 	 * If this {@link Param} is a varparam, then the type in 'type name...' is returned (and not {@code array<type>}).
 	 * @return The type.
 	 */
@@ -60,15 +55,6 @@ public class Param {
 	 */
 	public String getName() {
 		return this.name;
-	}
-
-	/**
-	 * Gets the generic identifier.
-	 * @return The generic identifier in 'genericIdentifier extends type',
-	 * or {@code null} if the parameter type is not generic.
-	 */
-	public String getGenericIdentifier() {
-		return this.genericIdentifier;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
@@ -12,22 +12,27 @@ public class Param {
 	private final String name;
 	private final String genericIdentifier;
 	private final boolean isVarParam;
+	private final boolean isOptional;
 
 	/**
 	 * Creates a new {@link Param} with the given properties.
 	 * If geneticIdentifier is non-null, then the parameter type is 'geneticIdentifier extends type'.
+	 * Parameters cannot be variable and optional at the same time, as varparams already imply optionality.
 	 * @param genericIdentifier - The generic identifier, which can be used to link generic types.
 	 * @param type - The (parent) type of the parameter.
 	 * @param name - The name of the parameter.
 	 * @param isVarParam - {@code true} if the parameter is a varparam, meaning that it matches zero or more arguments
 	 * of the given type, or one argument of type {@code array<type>}. {@code false} otherwise.
 	 * Note that a varparam is only usable as type {@code array<type>}.
+	 * @param isOptional - {@code true} if the parameter is optional, {@code false} otherwise.
 	 */
-	public Param(String genericIdentifier, CClassType type, String name, boolean isVarParam) {
+	public Param(String genericIdentifier, CClassType type, String name, boolean isVarParam, boolean isOptional) {
+		assert !isVarParam || !isOptional : "A parameter cannot be variable and optional at the same time.";
 		this.genericIdentifier = genericIdentifier;
 		this.type = type;
 		this.name = name;
 		this.isVarParam = isVarParam;
+		this.isOptional = isOptional;
 	}
 
 	/**
@@ -36,7 +41,7 @@ public class Param {
 	 * @param name - The name of the parameter.
 	 */
 	public Param(CClassType type, String name) {
-		this(null, type, name, false);
+		this(null, type, name, false, false);
 	}
 
 	/**
@@ -73,5 +78,13 @@ public class Param {
 	 */
 	public boolean isVarParam() {
 		return this.isVarParam;
+	}
+
+	/**
+	 * Gets whether the parameter is optional or not.
+	 * @return {@code true} if this parameter is optional, {@code false} otherwise.
+	 */
+	public boolean isOptional() {
+		return this.isOptional;
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
@@ -1,0 +1,77 @@
+package com.laytonsmith.core.compiler.signature;
+
+import com.laytonsmith.core.constructs.CClassType;
+
+/**
+ * Represents a parameter for a function, closure or procedure.
+ * @author P.J.S. Kools
+ */
+public class Param {
+
+	private final CClassType type;
+	private final String name;
+	private final String genericIdentifier;
+	private final boolean isVarParam;
+
+	/**
+	 * Creates a new {@link Param} with the given properties.
+	 * If geneticIdentifier is non-null, then the parameter type is 'geneticIdentifier extends type'.
+	 * @param genericIdentifier - The generic identifier, which can be used to link generic types.
+	 * @param type - The (parent) type of the parameter.
+	 * @param name - The name of the parameter.
+	 * @param isVarParam - {@code true} if the parameter is a varparam, meaning that it matches zero or more arguments
+	 * of the given type, or one argument of type {@code array<type>}. {@code false} otherwise.
+	 * Note that a varparam is only usable as type {@code array<type>}.
+	 */
+	public Param(String genericIdentifier, CClassType type, String name, boolean isVarParam) {
+		this.genericIdentifier = genericIdentifier;
+		this.type = type;
+		this.name = name;
+		this.isVarParam = isVarParam;
+	}
+
+	/**
+	 * Creates a new non-generic non-varparam {@link Param} with the given properties.
+	 * @param type - The type of the parameter.
+	 * @param name - The name of the parameter.
+	 */
+	public Param(CClassType type, String name) {
+		this(null, type, name, false);
+	}
+
+	/**
+	 * Gets the parameter {@link CClassType}.
+	 * If this {@link Param} is generic, then the type in 'genericIdentifier extends type' is returned.
+	 * If this {@link Param} is a varparam, then the type in 'type name...' is returned (and not {@code array<type>}).
+	 * @return The type.
+	 */
+	public CClassType getType() {
+		return this.type;
+	}
+
+	/**
+	 * Gets the name of the parameter.
+	 * @return The name.
+	 */
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Gets the generic identifier.
+	 * @return The generic identifier in 'genericIdentifier extends type',
+	 * or {@code null} if the parameter type is not generic.
+	 */
+	public String getGenericIdentifier() {
+		return this.genericIdentifier;
+	}
+
+	/**
+	 * Gets whether the parameter is a varparam or not. Varparams accept 0 or more arguments of their type,
+	 * or one argument of type {@code array<type>} and they become usable as {@code array<type>}.
+	 * @return {@code true} if this parameter is a varparam, {@code false} otherwise.
+	 */
+	public boolean isVarParam() {
+		return this.isVarParam;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Param.java
@@ -15,7 +15,7 @@ public class Param {
 
 	/**
 	 * Creates a new {@link Param} with the given properties.
-	 * Parameters cannot be variable and optional at the same time, as varparams already imply optionality.
+	 * Parameters cannot be variadic and optional at the same time, as varparams already imply optionality.
 	 * @param type - The (parent) type of the parameter.
 	 * @param name - The name of the parameter.
 	 * @param isVarParam - {@code true} if the parameter is a varparam, meaning that it matches zero or more arguments
@@ -24,7 +24,7 @@ public class Param {
 	 * @param isOptional - {@code true} if the parameter is optional, {@code false} otherwise.
 	 */
 	public Param(CClassType type, String name, boolean isVarParam, boolean isOptional) {
-		assert !isVarParam || !isOptional : "A parameter cannot be variable and optional at the same time.";
+		assert !isVarParam || !isOptional : "A parameter cannot be variadic and optional at the same time.";
 		this.type = type;
 		this.name = name;
 		this.isVarParam = isVarParam;

--- a/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
@@ -1,0 +1,50 @@
+package com.laytonsmith.core.compiler.signature;
+
+import com.laytonsmith.core.constructs.CClassType;
+
+/**
+ * Represents the return type of a function, closure or procedure.
+ * @author P.J.S. Kools
+ */
+public class ReturnType {
+
+	private final CClassType type;
+	private final String genericIdentifier;
+
+	/**
+	 * Creates a new {@link ReturnType} with the given properties.
+	 * If geneticIdentifier is non-null, then the return type is 'geneticIdentifier extends type'.
+	 * @param genericIdentifier - The generic identifier, which can be used to link generic types.
+	 * @param type - The (parent) type that will be returned.
+	 */
+	public ReturnType(String genericIdentifier, CClassType type) {
+		this.genericIdentifier = genericIdentifier;
+		this.type = type;
+	}
+
+	/**
+	 * Creates a new {@link ReturnType} with the given type.
+	 * @param type - The type that will be returned.
+	 */
+	public ReturnType(CClassType type) {
+		this(null, type);
+	}
+
+	/**
+	 * Gets the {@link CClassType} return type.
+	 * If this {@link ReturnType} is generic, then the type in 'genericIdentifier extends type' is returned.
+	 * @return The type.
+	 */
+	public CClassType getType() {
+		return this.type;
+	}
+
+	/**
+	 * Gets the generic identifier.
+	 * @return The generic identifier in 'genericIdentifier extends type',
+	 * or {@code null} if the return type is not generic.
+	 */
+	public String getGenericIdentifier() {
+		return this.genericIdentifier;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
@@ -9,13 +9,16 @@ import com.laytonsmith.core.constructs.CClassType;
 public class ReturnType {
 
 	private final CClassType type;
+	private final String valDesc;
 
 	/**
 	 * Creates a new {@link ReturnType} with the given type.
 	 * @param type - The type that will be returned.
+	 * @param valDesc - The return value description.
 	 */
-	public ReturnType(CClassType type) {
+	public ReturnType(CClassType type, String valDesc) {
 		this.type = type;
+		this.valDesc = valDesc;
 	}
 
 	/**
@@ -24,5 +27,13 @@ public class ReturnType {
 	 */
 	public CClassType getType() {
 		return this.type;
+	}
+
+	/**
+	 * Gets the description of the return value.
+	 * @return The description.
+	 */
+	public String getValDesc() {
+		return this.valDesc;
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/ReturnType.java
@@ -9,42 +9,20 @@ import com.laytonsmith.core.constructs.CClassType;
 public class ReturnType {
 
 	private final CClassType type;
-	private final String genericIdentifier;
-
-	/**
-	 * Creates a new {@link ReturnType} with the given properties.
-	 * If geneticIdentifier is non-null, then the return type is 'geneticIdentifier extends type'.
-	 * @param genericIdentifier - The generic identifier, which can be used to link generic types.
-	 * @param type - The (parent) type that will be returned.
-	 */
-	public ReturnType(String genericIdentifier, CClassType type) {
-		this.genericIdentifier = genericIdentifier;
-		this.type = type;
-	}
 
 	/**
 	 * Creates a new {@link ReturnType} with the given type.
 	 * @param type - The type that will be returned.
 	 */
 	public ReturnType(CClassType type) {
-		this(null, type);
+		this.type = type;
 	}
 
 	/**
-	 * Gets the {@link CClassType} return type.
-	 * If this {@link ReturnType} is generic, then the type in 'genericIdentifier extends type' is returned.
-	 * @return The type.
+	 * Gets the return type.
+	 * @return The {@link CClassType}.
 	 */
 	public CClassType getType() {
 		return this.type;
-	}
-
-	/**
-	 * Gets the generic identifier.
-	 * @return The generic identifier in 'genericIdentifier extends type',
-	 * or {@code null} if the return type is not generic.
-	 */
-	public String getGenericIdentifier() {
-		return this.genericIdentifier;
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -19,7 +19,7 @@ public class SignatureBuilder {
 	 * @param returnType - The return type for the first {@link FunctionSignature}.
 	 */
 	public SignatureBuilder(CClassType returnType) {
-		this(returnType, MatchType.MATCH_ALL);
+		this(returnType, null, MatchType.MATCH_ALL);
 	}
 
 	/**
@@ -28,8 +28,28 @@ public class SignatureBuilder {
 	 * @param matchType - The {@link MatchType} used for determining the return type for given argument types.
 	 */
 	public SignatureBuilder(CClassType returnType, MatchType matchType) {
+		this(returnType, null, matchType);
+	}
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given return type.
+	 * When determining the return type for given argument types, all matching signatures will be used.
+	 * @param returnType - The return type for the first {@link FunctionSignature}.
+	 * @param returnValDesc - The return value description.
+	 */
+	public SignatureBuilder(CClassType returnType, String returnValDesc) {
+		this(returnType, returnValDesc, MatchType.MATCH_ALL);
+	}
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given return type.
+	 * @param returnType - The return type for the first {@link FunctionSignature}.
+	 * @param returnValDesc - The return value description.
+	 * @param matchType - The {@link MatchType} used for determining the return type for given argument types.
+	 */
+	public SignatureBuilder(CClassType returnType, String returnValDesc, MatchType matchType) {
 		this.signatures = new FunctionSignatures(matchType);
-		this.signature = new FunctionSignature(new ReturnType(returnType));
+		this.signature = new FunctionSignature(new ReturnType(returnType, returnValDesc));
 	}
 
 	/**
@@ -85,7 +105,17 @@ public class SignatureBuilder {
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
 	public SignatureBuilder newSignature(CClassType returnType) {
-		return this.newSignature(new ReturnType(returnType));
+		return this.newSignature(returnType, null);
+	}
+
+	/**
+	 * Finalizes the last function signature and starts a new function signature with the given return type.
+	 * @param returnType - The return type of the new function signature.
+	 * @param returnValDesc - The return value description.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder newSignature(CClassType returnType, String returnValDesc) {
+		return this.newSignature(new ReturnType(returnType, returnValDesc));
 	}
 
 	private SignatureBuilder newSignature(ReturnType returnType) {

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -1,5 +1,6 @@
 package com.laytonsmith.core.compiler.signature;
 
+import com.laytonsmith.core.compiler.signature.FunctionSignatures.MatchType;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 
@@ -9,14 +10,25 @@ import com.laytonsmith.core.exceptions.CRE.CREThrowable;
  */
 public class SignatureBuilder {
 
-	private final FunctionSignatures signatures = new FunctionSignatures();
+	private final FunctionSignatures signatures;
 	private FunctionSignature signature;
 
 	/**
 	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given return type.
+	 * When determining the return type for given argument types, all matching signatures will be used.
 	 * @param returnType - The return type for the first {@link FunctionSignature}.
 	 */
 	public SignatureBuilder(CClassType returnType) {
+		this(returnType, MatchType.MATCH_ALL);
+	}
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given return type.
+	 * @param returnType - The return type for the first {@link FunctionSignature}.
+	 * @param matchType - The {@link MatchType} used for determining the return type for given argument types.
+	 */
+	public SignatureBuilder(CClassType returnType, MatchType matchType) {
+		this.signatures = new FunctionSignatures(matchType);
 		this.signature = new FunctionSignature(new ReturnType(returnType));
 	}
 
@@ -25,10 +37,26 @@ public class SignatureBuilder {
 	 * generic return type.
 	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
 	 * latter implies 'genericIdentifier extends mixed'.
+	 * When determining the return type for given argument types, all matching signatures will be used.
 	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
 	 * @param returnType - The parent {@link CClassType} of the return type for the first {@link FunctionSignature}.
 	 */
 	public SignatureBuilder(String genericTypeName, CClassType returnType) {
+		this(genericTypeName, returnType, MatchType.MATCH_ALL);
+		this.signature = new FunctionSignature(new ReturnType(genericTypeName, returnType));
+	}
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given
+	 * generic return type.
+	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
+	 * latter implies 'genericIdentifier extends mixed'.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param matchType - The {@link MatchType} used for determining the return type for given argument types.
+	 * @param returnType - The parent {@link CClassType} of the return type for the first {@link FunctionSignature}.
+	 */
+	public SignatureBuilder(String genericTypeName, CClassType returnType, MatchType matchType) {
+		this.signatures = new FunctionSignatures(matchType);
 		this.signature = new FunctionSignature(new ReturnType(genericTypeName, returnType));
 	}
 

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -1,0 +1,140 @@
+package com.laytonsmith.core.compiler.signature;
+
+import com.laytonsmith.core.constructs.CClassType;
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
+
+/**
+ * A builder for {@link FunctionSignatures}.
+ * @author P.J.S. Kools
+ */
+public class SignatureBuilder {
+
+	private final FunctionSignatures signatures = new FunctionSignatures();
+	private FunctionSignature signature;
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given return type.
+	 * @param returnType - The return type for the first {@link FunctionSignature}.
+	 */
+	public SignatureBuilder(CClassType returnType) {
+		this.signature = new FunctionSignature(new ReturnType(returnType));
+	}
+
+	/**
+	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given
+	 * generic return type.
+	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
+	 * latter implies 'genericIdentifier extends mixed'.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param returnType - The parent {@link CClassType} of the return type for the first {@link FunctionSignature}.
+	 */
+	public SignatureBuilder(String genericTypeName, CClassType returnType) {
+		this.signature = new FunctionSignature(new ReturnType(genericTypeName, returnType));
+	}
+
+	/**
+	 * Adds a normal function parameter. Parameters should be added from left to right.
+	 * @param paramType - The {@link CClassType} of the parameter.
+	 * @param paramName - The name of the parameter.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder param(CClassType paramType, String paramName) {
+		this.signature.addParam(new Param(paramType, paramName));
+		return this;
+	}
+
+	/**
+	 * Adds a variable function parameter (varparam). Parameters should be added from left to right.
+	 * @param paramType - The {@link CClassType} of the parameter (the type in 'paramType paramName...').
+	 * @param paramName - The name of the parameter.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder varParam(CClassType paramType, String paramName) {
+		this.signature.addParam(new Param(null, paramType, paramName, true));
+		return this;
+	}
+
+	/**
+	 * Adds a generic function parameter (in format 'genericTypeName extends genericTypeParent paramName').
+	 * Parameters should be added from left to right.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
+	 * This should be {@link Mixed} if the 'genericTypeName paramName' format is provided.
+	 * @param paramName - The name of the parameter.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder genericParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
+		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, false));
+		return this;
+	}
+
+	/**
+	 * Adds a generic variable function parameter (in format 'genericTypeName extends genericTypeParent paramName...').
+	 * Parameters should be added from left to right.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
+	 * This should be {@link Mixed} if the 'genericTypeName paramName...' format is provided.
+	 * @param paramName - The name of the parameter.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder genericVarParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
+		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, true));
+		return this;
+	}
+
+	/**
+	 * Adds a possibly thrown exception to the function signature.
+	 * @param exception - The class representing the possibly thrown exception.
+	 * @param when - The condition under which the exception can be thrown.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder throwsEx(Class<? extends CREThrowable> exception, String when) {
+		this.signature.addThrows(new Throws(exception, when));
+		return this;
+	}
+
+	/**
+	 * Finalizes the last function signature and starts a new function signature with the given generic return type.
+	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
+	 * latter implies 'genericIdentifier extends mixed'.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param returnType - The parent {@link CClassType} of the return type.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder newGenericSignature(String genericTypeName, CClassType returnType) {
+		return this.newSignature(new ReturnType(genericTypeName, returnType));
+	}
+
+	/**
+	 * Finalizes the last function signature and starts a new function signature with the given return type.
+	 * @param returnType - The return type of the new function signature.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder newSignature(CClassType returnType) {
+		return this.newSignature(new ReturnType(returnType));
+	}
+
+	private SignatureBuilder newSignature(ReturnType returnType) {
+
+		// Add current signature.
+		this.signatures.addSignature(this.signature);
+
+		// Create new signature.
+		this.signature = new FunctionSignature(returnType);
+
+		return this;
+	}
+
+	/**
+	 * Builds a {@link FunctionSignatures} from the information provided to this builder.
+	 * @return The resulting {@link FunctionSignatures}.
+	 */
+	public FunctionSignatures build() {
+
+		// Add current signature.
+		this.signatures.addSignature(this.signature);
+
+		// Return the signatures.
+		return this.signatures;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -36,11 +36,22 @@ public class SignatureBuilder {
 	 * Adds a normal function parameter. Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter.
 	 * @param paramName - The name of the parameter.
+	 * @param isOptional - Whether the parameter is optional or not.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder param(CClassType paramType, String paramName, boolean isOptional) {
+		this.signature.addParam(new Param(null, paramType, paramName, false, isOptional));
+		return this;
+	}
+
+	/**
+	 * Adds a normal non-optional function parameter. Parameters should be added from left to right.
+	 * @param paramType - The {@link CClassType} of the parameter.
+	 * @param paramName - The name of the parameter.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
 	public SignatureBuilder param(CClassType paramType, String paramName) {
-		this.signature.addParam(new Param(paramType, paramName));
-		return this;
+		return this.param(paramType, paramName, false);
 	}
 
 	/**
@@ -50,7 +61,7 @@ public class SignatureBuilder {
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
 	public SignatureBuilder varParam(CClassType paramType, String paramName) {
-		this.signature.addParam(new Param(null, paramType, paramName, true));
+		this.signature.addParam(new Param(null, paramType, paramName, true, false));
 		return this;
 	}
 
@@ -61,15 +72,31 @@ public class SignatureBuilder {
 	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
 	 * This should be {@link Mixed} if the 'genericTypeName paramName' format is provided.
 	 * @param paramName - The name of the parameter.
+	 * @param isOptional - Whether the parameter is optional or not.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
-	public SignatureBuilder genericParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
-		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, false));
+	public SignatureBuilder genericParam(
+			String genericTypeName, CClassType genericTypeParent, String paramName, boolean isOptional) {
+		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, false, isOptional));
 		return this;
 	}
 
 	/**
-	 * Adds a generic variable function parameter (in format 'genericTypeName extends genericTypeParent paramName...').
+	 * Adds a generic non-optional function parameter (in format 'genericTypeName extends genericTypeParent paramName').
+	 * Parameters should be added from left to right.
+	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
+	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
+	 * This should be {@link Mixed} if the 'genericTypeName paramName' format is provided.
+	 * @param paramName - The name of the parameter.
+	 * @return This {@link SignatureBuilder}, for chaining builder methods.
+	 */
+	public SignatureBuilder genericParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
+		return this.genericParam(genericTypeName, genericTypeParent, paramName, false);
+	}
+
+	/**
+	 * Adds a non-optional generic variable function parameter
+	 * (in format 'genericTypeName extends genericTypeParent paramName...').
 	 * Parameters should be added from left to right.
 	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
 	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
@@ -77,8 +104,9 @@ public class SignatureBuilder {
 	 * @param paramName - The name of the parameter.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
-	public SignatureBuilder genericVarParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
-		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, true));
+	public SignatureBuilder genericVarParam(
+			String genericTypeName, CClassType genericTypeParent, String paramName) {
+		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, true, false));
 		return this;
 	}
 

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -55,7 +55,7 @@ public class SignatureBuilder {
 	}
 
 	/**
-	 * Adds a variable function parameter (varparam). Parameters should be added from left to right.
+	 * Adds a variadic function parameter (varparam). Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter (the type in 'paramType paramName...').
 	 * @param paramName - The name of the parameter.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -33,34 +33,6 @@ public class SignatureBuilder {
 	}
 
 	/**
-	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given
-	 * generic return type.
-	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
-	 * latter implies 'genericIdentifier extends mixed'.
-	 * When determining the return type for given argument types, all matching signatures will be used.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param returnType - The parent {@link CClassType} of the return type for the first {@link FunctionSignature}.
-	 */
-	public SignatureBuilder(String genericTypeName, CClassType returnType) {
-		this(genericTypeName, returnType, MatchType.MATCH_ALL);
-		this.signature = new FunctionSignature(new ReturnType(genericTypeName, returnType));
-	}
-
-	/**
-	 * Creates a new {@link SignatureBuilder}, initialized with a {@link FunctionSignature} with the given
-	 * generic return type.
-	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
-	 * latter implies 'genericIdentifier extends mixed'.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param matchType - The {@link MatchType} used for determining the return type for given argument types.
-	 * @param returnType - The parent {@link CClassType} of the return type for the first {@link FunctionSignature}.
-	 */
-	public SignatureBuilder(String genericTypeName, CClassType returnType, MatchType matchType) {
-		this.signatures = new FunctionSignatures(matchType);
-		this.signature = new FunctionSignature(new ReturnType(genericTypeName, returnType));
-	}
-
-	/**
 	 * Adds a normal function parameter. Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter.
 	 * @param paramName - The name of the parameter.
@@ -68,7 +40,7 @@ public class SignatureBuilder {
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
 	public SignatureBuilder param(CClassType paramType, String paramName, boolean isOptional) {
-		this.signature.addParam(new Param(null, paramType, paramName, false, isOptional));
+		this.signature.addParam(new Param(paramType, paramName, false, isOptional));
 		return this;
 	}
 
@@ -89,52 +61,7 @@ public class SignatureBuilder {
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
 	public SignatureBuilder varParam(CClassType paramType, String paramName) {
-		this.signature.addParam(new Param(null, paramType, paramName, true, false));
-		return this;
-	}
-
-	/**
-	 * Adds a generic function parameter (in format 'genericTypeName extends genericTypeParent paramName').
-	 * Parameters should be added from left to right.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
-	 * This should be {@link Mixed} if the 'genericTypeName paramName' format is provided.
-	 * @param paramName - The name of the parameter.
-	 * @param isOptional - Whether the parameter is optional or not.
-	 * @return This {@link SignatureBuilder}, for chaining builder methods.
-	 */
-	public SignatureBuilder genericParam(
-			String genericTypeName, CClassType genericTypeParent, String paramName, boolean isOptional) {
-		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, false, isOptional));
-		return this;
-	}
-
-	/**
-	 * Adds a generic non-optional function parameter (in format 'genericTypeName extends genericTypeParent paramName').
-	 * Parameters should be added from left to right.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
-	 * This should be {@link Mixed} if the 'genericTypeName paramName' format is provided.
-	 * @param paramName - The name of the parameter.
-	 * @return This {@link SignatureBuilder}, for chaining builder methods.
-	 */
-	public SignatureBuilder genericParam(String genericTypeName, CClassType genericTypeParent, String paramName) {
-		return this.genericParam(genericTypeName, genericTypeParent, paramName, false);
-	}
-
-	/**
-	 * Adds a non-optional generic variable function parameter
-	 * (in format 'genericTypeName extends genericTypeParent paramName...').
-	 * Parameters should be added from left to right.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param genericTypeParent - The parent {@link CClassType} of the parameter.
-	 * This should be {@link Mixed} if the 'genericTypeName paramName...' format is provided.
-	 * @param paramName - The name of the parameter.
-	 * @return This {@link SignatureBuilder}, for chaining builder methods.
-	 */
-	public SignatureBuilder genericVarParam(
-			String genericTypeName, CClassType genericTypeParent, String paramName) {
-		this.signature.addParam(new Param(genericTypeName, genericTypeParent, paramName, true, false));
+		this.signature.addParam(new Param(paramType, paramName, true, false));
 		return this;
 	}
 
@@ -147,18 +74,6 @@ public class SignatureBuilder {
 	public SignatureBuilder throwsEx(Class<? extends CREThrowable> exception, String when) {
 		this.signature.addThrows(new Throws(exception, when));
 		return this;
-	}
-
-	/**
-	 * Finalizes the last function signature and starts a new function signature with the given generic return type.
-	 * Generic return types are in format 'genericIdentifier extends returnType' or 'genericIdentifier', where the
-	 * latter implies 'genericIdentifier extends mixed'.
-	 * @param genericTypeName - The generic type name, used for matching with other generic types in the same signature.
-	 * @param returnType - The parent {@link CClassType} of the return type.
-	 * @return This {@link SignatureBuilder}, for chaining builder methods.
-	 */
-	public SignatureBuilder newGenericSignature(String genericTypeName, CClassType returnType) {
-		return this.newSignature(new ReturnType(genericTypeName, returnType));
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/SignatureBuilder.java
@@ -36,11 +36,12 @@ public class SignatureBuilder {
 	 * Adds a normal function parameter. Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter.
 	 * @param paramName - The name of the parameter.
+	 * @param paramDesc - The description of the parameter.
 	 * @param isOptional - Whether the parameter is optional or not.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
-	public SignatureBuilder param(CClassType paramType, String paramName, boolean isOptional) {
-		this.signature.addParam(new Param(paramType, paramName, false, isOptional));
+	public SignatureBuilder param(CClassType paramType, String paramName, String paramDesc, boolean isOptional) {
+		this.signature.addParam(new Param(paramType, paramName, paramDesc, false, isOptional));
 		return this;
 	}
 
@@ -48,20 +49,22 @@ public class SignatureBuilder {
 	 * Adds a normal non-optional function parameter. Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter.
 	 * @param paramName - The name of the parameter.
+	 * @param paramDesc - The description of the parameter.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
-	public SignatureBuilder param(CClassType paramType, String paramName) {
-		return this.param(paramType, paramName, false);
+	public SignatureBuilder param(CClassType paramType, String paramName, String paramDesc) {
+		return this.param(paramType, paramName, paramDesc, false);
 	}
 
 	/**
 	 * Adds a variadic function parameter (varparam). Parameters should be added from left to right.
 	 * @param paramType - The {@link CClassType} of the parameter (the type in 'paramType paramName...').
 	 * @param paramName - The name of the parameter.
+	 * @param paramDesc - The description of the parameter.
 	 * @return This {@link SignatureBuilder}, for chaining builder methods.
 	 */
-	public SignatureBuilder varParam(CClassType paramType, String paramName) {
-		this.signature.addParam(new Param(paramType, paramName, true, false));
+	public SignatureBuilder varParam(CClassType paramType, String paramName, String paramDesc) {
+		this.signature.addParam(new Param(paramType, paramName, paramDesc, true, false));
 		return this;
 	}
 

--- a/src/main/java/com/laytonsmith/core/compiler/signature/Throws.java
+++ b/src/main/java/com/laytonsmith/core/compiler/signature/Throws.java
@@ -1,0 +1,39 @@
+package com.laytonsmith.core.compiler.signature;
+
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
+
+/**
+ * Represents an exception that is stated to be possibly thrown by a function.
+ * @author P.J.S. Kools
+ */
+public class Throws {
+
+	private final Class<? extends CREThrowable> exceptionClass;
+	private final String thrownWhen;
+
+	/**
+	 * Creates a new {@link Throws} with the given properties.
+	 * @param exception - The exception {@link Class} representing the exception that can be thrown.
+	 * @param when - When the exception can be thrown.
+	 */
+	public Throws(Class<? extends CREThrowable> exception, String when) {
+		this.exceptionClass = exception;
+		this.thrownWhen = when;
+	}
+
+	/**
+	 * Gets the exception class representing the exception that can be thrown.
+	 * @return The exception {@link Class}.
+	 */
+	public Class<? extends CREThrowable> getExceptionClass() {
+		return this.exceptionClass;
+	}
+
+	/**
+	 * Gets when the exception can be thrown.
+	 * @return When the exception can be thrown.
+	 */
+	public String getThrownWhen() {
+		return this.thrownWhen;
+	}
+}

--- a/src/main/java/com/laytonsmith/core/constructs/InstanceofUtil.java
+++ b/src/main/java/com/laytonsmith/core/constructs/InstanceofUtil.java
@@ -131,25 +131,29 @@ public class InstanceofUtil {
 	 * The following rules apply in the given order:
 	 * <ul>
 	 *     <li>If value == instanceofThis, {@code true} is returned.</li>
+	 *     <li>If instanceofThis == Java null, {@code true} is returned.</li>
+	 *     <li>Java null is only instanceof Java null.</li>
 	 *     <li>auto and null are instanceof any type.</li>
 	 *     <li>Any type is instanceof auto.</li>
 	 *     <li>Nothing is instanceof void and null.</li>
 	 *     <li>void is instanceof nothing.</li>
 	 * </ul>
-	 * @param type The type to check for
-	 * @param instanceofThis The CClassType to check
+	 * @param type - The type to check for.
+	 * Java {@code null} can be used to indicate no type (e.g. from control flow breaking statements).
+	 * @param instanceofThis - The {@link CClassType} to check against.
+	 * Java {@code null} can be used to indicate that anything is allowed to match this
+	 * (i.e. making this method return {@code true}).
 	 * @param env
 	 * @return
 	 */
 	public static boolean isInstanceof(CClassType type, CClassType instanceofThis, Environment env) {
-		Static.AssertNonNull(instanceofThis, "instanceofThis may not be null");
 
 		// Handle special cases.
-		if(type == instanceofThis || type == CClassType.AUTO
+		if(type == instanceofThis || instanceofThis == null || type == CClassType.AUTO
 				|| type == CNull.TYPE || instanceofThis == CClassType.AUTO) {
 			return true;
 		}
-		if(type == CVoid.TYPE || instanceofThis == CVoid.TYPE || instanceofThis == CNull.TYPE) {
+		if(type == null || type == CVoid.TYPE || instanceofThis == CVoid.TYPE || instanceofThis == CNull.TYPE) {
 			return false;
 		}
 

--- a/src/main/java/com/laytonsmith/core/constructs/InstanceofUtil.java
+++ b/src/main/java/com/laytonsmith/core/constructs/InstanceofUtil.java
@@ -128,7 +128,14 @@ public class InstanceofUtil {
 
 	/**
 	 * Returns whether or not a given MethodScript type is an instance of the specified MethodScript type.
-	 *
+	 * The following rules apply in the given order:
+	 * <ul>
+	 *     <li>If value == instanceofThis, {@code true} is returned.</li>
+	 *     <li>auto and null are instanceof any type.</li>
+	 *     <li>Any type is instanceof auto.</li>
+	 *     <li>Nothing is instanceof void and null.</li>
+	 *     <li>void is instanceof nothing.</li>
+	 * </ul>
 	 * @param type The type to check for
 	 * @param instanceofThis The CClassType to check
 	 * @param env
@@ -137,9 +144,13 @@ public class InstanceofUtil {
 	public static boolean isInstanceof(CClassType type, CClassType instanceofThis, Environment env) {
 		Static.AssertNonNull(instanceofThis, "instanceofThis may not be null");
 
-		// Return true for AUTO, as everything can be used as AUTO.
-		if(instanceofThis == CClassType.AUTO) {
+		// Handle special cases.
+		if(type == instanceofThis || type == CClassType.AUTO
+				|| type == CNull.TYPE || instanceofThis == CClassType.AUTO) {
 			return true;
+		}
+		if(type == CVoid.TYPE || instanceofThis == CVoid.TYPE || instanceofThis == CNull.TYPE) {
+			return false;
 		}
 
 		// Get cached result or compute and cache result.

--- a/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
@@ -16,6 +16,7 @@ import com.laytonsmith.core.SimpleDocumentation;
 import com.laytonsmith.core.compiler.FileOptions;
 import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CClosure;
@@ -70,13 +71,26 @@ public abstract class AbstractFunction implements Function {
 		return CVoid.VOID;
 	}
 
+	@Override
+	public FunctionSignatures getSignatures() {
+		return null;
+	}
+
 	/**
 	 * {@inheritDoc} By default, {@link CClassType#AUTO} is returned.
 	 */
 	@Override
 	public CClassType getReturnType(Target t, List<CClassType> argTypes,
 			List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-		return CClassType.AUTO; // No information is available about the return type.
+
+		// Match arguments to function signatures if available.
+		FunctionSignatures signatures = this.getSignatures();
+		if(signatures != null) {
+			return signatures.getReturnType(t, argTypes, argTargets, env, exceptions);
+		}
+
+		// No information is available about the return type.
+		return CClassType.AUTO;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/AbstractFunction.java
@@ -49,6 +49,7 @@ import java.util.Stack;
 public abstract class AbstractFunction implements Function {
 
 	private boolean shouldProfile = true;
+	private FunctionSignatures cachedFunctionSignatures = null;
 
 	protected AbstractFunction() {
 		//If we have the noprofile annotation, cache that we don't want to profile.
@@ -71,9 +72,26 @@ public abstract class AbstractFunction implements Function {
 		return CVoid.VOID;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Calling {@link #getCachedSignatures()} where possible is preferred for runtime performance.
+	 */
 	@Override
 	public FunctionSignatures getSignatures() {
 		return null;
+	}
+
+	/**
+	 * Gets the function's signatures from the cache, or through {@link #getSignatures()} if they have not been cached.
+	 * The signatures will be cached in this second case.
+	 * Do NOT call this method from {@link #getSignatures()}.
+	 * @return This function's signatures.
+	 */
+	public FunctionSignatures getCachedSignatures() {
+		if(this.cachedFunctionSignatures == null) {
+			this.cachedFunctionSignatures = this.getSignatures();
+		}
+		return this.cachedFunctionSignatures;
 	}
 
 	/**
@@ -84,7 +102,7 @@ public abstract class AbstractFunction implements Function {
 			List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
 
 		// Match arguments to function signatures if available.
-		FunctionSignatures signatures = this.getSignatures();
+		FunctionSignatures signatures = this.getCachedSignatures();
 		if(signatures != null) {
 			return signatures.getReturnType(t, argTypes, argTargets, env, exceptions);
 		}

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -156,7 +156,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -269,7 +271,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -333,7 +337,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -409,7 +415,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -524,7 +532,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -574,7 +584,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -666,7 +678,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -715,7 +729,9 @@ public class BasicLogic {
 		@Override
 		public FunctionSignatures getSignatures() {
 			return new SignatureBuilder(CBoolean.TYPE)
-					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
+					.param(Mixed.TYPE, "obj1", "The first object.")
+					.param(Mixed.TYPE, "obj2", "The second object.")
+					.varParam(Mixed.TYPE, "objs", "Additional objects.").build();
 		}
 
 		@Override
@@ -785,7 +801,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(CNumber.TYPE, "val1", null).param(CNumber.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -858,7 +875,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(CNumber.TYPE, "val1", null).param(CNumber.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -931,7 +949,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(CNumber.TYPE, "val1", null).param(CNumber.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -1005,7 +1024,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(CNumber.TYPE, "val1", null).param(CNumber.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -1094,8 +1114,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null)
+					.varParam(Booleanish.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1251,7 +1273,7 @@ public class BasicLogic {
 			 *  Note that getReturnType could be overridden, not using this signature for typechecking.
 			 *  That implementation is not yet possible until A OR B OR ... types can be described.
 			 */
-			return new SignatureBuilder(CClassType.AUTO).varParam(Mixed.TYPE, "vals").build();
+			return new SignatureBuilder(CClassType.AUTO).varParam(Mixed.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1384,8 +1406,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null)
+					.varParam(Booleanish.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1544,7 +1568,7 @@ public class BasicLogic {
 			 *  Note that getReturnType could be overridden, not using this signature for typechecking.
 			 *  That implementation is not yet possible until A OR B OR ... types can be described.
 			 */
-			return new SignatureBuilder(Mixed.TYPE).varParam(Mixed.TYPE, "vals").build();
+			return new SignatureBuilder(Mixed.TYPE).varParam(Mixed.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1626,7 +1650,7 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val").build();
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val", "The value to negate.").build();
 		}
 
 		@Override
@@ -1732,8 +1756,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -1806,8 +1830,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null)
+					.varParam(Booleanish.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1879,8 +1905,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null)
+					.varParam(Booleanish.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -1950,8 +1978,9 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
-					.param(Booleanish.TYPE, "val2").build();
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Booleanish.TYPE, "val1", null)
+					.param(Booleanish.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -2025,8 +2054,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
-					.varParam(CInt.TYPE, "vals").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null)
+					.varParam(CInt.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -2110,8 +2141,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
-					.varParam(CInt.TYPE, "vals").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null)
+					.varParam(CInt.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -2197,8 +2230,10 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
-					.varParam(CInt.TYPE, "vals").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null)
+					.varParam(CInt.TYPE, "vals", null).build();
 		}
 
 		@Override
@@ -2276,7 +2311,7 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val").build();
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val", null).build();
 		}
 
 		@Override
@@ -2344,7 +2379,9 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -2412,7 +2449,9 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -2482,7 +2521,9 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
+			return new SignatureBuilder(CInt.TYPE)
+					.param(CInt.TYPE, "val1", null)
+					.param(CInt.TYPE, "val2", null).build();
 		}
 
 		@Override
@@ -2526,7 +2567,8 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(CString.TYPE, "message").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(CString.TYPE, "message", "The compile error message.").build();
 		}
 
 		@Override
@@ -2605,7 +2647,7 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CInt.TYPE).param(Mixed.TYPE, "val").build();
+			return new SignatureBuilder(CInt.TYPE).param(Mixed.TYPE, "value", "The value to hash.").build();
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -18,6 +18,7 @@ import com.laytonsmith.core.compiler.signature.FunctionSignatures;
 import com.laytonsmith.core.compiler.signature.SignatureBuilder;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
+import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.CInt;
 import com.laytonsmith.core.constructs.CNull;
@@ -1245,7 +1246,12 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder("T", Mixed.TYPE).genericVarParam("T", Mixed.TYPE, "vals").build();
+			/*
+			 *  TODO - Decide how to define the return value.
+			 *  Note that getReturnType could be overridden, not using this signature for typechecking.
+			 *  That implementation is not yet possible until A OR B OR ... types can be described.
+			 */
+			return new SignatureBuilder(CClassType.AUTO).varParam(Mixed.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1533,7 +1539,12 @@ public class BasicLogic {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder("T", Mixed.TYPE).genericVarParam("T", Mixed.TYPE, "vals").build();
+			/*
+			 *  TODO - Decide how to define the return value.
+			 *  Note that getReturnType could be overridden, not using this signature for typechecking.
+			 *  That implementation is not yet possible until A OR B OR ... types can be described.
+			 */
+			return new SignatureBuilder(Mixed.TYPE).varParam(Mixed.TYPE, "vals").build();
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
+++ b/src/main/java/com/laytonsmith/core/functions/BasicLogic.java
@@ -14,9 +14,10 @@ import com.laytonsmith.core.compiler.FileOptions;
 import com.laytonsmith.core.compiler.OptimizationUtilities;
 import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
+import com.laytonsmith.core.compiler.signature.SignatureBuilder;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
-import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.CInt;
 import com.laytonsmith.core.constructs.CNull;
@@ -152,12 +153,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -268,12 +266,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -335,12 +330,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -414,12 +406,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -532,12 +521,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -585,12 +571,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -680,12 +663,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -732,12 +712,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE)
+					.param(Mixed.TYPE, "obj1").param(Mixed.TYPE, "obj2").varParam(Mixed.TYPE, "objs").build();
 		}
 
 		@Override
@@ -806,13 +783,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CNumber.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CNumber.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
 		}
 
 		@Override
@@ -884,13 +856,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CNumber.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CNumber.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
 		}
 
 		@Override
@@ -962,13 +929,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CNumber.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CNumber.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
 		}
 
 		@Override
@@ -1041,13 +1003,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CNumber.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CNumber.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(CNumber.TYPE, "val1").param(CNumber.TYPE, "val2").build();
 		}
 
 		@Override
@@ -1135,12 +1092,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Booleanish.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1290,13 +1244,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			// TODO - Return the most specific subtype among all arguments.
-			return CClassType.AUTO;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder("T", Mixed.TYPE).genericVarParam("T", Mixed.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1428,12 +1377,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Booleanish.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1586,13 +1532,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Mixed.TYPE, argTargets.get(i), env, exceptions);
-			}
-			// TODO - Return the most specific subtype among all arguments.
-			return CClassType.AUTO;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder("T", Mixed.TYPE).genericVarParam("T", Mixed.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1673,12 +1614,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 1) {
-				StaticAnalysis.requireType(argTypes.get(0), Booleanish.TYPE, argTargets.get(0), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val").build();
 		}
 
 		@Override
@@ -1783,13 +1720,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), Booleanish.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), Booleanish.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").build();
 		}
 
 		@Override
@@ -1861,12 +1794,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Booleanish.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
 		}
 
 		@Override
@@ -1937,12 +1867,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), Booleanish.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").varParam(Booleanish.TYPE, "vals").build();
 		}
 
 		@Override
@@ -2011,13 +1938,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes, List<Target> argTargets,
-				Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), Booleanish.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), Booleanish.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CBoolean.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CBoolean.TYPE).param(Booleanish.TYPE, "val1")
+					.param(Booleanish.TYPE, "val2").build();
 		}
 
 		@Override
@@ -2090,12 +2013,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), CInt.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
+					.varParam(CInt.TYPE, "vals").build();
 		}
 
 		@Override
@@ -2178,12 +2098,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), CInt.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
+					.varParam(CInt.TYPE, "vals").build();
 		}
 
 		@Override
@@ -2268,12 +2185,9 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			for(int i = 0; i < argTypes.size(); i++) {
-				StaticAnalysis.requireType(argTypes.get(i), CInt.TYPE, argTargets.get(i), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2")
+					.varParam(CInt.TYPE, "vals").build();
 		}
 
 		@Override
@@ -2350,12 +2264,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 1) {
-				StaticAnalysis.requireType(argTypes.get(0), CInt.TYPE, argTargets.get(0), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val").build();
 		}
 
 		@Override
@@ -2422,13 +2332,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CInt.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CInt.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
 		}
 
 		@Override
@@ -2495,13 +2400,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CInt.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CInt.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
 		}
 
 		@Override
@@ -2570,13 +2470,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 2) {
-				StaticAnalysis.requireType(argTypes.get(0), CInt.TYPE, argTargets.get(0), env, exceptions);
-				StaticAnalysis.requireType(argTypes.get(1), CInt.TYPE, argTargets.get(1), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "val1").param(CInt.TYPE, "val2").build();
 		}
 
 		@Override
@@ -2619,9 +2514,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			return CVoid.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(CString.TYPE, "message").build();
 		}
 
 		@Override
@@ -2699,12 +2593,8 @@ public class BasicLogic {
 		}
 
 		@Override
-		public CClassType getReturnType(Target t, List<CClassType> argTypes,
-				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
-			if(argTypes.size() == 1) {
-				StaticAnalysis.requireType(argTypes.get(0), Mixed.TYPE, argTargets.get(0), env, exceptions);
-			}
-			return CInt.TYPE;
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CInt.TYPE).param(Mixed.TYPE, "val").build();
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -581,6 +581,11 @@ public class Compiler {
 		@Override
 		public CClassType getReturnType(Target t, List<CClassType> argTypes,
 				List<Target> argTargets, Environment env, Set<ConfigCompileException> exceptions) {
+			for(CClassType argType : argTypes) {
+				if(argType == null) {
+					return null; // An argument alters control flow, so this function will never return.
+				}
+			}
 			return CVoid.TYPE;
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
+++ b/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
@@ -122,8 +122,12 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder("T", Mixed.TYPE, MatchType.MATCH_FIRST).param(Booleanish.TYPE, "cond")
-					.genericParam("T", Mixed.TYPE, "ifValue").genericParam("T", Mixed.TYPE, "elseValue")
+			/*
+			 *  TODO - Decide how to define the ternary return value.
+			 *  Note that getReturnType is overridden, so these signatures are not used for typechecking.
+			 */
+			return new SignatureBuilder(CClassType.AUTO, MatchType.MATCH_FIRST).param(Booleanish.TYPE, "cond")
+					.param(Mixed.TYPE, "ifValue").param(Mixed.TYPE, "elseValue")
 					.newSignature(CVoid.TYPE).param(Booleanish.TYPE, "cond")
 					.param(null, "ifCode").param(null, "elseCode", true).build();
 		}
@@ -148,7 +152,7 @@ public class ControlFlow {
 				}
 			}
 
-			// Perform partial type inference since there is no way to set the generic type yet.
+			// Perform partial type inference since there is no way to express an A OR B type yet.
 			/*
 			 * TODO - This currently returns the lowest type if one extends the other.
 			 * Make this return a multitype instead as soon as all typechecking code supports multitypes.

--- a/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
+++ b/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
@@ -126,10 +126,13 @@ public class ControlFlow {
 			 *  TODO - Decide how to define the ternary return value.
 			 *  Note that getReturnType is overridden, so these signatures are not used for typechecking.
 			 */
-			return new SignatureBuilder(CClassType.AUTO, MatchType.MATCH_FIRST).param(Booleanish.TYPE, "cond")
-					.param(Mixed.TYPE, "ifValue").param(Mixed.TYPE, "elseValue")
-					.newSignature(CVoid.TYPE).param(Booleanish.TYPE, "cond")
-					.param(null, "ifCode").param(null, "elseCode", true).build();
+			return new SignatureBuilder(CClassType.AUTO, MatchType.MATCH_FIRST)
+					.param(Booleanish.TYPE, "cond", "The condition.")
+					.param(Mixed.TYPE, "ifValue", "The value that is returned when the condition is true.")
+					.param(Mixed.TYPE, "elseValue", "The value that is returned when the condition is false.")
+					.newSignature(CVoid.TYPE).param(Booleanish.TYPE, "cond", "The condition.")
+					.param(null, "ifCode", "The code that runs when the condition is true.")
+					.param(null, "elseCode", "The optional code that runs when the condition is false.", true).build();
 		}
 
 		@Override
@@ -1083,8 +1086,14 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(Mixed.TYPE, "assign").param(Booleanish.TYPE, "condition")
-					.param(Mixed.TYPE, "loopExpr").param(null, "loopCode").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(Mixed.TYPE, "assign", "The ivariable assign for the loop variable in this loop.")
+					.param(Booleanish.TYPE, "condition",
+							"The loop condition that is checked each time before the loopCode is executed."
+							+ "When this is false, this function returns.")
+					.param(Mixed.TYPE, "loopExpr", "The expression that is executed each time the loop continues"
+							+ " after executing the loopCode.")
+					.param(null, "loopCode", "The code that is executed in the loop.").build();
 		}
 
 		@Override
@@ -1300,8 +1309,17 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(Mixed.TYPE, "assign").param(Booleanish.TYPE, "condition")
-					.param(Mixed.TYPE, "loopExpr").param(null, "loopCode").param(null, "elseCode").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(Mixed.TYPE, "assign", "The ivariable assign for the loop variable in this loop.")
+					.param(Booleanish.TYPE, "condition",
+							"The loop condition that is checked each time before the loopCode is executed."
+							+ "When this is false, this function returns."
+							+ " If loopCode has not been executed in the first iteration, then elseCode is executed.")
+					.param(Mixed.TYPE, "loopExpr", "The expression that is executed each time the loop continues"
+							+ " after executing the loopCode.")
+					.param(null, "loopCode", "The code that is executed in the loop.")
+					.param(null, "elseCode", "The code that is executed when the condition returns"
+							+ " false in the first iteration of the loop.").build();
 		}
 
 		@Override
@@ -1531,8 +1549,12 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data")
-					.param(null, "key", true).param(null, "value").param(null, "code").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data", "The iterable data.")
+					.param(null, "key",
+							"The optional ivariable used to assign the key of each data entry key to.", true)
+					.param(null, "value", "The ivariable used to assign each data entry value to.")
+					.param(null, "code", "The code that will be executed for each entry in the data.").build();
 		}
 
 		@Override
@@ -1822,8 +1844,14 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data")
-					.param(null, "key", true).param(null, "value").param(null, "code").param(null, "elseCode").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data", "The iterable data.")
+					.param(null, "key",
+							"The optional ivariable used to assign the key of each data entry key to.", true)
+					.param(null, "value", "The ivariable used to assign each data entry value to.")
+					.param(null, "code", "The code that will be executed for each entry in the data.")
+					.param(null, "elseCode", "The code that will be executed when the data contains no entries.")
+					.build();
 		}
 
 		@Override
@@ -1976,7 +2004,10 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(Booleanish.TYPE, "cond").param(null, "code", true).build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(Booleanish.TYPE, "cond",
+							"The loop condition that is checked each time before the code is executed.")
+					.param(null, "code", "The code that is executed in the loop.", true).build();
 		}
 
 		@Override
@@ -2071,7 +2102,10 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(CVoid.TYPE).param(null, "code").param(Booleanish.TYPE, "cond").build();
+			return new SignatureBuilder(CVoid.TYPE)
+					.param(null, "code", "The code that is executed in the loop.")
+					.param(Booleanish.TYPE, "cond",
+							"The loop condition that is checked each time after the code is executed.").build();
 		}
 
 		@Override
@@ -2218,7 +2252,8 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(null).param(CInt.TYPE, "loopAmount", true).build();
+			return new SignatureBuilder(null)
+					.param(CInt.TYPE, "loopAmount", "The amount of loops to break from.", true).build();
 		}
 
 		@Override
@@ -2319,7 +2354,8 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(null).param(CInt.TYPE, "loopAmount", true).build();
+			return new SignatureBuilder(null)
+					.param(CInt.TYPE, "loopAmount", "The amount of loop iterations to continue.", true).build();
 		}
 
 		@Override
@@ -2394,8 +2430,9 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(null).param(Mixed.TYPE, "value", true)
-					.newSignature(null).param(CVoid.TYPE, "value").build();
+			return new SignatureBuilder(null)
+					.param(Mixed.TYPE, "value", "The value to return. If omitted, void will be returned.", true)
+					.build();
 		}
 	}
 
@@ -2459,7 +2496,9 @@ public class ControlFlow {
 		@Override
 		public FunctionSignatures getSignatures() {
 			// TODO - Overwrite getReturnType() to return the return type of the proc when available.
-			return new SignatureBuilder(Auto.TYPE).param(CString.TYPE, "procName").varParam(Mixed.TYPE, "args").build();
+			return new SignatureBuilder(Auto.TYPE)
+					.param(CString.TYPE, "procName", "The name of the procedure.")
+					.varParam(Mixed.TYPE, "args", "The procedure arguments.").build();
 		}
 
 		@Override
@@ -2579,7 +2618,8 @@ public class ControlFlow {
 
 		@Override
 		public FunctionSignatures getSignatures() {
-			return new SignatureBuilder(null).varParam(Mixed.TYPE, "values").build();
+			return new SignatureBuilder(null).varParam(Mixed.TYPE, "messages",
+					"The messages that will be shown to the user (concatenated together).").build();
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
+++ b/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
@@ -23,6 +23,10 @@ import com.laytonsmith.core.compiler.FileOptions;
 import com.laytonsmith.core.compiler.VariableScope;
 import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures.MatchType;
+import com.laytonsmith.core.compiler.signature.SignatureBuilder;
+import com.laytonsmith.core.constructs.Auto;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.CInt;
@@ -58,6 +62,7 @@ import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.FunctionReturnException;
 import com.laytonsmith.core.exceptions.LoopBreakException;
 import com.laytonsmith.core.exceptions.LoopContinueException;
+import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Iterator;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.tools.docgen.templates.ArrayIteration;
@@ -111,6 +116,14 @@ public class ControlFlow {
 		public Mixed exec(Target t, Environment env, Mixed... args)
 				throws CancelCommandException, ConfigRuntimeException {
 			return CVoid.VOID;
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder("T", Mixed.TYPE, MatchType.MATCH_FIRST).param(Booleanish.TYPE, "cond")
+					.genericParam("T", Mixed.TYPE, "ifValue").genericParam("T", Mixed.TYPE, "elseValue", true)
+					.newSignature(CVoid.TYPE).param(Booleanish.TYPE, "cond")
+					.param(null, "ifCode").param(null, "elseCode", true).build();
 		}
 
 		@Override
@@ -336,6 +349,15 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			/*
+			 * TODO - Implement a way to define [cond, code]* using signatures, and use it here.
+			 * Also check switch() and switch_ic(), as they need the same feature.
+			 */
+			return super.getSignatures();
+		}
+
+		@Override
 		public boolean useSpecialExec() {
 			return true;
 		}
@@ -524,6 +546,15 @@ public class ControlFlow {
 				}
 			}
 			return CVoid.VOID;
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			/*
+			 * TODO - Implement a way to define [case, code]* using signatures, and use it here.
+			 * Also check ifelse() and switch_ic(), as they need the same feature.
+			 */
+			return super.getSignatures();
 		}
 
 		@Override
@@ -1007,6 +1038,12 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(Mixed.TYPE, "assign").param(Booleanish.TYPE, "condition")
+					.param(Mixed.TYPE, "loopExpr").param(null, "loopCode").build();
+		}
+
+		@Override
 		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{CRECastException.class};
 		}
@@ -1020,10 +1057,10 @@ public class ControlFlow {
 
 		@Override
 		public String docs() {
-			return "void {assign, condition, expression1, expression2} Acts as a typical for loop. The assignment is"
+			return "void {assign, condition, loopExpr, loopCode} Acts as a typical for loop. The assignment is"
 					+ " first run. Then, a condition is checked. If that condition is checked and returns true,"
-					+ " expression2 is run. After that, expression1 is run. In java syntax, this would be:"
-					+ " for(assign; condition; expression1){expression2}. assign must be an ivariable, either a "
+					+ " loopCode is run. After that, loopExpr is run. In java syntax, this would be:"
+					+ " for(assign; condition; loopExpr){loopCode}. assign must be an ivariable, either a "
 					+ "pre defined one, or the results of the assign() function. condition must be a boolean.";
 		}
 
@@ -1218,6 +1255,12 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(Mixed.TYPE, "assign").param(Booleanish.TYPE, "condition")
+					.param(Mixed.TYPE, "loopExpr").param(null, "loopCode").param(null, "elseCode").build();
+		}
+
+		@Override
 		public Scope linkScope(StaticAnalysis analysis, Scope parentScope,
 				ParseTree ast, Environment env, Set<ConfigCompileException> exceptions) {
 			if(ast.numberOfChildren() >= (this.runAsFor ? 3 : 4)) {
@@ -1246,7 +1289,7 @@ public class ControlFlow {
 
 		@Override
 		public String docs() {
-			return "void {assign, condition, expression1, expression2, else} Works like a normal for loop, but if upon"
+			return "void {assign, condition, loopExpr, loopCode, elseCode} Works like a normal for loop, but if upon"
 					+ " checking the condition the first time, it is determined that it is false (that is, NO code"
 					+ " loops are going to be run) the else code is run instead. If the loop runs, even once, it will"
 					+ " NOT run the else branch. In general, brace syntax and use of for(){ } else { } syntax is"
@@ -1440,6 +1483,12 @@ public class ControlFlow {
 				}
 			}
 			return CVoid.VOID;
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data")
+					.param(null, "key", true).param(null, "value").param(null, "code").build();
 		}
 
 		@Override
@@ -1728,6 +1777,12 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(com.laytonsmith.core.natives.interfaces.Iterable.TYPE, "data")
+					.param(null, "key", true).param(null, "value").param(null, "code").param(null, "elseCode").build();
+		}
+
+		@Override
 		public Scope linkScope(StaticAnalysis analysis, Scope parentScope,
 				ParseTree ast, Environment env, Set<ConfigCompileException> exceptions) {
 			if(ast.numberOfChildren() >= 4) {
@@ -1876,6 +1931,11 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(Booleanish.TYPE, "cond").param(null, "code", true).build();
+		}
+
+		@Override
 		public boolean useSpecialExec() {
 			return true;
 		}
@@ -1963,6 +2023,11 @@ public class ControlFlow {
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			return CNull.NULL;
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(CVoid.TYPE).param(null, "code").param(Booleanish.TYPE, "cond").build();
 		}
 
 		@Override
@@ -2108,6 +2173,11 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(null).param(CInt.TYPE, "loopAmount", true).build();
+		}
+
+		@Override
 		public ExampleScript[] examples() throws ConfigCompileException {
 			return new ExampleScript[]{
 				new ExampleScript("Basic usage", "for(assign(@i, 0), @i < 1000, @i++,\n"
@@ -2204,6 +2274,11 @@ public class ControlFlow {
 		}
 
 		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(null).param(CInt.TYPE, "loopAmount", true).build();
+		}
+
+		@Override
 		public ExampleScript[] examples() throws ConfigCompileException {
 			return new ExampleScript[]{
 				new ExampleScript("Basic usage", "for(assign(@i, 0), @i < 5, @i++){\n"
@@ -2272,6 +2347,12 @@ public class ControlFlow {
 			Mixed ret = (args.length == 1 ? args[0] : CVoid.VOID);
 			throw new FunctionReturnException(ret, t);
 		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(null).param(Mixed.TYPE, "value", true)
+					.newSignature(null).param(CVoid.TYPE, "value").build();
+		}
 	}
 
 	@api
@@ -2329,6 +2410,12 @@ public class ControlFlow {
 				return proc.execute(vars, env, t);
 			}
 			throw new CREInvalidProcedureException("Unknown procedure \"" + args[0].val() + "\"", t);
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			// TODO - Overwrite getReturnType() to return the return type of the proc when available.
+			return new SignatureBuilder(Auto.TYPE).param(CString.TYPE, "procName").varParam(Mixed.TYPE, "args").build();
 		}
 
 		@Override
@@ -2444,6 +2531,11 @@ public class ControlFlow {
 			} finally {
 				throw new CancelCommandException("", t);
 			}
+		}
+
+		@Override
+		public FunctionSignatures getSignatures() {
+			return new SignatureBuilder(null).varParam(Mixed.TYPE, "values").build();
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Function.java
+++ b/src/main/java/com/laytonsmith/core/functions/Function.java
@@ -6,6 +6,8 @@ import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Script;
 import com.laytonsmith.core.compiler.analysis.Scope;
 import com.laytonsmith.core.compiler.analysis.StaticAnalysis;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
+import com.laytonsmith.core.compiler.signature.SignatureBuilder;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
@@ -77,6 +79,12 @@ public interface Function extends FunctionBase, Documentation, Comparable<Functi
 	 * @throws CancelCommandException
 	 */
 	public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException;
+
+	/**
+	 * Gets the function's signatures. {@link SignatureBuilder} offers a convenient way to create these signatures.
+	 * @return This function's signatures.
+	 */
+	public FunctionSignatures getSignatures();
 
 	/**
 	 * Gets the return type of this function, based on the types of the passed arguments.

--- a/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
+++ b/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
@@ -57,7 +57,7 @@ public class FunctionSignaturesTest {
 	public void testSingleParam() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert that a parameter was added with the correct type and description.
 		assertEquals(1, signatures.getSignatures().size());
@@ -71,7 +71,7 @@ public class FunctionSignaturesTest {
 	public void testSingleThrows() {
 
 		// Create "array func(int param1) throws CREIndexOverflowException" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1")
 				.throwsEx(CREIndexOverflowException.class, "exDesc").build();
 
 		// Assert that a throws was added with the correct exception class and description.
@@ -86,7 +86,7 @@ public class FunctionSignaturesTest {
 	public void testDoubleThrows() {
 
 		// Create "array func(int param1) throws CREIndexOverflowException, CRECastException" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1")
 				.throwsEx(CREIndexOverflowException.class, "exDesc1")
 				.throwsEx(CRECastException.class, "exDesc2").build();
 
@@ -141,7 +141,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureMatch() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for one argument.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -158,7 +158,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureAutoMatch() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for one argument.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -175,7 +175,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureTooFewArgs() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for two arguments.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -192,7 +192,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureTooManyArgs() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for two arguments.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -209,7 +209,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureWrongType() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for one wrongly typed argument.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -226,7 +226,7 @@ public class FunctionSignaturesTest {
 	public void testSingleArgSingleSignatureWrongVoidType() {
 
 		// Create "array func(int param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for one wrongly typed argument.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -243,8 +243,8 @@ public class FunctionSignaturesTest {
 	public void testSingleArgMultiSignatureSingleMatch1() {
 
 		// Create "array func(int param1)|int func(boolean param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
-				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for matching the first signature.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -261,8 +261,8 @@ public class FunctionSignaturesTest {
 	public void testSingleArgMultiSignatureSingleMatch2() {
 
 		// Create "array func(int param1)|int func(boolean param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
-				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for matching the second signature.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -279,8 +279,8 @@ public class FunctionSignaturesTest {
 	public void testSingleArgMultiSignatureMultiMatchSameType() {
 
 		// Create "int func(int param1)|int func(boolean param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1")
-				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1", "desc1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for matching the both signatures.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -298,8 +298,8 @@ public class FunctionSignaturesTest {
 	public void testSingleArgMultiSignatureMultiMatchDifferentType() {
 
 		// Create "array func(int param1)|int func(boolean param1)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1")
-				.newSignature(CArray.TYPE).param(CBoolean.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1", "desc1")
+				.newSignature(CArray.TYPE).param(CBoolean.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for matching the both signatures.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -316,7 +316,7 @@ public class FunctionSignaturesTest {
 	public void testOptionalArgSingleSignatureMatch() {
 
 		// Create "array func([int param1])" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", true).build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", "desc1", true).build();
 
 		// Assert return type and compile exceptions for zero and one arguments.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -340,7 +340,7 @@ public class FunctionSignaturesTest {
 	public void testVarArgSingleSignatureMatch() {
 
 		// Create "array func(int param1...)" signature.
-		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).varParam(CInt.TYPE, "param1").build();
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).varParam(CInt.TYPE, "param1", "desc1").build();
 
 		// Assert return type and compile exceptions for zero, one and two arguments.
 		Set<ConfigCompileException> exceptions = new HashSet<>();
@@ -372,8 +372,9 @@ public class FunctionSignaturesTest {
 
 		// Create "array func(int param1, int param2..., int param3, [array param4], array param5)" signature.
 		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE)
-				.param(CInt.TYPE, "param1").varParam(CInt.TYPE, "param2").param(CInt.TYPE, "param3")
-				.param(CArray.TYPE, "param4", true).param(CArray.TYPE, "param5").build();
+				.param(CInt.TYPE, "param1", "desc1").varParam(CInt.TYPE, "param2", "desc2")
+				.param(CInt.TYPE, "param3", "desc3").param(CArray.TYPE, "param4", "desc4", true)
+				.param(CArray.TYPE, "param5", "desc5").build();
 
 		// Validate signature parameter types through its string version.
 		assertEquals("(int, int..., int, [array], array)", signatures.getSignaturesParamTypesString());
@@ -410,9 +411,10 @@ public class FunctionSignaturesTest {
 		// Create "array func(int param1..., int param2..., int param3...,
 		// [int param4], int param5, int param6, int param7)" signature.
 		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE)
-				.varParam(CInt.TYPE, "param1").varParam(CInt.TYPE, "param2").varParam(CInt.TYPE, "param3")
-				.param(CInt.TYPE, "param4", true).param(CInt.TYPE, "param5").param(CInt.TYPE, "param6")
-				.param(CInt.TYPE, "param7").build();
+				.varParam(CInt.TYPE, "param1", "desc1").varParam(CInt.TYPE, "param2", "desc2")
+				.varParam(CInt.TYPE, "param3", "desc3").param(CInt.TYPE, "param4", "desc4", true)
+				.param(CInt.TYPE, "param5", "desc5").param(CInt.TYPE, "param6", "desc6")
+				.param(CInt.TYPE, "param7", "desc7").build();
 
 		// Validate signature parameter types through its string version.
 		assertEquals("(int..., int..., int..., [int], int, int, int)", signatures.getSignaturesParamTypesString());

--- a/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
+++ b/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
@@ -1,0 +1,437 @@
+package com.laytonsmith.core.compiler.signatures;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.laytonsmith.core.Static;
+import com.laytonsmith.core.compiler.signature.FunctionSignatures;
+import com.laytonsmith.core.compiler.signature.Param;
+import com.laytonsmith.core.compiler.signature.SignatureBuilder;
+import com.laytonsmith.core.compiler.signature.Throws;
+import com.laytonsmith.core.constructs.CArray;
+import com.laytonsmith.core.constructs.CBoolean;
+import com.laytonsmith.core.constructs.CClassType;
+import com.laytonsmith.core.constructs.CInt;
+import com.laytonsmith.core.constructs.CVoid;
+import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
+import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.core.exceptions.CRE.CREIndexOverflowException;
+import com.laytonsmith.testing.StaticTest;
+
+public class FunctionSignaturesTest {
+
+	private Environment env;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		StaticTest.InstallFakeServerFrontend();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		this.env = Static.GenerateStandaloneEnvironment(false);
+	}
+
+	@Test
+	public void testReturnType() {
+
+		// Create "array func()" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).build();
+
+		// Assert that the return type was correctly set.
+		assertEquals(CArray.TYPE, signatures.getSignatures().get(0).getReturnType().getType());
+	}
+
+	@Test
+	public void testSingleParam() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert that a parameter was added with the correct type and description.
+		assertEquals(1, signatures.getSignatures().size());
+		List<Param> paramsList = signatures.getSignatures().get(0).getParams();
+		assertEquals(1, paramsList.size());
+		assertEquals("param1", paramsList.get(0).getName());
+		assertEquals(CInt.TYPE, paramsList.get(0).getType());
+	}
+
+	@Test
+	public void testSingleThrows() {
+
+		// Create "array func(int param1) throws CREIndexOverflowException" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+				.throwsEx(CREIndexOverflowException.class, "exDesc").build();
+
+		// Assert that a throws was added with the correct exception class and description.
+		assertEquals(1, signatures.getSignatures().size());
+		List<Throws> throwsList = signatures.getSignatures().get(0).getThrows();
+		assertEquals(1, throwsList.size());
+		assertEquals("exDesc", throwsList.get(0).getThrownWhen());
+		assertEquals(CREIndexOverflowException.class, throwsList.get(0).getExceptionClass());
+	}
+
+	@Test
+	public void testDoubleThrows() {
+
+		// Create "array func(int param1) throws CREIndexOverflowException, CRECastException" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+				.throwsEx(CREIndexOverflowException.class, "exDesc1")
+				.throwsEx(CRECastException.class, "exDesc2").build();
+
+		assertEquals(1, signatures.getSignatures().size());
+		List<Throws> throwsList = signatures.getSignatures().get(0).getThrows();
+		assertEquals(2, throwsList.size());
+		for(Throws throwsObj : throwsList) {
+			if(throwsObj.getThrownWhen().equals("exDesc1")) {
+				assertEquals(CREIndexOverflowException.class, throwsObj.getExceptionClass());
+			} else {
+				assertEquals("exDesc2", throwsObj.getThrownWhen());
+				assertEquals(CRECastException.class, throwsObj.getExceptionClass());
+			}
+		}
+	}
+
+	@Test
+	public void testNoArgsSingleSignatureMatch() {
+
+		// Create "void func()" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CVoid.TYPE).build();
+
+		// Assert return type and compile exceptions for zero arguments.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(),
+				Arrays.asList(),
+				this.env, exceptions);
+		assertEquals(CVoid.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testNoArgsSingleSignatureTooManyArgs() {
+
+		// Create "void func()" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CVoid.TYPE).build();
+
+		// Assert return type and compile exceptions for one argument.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertFalse(exceptions.isEmpty());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureMatch() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for one argument.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureAutoMatch() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for one argument.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CClassType.AUTO),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureTooFewArgs() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for two arguments.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(),
+				Arrays.asList(),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertFalse(exceptions.isEmpty());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureTooManyArgs() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for two arguments.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE, CBoolean.TYPE),
+				Arrays.asList(Target.UNKNOWN, Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertFalse(exceptions.isEmpty());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureWrongType() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for one wrongly typed argument.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CBoolean.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertFalse(exceptions.isEmpty());
+	}
+
+	@Test
+	public void testSingleArgSingleSignatureWrongVoidType() {
+
+		// Create "array func(int param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for one wrongly typed argument.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CVoid.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertFalse(exceptions.isEmpty());
+	}
+
+	@Test
+	public void testSingleArgMultiSignatureSingleMatch1() {
+
+		// Create "array func(int param1)|int func(boolean param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for matching the first signature.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testSingleArgMultiSignatureSingleMatch2() {
+
+		// Create "array func(int param1)|int func(boolean param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for matching the second signature.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CBoolean.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CInt.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testSingleArgMultiSignatureMultiMatchSameType() {
+
+		// Create "int func(int param1)|int func(boolean param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1")
+				.newSignature(CInt.TYPE).param(CBoolean.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for matching the both signatures.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CClassType.AUTO),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CInt.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	@Deprecated // This test should fail as soon as multiple signature matches can return an A OR B type.
+	public void testSingleArgMultiSignatureMultiMatchDifferentType() {
+
+		// Create "array func(int param1)|int func(boolean param1)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CInt.TYPE).param(CInt.TYPE, "param1")
+				.newSignature(CArray.TYPE).param(CBoolean.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for matching the both signatures.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CClassType.AUTO),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CClassType.AUTO, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testOptionalArgSingleSignatureMatch() {
+
+		// Create "array func([int param1])" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).param(CInt.TYPE, "param1", true).build();
+
+		// Assert return type and compile exceptions for zero and one arguments.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType1 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(),
+				Arrays.asList(),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType1);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+		CClassType returnType2 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType2);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testVarArgSingleSignatureMatch() {
+
+		// Create "array func(int param1...)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE).varParam(CInt.TYPE, "param1").build();
+
+		// Assert return type and compile exceptions for zero, one and two arguments.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType1 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(),
+				Arrays.asList(),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType1);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+		CClassType returnType2 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType2);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+		CClassType returnType3 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE, CInt.TYPE),
+				Arrays.asList(Target.UNKNOWN, Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType3);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testComplexSingleSignatureMatch() {
+
+		// Create "array func(int param1, int param2..., int param3, [array param4], array param5)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE)
+				.param(CInt.TYPE, "param1").varParam(CInt.TYPE, "param2").param(CInt.TYPE, "param3")
+				.param(CArray.TYPE, "param4", true).param(CArray.TYPE, "param5").build();
+
+		// Validate signature parameter types through its string version.
+		assertEquals("(int, int..., int, [array], array)", signatures.getSignaturesParamTypesString());
+
+		// Assert return type and compile exceptions for matching the signature in multiple ways.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		CClassType returnType = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE, CInt.TYPE, CArray.TYPE),
+				Arrays.asList(Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+		CClassType returnType2 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE, CInt.TYPE, CInt.TYPE, CInt.TYPE, CArray.TYPE),
+				Arrays.asList(Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType2);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+		CClassType returnType3 = signatures.getReturnType(
+				Target.UNKNOWN,
+				Arrays.asList(CInt.TYPE, CInt.TYPE, CInt.TYPE, CInt.TYPE, CArray.TYPE, CArray.TYPE),
+				Arrays.asList(Target.UNKNOWN, Target.UNKNOWN,
+						Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN, Target.UNKNOWN),
+				this.env, exceptions);
+		assertEquals(CArray.TYPE, returnType3);
+		assertArrayEquals(new Object[0], exceptions.toArray());
+	}
+
+	@Test
+	public void testComplexSingleAmbiguousSignatureMatch() {
+
+		// Create "array func(int param1..., int param2..., int param3...,
+		// [int param4], int param5, int param6, int param7)" signature.
+		FunctionSignatures signatures = new SignatureBuilder(CArray.TYPE)
+				.varParam(CInt.TYPE, "param1").varParam(CInt.TYPE, "param2").varParam(CInt.TYPE, "param3")
+				.param(CInt.TYPE, "param4", true).param(CInt.TYPE, "param5").param(CInt.TYPE, "param6")
+				.param(CInt.TYPE, "param7").build();
+
+		// Validate signature parameter types through its string version.
+		assertEquals("(int..., int..., int..., [int], int, int, int)", signatures.getSignaturesParamTypesString());
+
+		// Assert return type and compile exceptions for matching the signature from 4 to 10 arguments.
+		// The interesting part about this test is that the varargs need to be backtrack-unmatched through multiple
+		// other varargs and an optional arg to match the last 3 arguments properly.
+		Set<ConfigCompileException> exceptions = new HashSet<>();
+		for(int numArgs = 3; numArgs < 10; numArgs++) {
+			List<CClassType> argTypes = new ArrayList<>();
+			List<Target> argTargets = new ArrayList<>();
+			for(int i = 0; i < numArgs; i++) {
+				argTypes.add(CInt.TYPE);
+				argTargets.add(Target.UNKNOWN);
+			}
+			CClassType returnType = signatures.getReturnType(
+					Target.UNKNOWN, argTypes, argTargets, this.env, exceptions);
+			assertEquals(CArray.TYPE, returnType);
+			assertArrayEquals(new Object[0], exceptions.toArray());
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a basic function signature framework and allows for defining signatures in functions for typechecking. In the current state, any MS function signature should be creatable, but signatures with generic types are not yet handled in typechecking.

Note: As long as the [WIP] prefix is in the PR title, it should not be merged.