### PR TITLE
CSS - Paragraph margin changed to 1em top & bottom

### DIFF
--- a/src/main/resources/siteDeploy/resources/css/style.css
+++ b/src/main/resources/siteDeploy/resources/css/style.css
@@ -41,7 +41,7 @@ em, i {
 }
 
 p {
-    margin: 0 0 2em 0;
+    margin: 1em 0 1em 0;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Currently the CSS styles used for the documentation site add a 2em margin below each paragraph, which means the paragraph is very close to anything that is *not* a paragraph above it.

To fix this, we can spread the margin between top and bottom, giving 1em each.