### PR TITLE
set_timeout example output should say 10 seconds

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Scheduling.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scheduling.java
@@ -419,7 +419,7 @@ public class Scheduling {
 			return new ExampleScript[]{
 				new ExampleScript("Basic usage", "set_timeout(10000, closure(){\n"
 				+ "\tmsg('Hello World!');\n"
-				+ "});", "<Would wait 5 seconds, then message the user \"Hello World!\">")
+				+ "});", "<Would wait 10 seconds, then message the user \"Hello World!\">")
 			};
 		}
 


### PR DESCRIPTION
The example code uses 10000 milliseconds, but the output is described as waiting 5 seconds. It should say 10 seconds instead :)