### PR TITLE
Add smart comments to aliases, and implement @command structure

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/SmartComment.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/SmartComment.java
@@ -127,7 +127,7 @@ public class SmartComment {
 	}
 
 	/**
-	 * Gets the body of the comment block.
+	 * Gets the body of the comment block. This will never be null.
 	 *
 	 * @return
 	 */
@@ -136,7 +136,8 @@ public class SmartComment {
 	}
 
 	/**
-	 * Gets a list of annotation values for the comment block.
+	 * Gets a list of annotation values for the comment block. If the annotation doesn't exist, an empty list
+	 * is returned.
 	 *
 	 * @param annotation
 	 * @return
@@ -145,7 +146,27 @@ public class SmartComment {
 		if(!annotation.startsWith("@")) {
 			annotation = "@" + annotation;
 		}
-		return new ArrayList<>(annotations.get(annotation));
+		List<String> ann = annotations.get(annotation);
+		if(ann == null) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(ann);
+	}
+
+	/**
+	 * Returns a complete set of annotations in this comment. Note that this doesn't include
+	 * embedded annotations, only the standalone ones. Further, note that the keys in the map
+	 * will start with the at symbol, a fact which is optional to consider when using the
+	 * {@link #getAnnotations(java.lang.String)} method, so consider using that if you aren't
+	 * iterating through the list dynamically.
+	 * @return
+	 */
+	public Map<String, List<String>> getAnnotations() {
+		Map<String, List<String>> ret = new HashMap<>();
+		for(String key : annotations.keySet()) {
+			ret.put(key, getAnnotations(key));
+		}
+		return ret;
 	}
 
 	public static interface Replacement {

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
@@ -575,6 +575,8 @@ public class CommandHelperPlugin extends JavaPlugin {
 			ac.reload(player, args, false);
 			return true;
 		} else if(cmdName.equalsIgnoreCase("commandhelper")) {
+			// Despite looking useless, this isn't. It's used for the server events and other
+			// places. Look for "commandhelper null" in the codebase.
 			return args.length >= 1 && args[0].equalsIgnoreCase("null");
 		} else if(cmdName.equals("runalias")) {
 			//Hardcoded alias rebroadcast

--- a/src/main/java/com/laytonsmith/core/Procedure.java
+++ b/src/main/java/com/laytonsmith/core/Procedure.java
@@ -188,7 +188,7 @@ public class Procedure implements Cloneable {
 		}
 		oldEnv.getEnv(GlobalEnv.class).setCloneVars(prev);
 
-		Script fakeScript = Script.GenerateScript(tree, env.getEnv(GlobalEnv.class).GetLabel()); // new Script(null, null);
+		Script fakeScript = Script.GenerateScript(tree, env.getEnv(GlobalEnv.class).GetLabel(), null);
 
 		// Create container for the @arguments variable.
 		CArray arguments = new CArray(Target.UNKNOWN, this.varIndex.size());

--- a/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
+++ b/src/main/java/com/laytonsmith/core/environments/GlobalEnv.java
@@ -2,6 +2,7 @@ package com.laytonsmith.core.environments;
 
 import com.laytonsmith.PureUtilities.Common.MutableObject;
 import com.laytonsmith.PureUtilities.ExecutionQueue;
+import com.laytonsmith.PureUtilities.SmartComment;
 import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSLog;
 import com.laytonsmith.core.MethodScriptExecutionQueue;
@@ -53,6 +54,7 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 	private Map<String, Procedure> procs = null;
 	private IVariableList iVariableList = null;
 	private String label = null;
+	private SmartComment aliasComment = null;
 	private final EnumSet<RuntimeMode> runtimeModes;
 	private boolean dynamicScriptingMode = false;
 	private BoundEvent.ActiveEvent event = null;
@@ -259,6 +261,14 @@ public class GlobalEnv implements Environment.EnvironmentImpl, Cloneable {
 
 	public void SetLabel(String label) {
 		this.label = label;
+	}
+
+	public SmartComment GetAliasComment() {
+		return aliasComment;
+	}
+
+	public void SetAliasComment(SmartComment comment) {
+		this.aliasComment = comment;
 	}
 
 	public boolean inCmdlineMode() {

--- a/src/main/java/com/laytonsmith/core/functions/Commands.java
+++ b/src/main/java/com/laytonsmith/core/functions/Commands.java
@@ -89,7 +89,7 @@ public class Commands {
 		 * @param cmd
 		 * @param arg
 		 */
-		static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
+		public static void customExec(Target t, Environment environment, MCCommand cmd, Mixed arg) {
 			if(arg.isInstanceOf(CClosure.TYPE)) {
 				onTabComplete.put(cmd.getName(), (CClosure) arg);
 			} else {

--- a/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
+++ b/src/main/java/com/laytonsmith/core/functions/CompositeFunction.java
@@ -79,7 +79,7 @@ public abstract class CompositeFunction extends AbstractFunction {
 				gEnv.GetScript().eval(tree, env);
 			} else {
 				// This can happen when the environment is not fully setup during tests, in addition to optimization
-				Script.GenerateScript(null, null).eval(tree, env);
+				Script.GenerateScript(null, null, null).eval(tree, env);
 			}
 		} catch (FunctionReturnException ex) {
 			ret = ex.getReturn();

--- a/src/main/java/com/laytonsmith/core/functions/DataHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/DataHandling.java
@@ -1598,7 +1598,7 @@ public class DataHandling {
 						options = children.get(0).getFileOptions();
 					}
 					ParseTree root = new ParseTree(new CFunction(__autoconcat__.NAME, Target.UNKNOWN), options);
-					Script fakeScript = Script.GenerateScript(root, Static.GLOBAL_PERMISSION);
+					Script fakeScript = Script.GenerateScript(root, Static.GLOBAL_PERMISSION, null);
 					Environment env = Static.GenerateStandaloneEnvironment();
 					env.getEnv(GlobalEnv.class).SetScript(fakeScript);
 					Mixed c = myProc.cexecute(children, env, t);
@@ -2422,7 +2422,7 @@ public class DataHandling {
 				List<ParseTree> children = new ArrayList<>();
 				children.add(node);
 				newNode.setChildren(children);
-				Script fakeScript = Script.GenerateScript(newNode, myEnv.getEnv(GlobalEnv.class).GetLabel());
+				Script fakeScript = Script.GenerateScript(newNode, myEnv.getEnv(GlobalEnv.class).GetLabel(), null);
 				myEnv.getEnv(GlobalEnv.class).SetFlag("closure-warn-overwrite", true);
 				Mixed ret = MethodScriptCompiler.execute(newNode, myEnv, null, fakeScript);
 				myEnv.getEnv(GlobalEnv.class).ClearFlag("closure-warn-overwrite");
@@ -2594,7 +2594,7 @@ public class DataHandling {
 				List<ParseTree> children = new ArrayList<>();
 				children.add(node);
 				newNode.setChildren(children);
-				Script fakeScript = Script.GenerateScript(newNode, myEnv.getEnv(GlobalEnv.class).GetLabel());
+				Script fakeScript = Script.GenerateScript(newNode, myEnv.getEnv(GlobalEnv.class).GetLabel(), null);
 				myEnv.getEnv(GlobalEnv.class).SetFlag("closure-warn-overwrite", true);
 				Mixed ret = MethodScriptCompiler.execute(newNode, myEnv, null, fakeScript);
 				myEnv.getEnv(GlobalEnv.class).ClearFlag("closure-warn-overwrite");

--- a/src/main/java/com/laytonsmith/core/functions/ExampleScript.java
+++ b/src/main/java/com/laytonsmith/core/functions/ExampleScript.java
@@ -205,7 +205,7 @@ public class ExampleScript {
 		if(output != null) {
 			return output;
 		}
-		Script s = Script.GenerateScript(script, Static.GLOBAL_PERMISSION);
+		Script s = Script.GenerateScript(script, Static.GLOBAL_PERMISSION, null);
 		Environment env;
 		try {
 			env = Static.GenerateStandaloneEnvironment();

--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -2,6 +2,7 @@ package com.laytonsmith.core.functions;
 
 import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscovery;
 import com.laytonsmith.PureUtilities.Common.StreamUtils;
+import com.laytonsmith.PureUtilities.SmartComment;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.abstraction.Implementation;
 import com.laytonsmith.abstraction.MCBlockCommandSender;
@@ -61,6 +62,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.jar.JarFile;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.zip.ZipEntry;
@@ -1634,6 +1636,66 @@ public class Meta {
 		@Override
 		public Version since() {
 			return MSVersion.V3_3_4;
+		}
+
+	}
+
+	@api
+	public static class get_alias_comment extends AbstractFunction {
+
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
+			return new Class[]{};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return true;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
+			SmartComment comment = environment.getEnv(GlobalEnv.class).GetAliasComment();
+			CArray ret = CArray.GetAssociativeArray(t);
+			ret.set("body", comment.getBody());
+			CArray annotations = CArray.GetAssociativeArray(t);
+			ret.set("annotations", annotations, t);
+			for(Map.Entry<String, List<String>> entry : comment.getAnnotations().entrySet()) {
+				CArray list = new CArray(t, entry.getValue().size());
+				for(String s : entry.getValue()) {
+					list.push(new CString(s, t), t);
+				}
+				annotations.set(entry.getKey(), list, t);
+			}
+			return ret;
+		}
+
+		@Override
+		public String getName() {
+			return "get_alias_comment";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{0};
+		}
+
+		@Override
+		public String docs() {
+			return "array {} Returns the smart comment on the currently running alias. The array returned will contain"
+					+ " the comment body in the 'body' element, and the annotations in the 'annotations' element as"
+					+ " an associative array. Each key in the annotation will contain an at symbol, so for instance"
+					+ " '@annotation' and the value is an array of all occurances. ";
+		}
+
+		@Override
+		public Version since() {
+			return MSVersion.V0_0_0;
 		}
 
 	}

--- a/src/main/resources/docs/Advanced_Guide
+++ b/src/main/resources/docs/Advanced_Guide
@@ -1,13 +1,13 @@
 
-If you are wanting to do more dynamic things other than variables, CommandHelper allows you to do this through the 
-use of Turing complete language, MethodScript. If you aren't familiar with any type of programming, you may wish to 
-find resources on languages like Java and PHP. The language mirrors both languages in certain ways, as well as 
+If you are wanting to do more dynamic things other than variables, CommandHelper allows you to do this through the
+use of Turing complete language, MethodScript. If you aren't familiar with any type of programming, you may wish to
+find resources on languages like Java and PHP. The language mirrors both languages in certain ways, as well as
 introducing its own methodologies.
 
 
 ===Functions===
 
-Functions allow for very dynamic scripts to be run. There are many defined functions, including functions that provide 
+Functions allow for very dynamic scripts to be run. There are many defined functions, including functions that provide
 control flow functionality. For the full list of functions, see the [[API]]. A function is identified
 by a literal string, followed by parenthesis. So in <code>func()</code>, "func" is the name of the function, and "("
 and ")" begin and end the function argument list (in this case, there are no arguments being passed in.) Functions
@@ -35,8 +35,8 @@ hashbang for cmdline code.
 Block comments start with <code>/*</code> and end with <code>*/</code> This causes the compiler to ignore everything
 within the comment block, including newlines.
 
-Smart comments are like block comments, but start with <code>/**</code> (two asterisks) instead. They are currently
-unused, but are reserved for future use. They are used for documentation generation functionality.
+Smart comments are like block comments, but start with <code>/**</code> (two asterisks) instead. See the article
+on [[SmartComments]] for more details about the format in general, and below for information specific to aliases.
 
 %%CODE|
 code(); # line comment
@@ -57,43 +57,43 @@ code();
 %%
 
 ===Data Types===
-In a script, there are several types of data. The language is currently loosely typed however, so the string '2' is 
-equivalent to the integer 2, is equivalent to the double 2.0, is equivalent to the boolean true. Values are cast just 
-before they are used. Note that sometimes data cannot be cast, for instance the string 'string' cannot be cast to a 
-number, so a runtime exception will be thrown if a function expects a number, and is given that. Also, arrays are not 
+In a script, there are several types of data. The language is currently loosely typed however, so the string '2' is
+equivalent to the integer 2, is equivalent to the double 2.0, is equivalent to the boolean true. Values are cast just
+before they are used. Note that sometimes data cannot be cast, for instance the string 'string' cannot be cast to a
+number, so a runtime exception will be thrown if a function expects a number, and is given that. Also, arrays are not
 able to be cast into other data types, but can contain values of any data type.
 
 * boolean - Created with the "true" or "false" keywords: true
 * int - Any number that doesn't have a decimal point: 2
 * double - Any number that has a decimal point: 2.0
-* string - Any set of characters surrounded by single quotes or double quotes: 'string', "also a string". 
-\u0000 inside a string will allow for arbitrary unicode characters to be inserted into a string, and \n is a newline. 
+* string - Any set of characters surrounded by single quotes or double quotes: 'string', "also a string".
+\u0000 inside a string will allow for arbitrary unicode characters to be inserted into a string, and \n is a newline.
 \\ (double slash) inserts a literal slash, and \' will insert a literal quote.
 * array - An array of any other datatypes, including other arrays. Created by using the function <code>array</code>
 * null - Created with the "null" keyword: null
-* void - Some functions return void, which is actually a datatype. When viewed as a string, it is equivalent to an 
+* void - Some functions return void, which is actually a datatype. When viewed as a string, it is equivalent to an
 empty string. Cannot be created directly.
-* ivariable - An ivariable (or simply a variable) is a variable that can be defined and used from within the script. 
-Constant variables ($var), are assigned by the user at command runtime, and are technically constants as far as the 
-rest of the script is concerned. IVariables can be defined by the script writer and assigned various values that can 
-change throughout the script running. To define and use an ivariable, use the assign() function, or the = operator. 
-If an ivariable is used without first being defined, the value of the variable will be 0, 0.0, %%NOWIKI|''%%, 
-false, or null, depending on how it is used. Most functions use the value in the ivariable without caring that it is 
-an ivariable, but it is possible that a function requires that a certain argument be an ivariable, such as the for() 
+* ivariable - An ivariable (or simply a variable) is a variable that can be defined and used from within the script.
+Constant variables ($var), are assigned by the user at command runtime, and are technically constants as far as the
+rest of the script is concerned. IVariables can be defined by the script writer and assigned various values that can
+change throughout the script running. To define and use an ivariable, use the assign() function, or the = operator.
+If an ivariable is used without first being defined, the value of the variable will be 0, 0.0, %%NOWIKI|''%%,
+false, or null, depending on how it is used. Most functions use the value in the ivariable without caring that it is
+an ivariable, but it is possible that a function requires that a certain argument be an ivariable, such as the for()
 function.
 
 ===Exception Handling===
-Sometimes a script may sometimes cause an error that could be anticipated. Instead of just having the script die, it is 
-possible to catch these errors, and perform alternate functionality. MethodScript mirrors the functionality of languages 
-like PHP and Java with exception handling. For more information about exception handling in MScript, see 
-[[Exceptions|this page]]. For a more general discussion on exception handling, see 
+Sometimes a script may sometimes cause an error that could be anticipated. Instead of just having the script die, it is
+possible to catch these errors, and perform alternate functionality. MethodScript mirrors the functionality of languages
+like PHP and Java with exception handling. For more information about exception handling in MScript, see
+[[Exceptions|this page]]. For a more general discussion on exception handling, see
 [http://en.wikipedia.org/wiki/Exception_handling this page] on Wikipedia.
 
 === main.ms, auto_include.ms, and aliases.msa ===
-Each of these files serve a separate purpose. main.ms is run at server startup, only once. Typically, you use this to 
-register bound events, using the bind() function, or anything else you want to run only once. Keep in mind, this is 
-re-run when you /reloadaliases, but bound events and intervals and such are stopped, so you won't have multiples of 
-anything. main.ms uses '''pure MethodScript''', that is, it has a slightly different syntax than aliases.msa. In aliases.msa, 
+Each of these files serve a separate purpose. main.ms is run at server startup, only once. Typically, you use this to
+register bound events, using the bind() function, or anything else you want to run only once. Keep in mind, this is
+re-run when you /reloadaliases, but bound events and intervals and such are stopped, so you won't have multiples of
+anything. main.ms uses '''pure MethodScript''', that is, it has a slightly different syntax than aliases.msa. In aliases.msa,
 each alias is defined, along with a snippet of MethodScript. For instance, in the alias,
 
 %%ALIAS|
@@ -102,21 +102,21 @@ each alias is defined, along with a snippet of MethodScript. For instance, in th
 <<<
 %%
 
-the <code>/test [$command=%%NOWIKI|''%%] = &gt;&gt;&gt; &lt;&lt;&lt;</code> part is the alias markup, and is not actual MethodScript, 
-that is, the symbols and characters follow different meanings than inside the alias definition. In this example, 
+the <code>/test [$command=%%NOWIKI|''%%] = &gt;&gt;&gt; &lt;&lt;&lt;</code> part is the alias markup, and is not actual MethodScript,
+that is, the symbols and characters follow different meanings than inside the alias definition. In this example,
 <code>console($command);</code> is pure MethodScript.
 
-aliases.msa is where your aliases go, and each alias is a fully separate '''compilation unit''', in fact, even a compile 
+aliases.msa is where your aliases go, and each alias is a fully separate '''compilation unit''', in fact, even a compile
 error in one alias will not usually interfere with the other aliases.
 
-The auto_include.ms file is also a pure MethodScript file, and it is as if in each '''execution unit''', it is 
-automatically {{function|include}}ed for you. There are a few different ways to make an execution unit. The first way is 
-to create a new alias. Each alias is it's own execution unit, and uniquely to the aliases, each alias is also it's own 
-compilation unit. A bound event handler is another execution unit, and the entirety of main.ms is an execution unit. 
+The auto_include.ms file is also a pure MethodScript file, and it is as if in each '''execution unit''', it is
+automatically {{function|include}}ed for you. There are a few different ways to make an execution unit. The first way is
+to create a new alias. Each alias is it's own execution unit, and uniquely to the aliases, each alias is also it's own
+compilation unit. A bound event handler is another execution unit, and the entirety of main.ms is an execution unit.
 set_interval and set_timeout are also separate execution unit, as well as execution queue elements, and others.
 
-So, what is an execution unit? It is a unit of code that gets run, from top to bottom. You can think of it as an 
-'''insertion point''' to your code, or places that will start up your code. An execution unit is often times made up of 
+So, what is an execution unit? It is a unit of code that gets run, from top to bottom. You can think of it as an
+'''insertion point''' to your code, or places that will start up your code. An execution unit is often times made up of
 several parts, so let's create a multifile example, which demonstrates a few execution units.
 
 In auto_include.ms:
@@ -143,10 +143,10 @@ In aliases.msa:
 <<<
 %%
 
-Here, we have created 3 separate execution units. main.ms and aliases are implicitly created, simply by their existence, 
-but here we have also created an event handler, which will get run when some_event is triggered. main.ms is triggered 
-upon server startup (and /reloadaliases) and aliases are triggered when a command is run. When this script is compiled, 
-you can essentially visualize the execution units as ending up like this: (with some code removed to make things more 
+Here, we have created 3 separate execution units. main.ms and aliases are implicitly created, simply by their existence,
+but here we have also created an event handler, which will get run when some_event is triggered. main.ms is triggered
+upon server startup (and /reloadaliases) and aliases are triggered when a command is run. When this script is compiled,
+you can essentially visualize the execution units as ending up like this: (with some code removed to make things more
 readable)
 
 First execution unit, main.ms:
@@ -170,17 +170,17 @@ _my_proc();
 console('In some_event');
 %%
 
-In this simple example, you can think of each execution path as a line through your code (in reality, it's a tree, but 
-if that doesn't make sense to you, ignore that for now). That line follows very specific rules based on code structure, 
+In this simple example, you can think of each execution path as a line through your code (in reality, it's a tree, but
+if that doesn't make sense to you, ignore that for now). That line follows very specific rules based on code structure,
 so how you lay out your code is important to be able to visualize.
 
 === recompile ===
 
-The built in <code>/recompile</code> command is used to reload just CommandHelper, though <code>/reload</code> will 
-also reload CommandHelper. However, using the recompile command can allow for finer grained control of what all gets 
+The built in <code>/recompile</code> command is used to reload just CommandHelper, though <code>/reload</code> will
+also reload CommandHelper. However, using the recompile command can allow for finer grained control of what all gets
 reloaded. By default, the command reloads the following things about CommandHelper:
 
-* <u>S</u>cripts - Any changes that you have made to any scripts will be reloaded and applied. Main files are re-run, 
+* <u>S</u>cripts - Any changes that you have made to any scripts will be reloaded and applied. Main files are re-run,
 and any new commands are re-registered.
 * <u>G</u>lobals - Global values, set with {{function|export}} are cleared out.
 * <u>T</u>asks - Any tasks set with {{function|set_interval}} or {{function|set_timeout}} are cleared.
@@ -189,21 +189,21 @@ and any new commands are re-registered.
 * Pro<u>f</u>iler - The profiler.config file is reloaded
 * E<u>x</u>tensions - Extensions are reloaded
 
-You can actually reload these sub-modules individually if you want, by passing parameters to the command. There are two 
-modes, whitelist, or by default, blacklist. In blacklist mode, all modules get reloaded except the modules that are 
-blacklisted, which aren't reloaded. In whitelist mode, only the specified modules are reloaded. You use the underlined 
-letter to refer to that specific module. For instance, if you want to reload everything but leave the exported variables 
+You can actually reload these sub-modules individually if you want, by passing parameters to the command. There are two
+modes, whitelist, or by default, blacklist. In blacklist mode, all modules get reloaded except the modules that are
+blacklisted, which aren't reloaded. In whitelist mode, only the specified modules are reloaded. You use the underlined
+letter to refer to that specific module. For instance, if you want to reload everything but leave the exported variables
 and execution queue alone, you can run <code>/recompile -ge</code>. If you ONLY want to reload tasks, you can
 run <code>/recompile --whitelist -t</code>. Note that reloading individual modules isn't normally encouraged,
-because it can put your server in an inconsistent and unreproducible state if you aren't careful. Running 
-<code>/recompile</code> by itself (which reloads everything) is recommended. You can also run 
+because it can put your server in an inconsistent and unreproducible state if you aren't careful. Running
+<code>/recompile</code> by itself (which reloads everything) is recommended. You can also run
 <code>/recompile -h</code> for the usage instructions and long options list.
 
 <code>/reloadaliases</code> is an alias to <code>/recompile</code>
 
 ===Scripting Examples===
 
-Here are a few more complex examples to get you started on how to use the advanced features of CommandHelper. Because of 
+Here are a few more complex examples to get you started on how to use the advanced features of CommandHelper. Because of
 the Turing completeness of the plugin, it is possible to do far more advanced things.
 
 %%ALIAS|
@@ -277,7 +277,7 @@ the Turing completeness of the plugin, it is possible to do far more advanced th
 
 ===Symbol Table===
 
-In your scripts, there are a few special symbols that are not treated as literals. In the event of a compiler error, 
+In your scripts, there are a few special symbols that are not treated as literals. In the event of a compiler error,
 it may be helpful to know what each symbol is called. These are as follows:
 
 {| class="wikitable" border="1"
@@ -292,7 +292,7 @@ it may be helpful to know what each symbol is called. These are as follows:
 |-
 | /* ... */
 | block comment
-| Everything inside this (newlines included) is a comment. The only thing you can't have inside a block comment is a */ 
+| Everything inside this (newlines included) is a comment. The only thing you can't have inside a block comment is a */
 (because that ends the comment)
 |-
 | =
@@ -301,8 +301,8 @@ it may be helpful to know what each symbol is called. These are as follows:
 |-
 | [ and ]
 | lsquare_bracket and rsquare_bracket
-| Denotes that this variable is optional, if included on the left side of an alias, or accesses an element in an array 
-if used on the right. 
+| Denotes that this variable is optional, if included on the left side of an alias, or accesses an element in an array
+if used on the right.
 |-
 | ,
 | comma
@@ -316,7 +316,7 @@ if used on the right.
 | newline
 | An 'enter' in the file
 |-
-| &gt;&gt;&gt; and &lt;&lt;&lt; 
+| &gt;&gt;&gt; and &lt;&lt;&lt;
 | multiline_start and multiline_end
 | Starts and stops a multiline construct
 |-
@@ -350,9 +350,9 @@ In general, autoconcatenation should not be relied on. It is better to use the <
 things together.
 %%
 
-Note that a lit and string are treated the same, however special characters must be put in a string to be treated as 
-literal character. Technically all other special characters are treated as literals, but to make your script compatible 
-with future versions, you must put any non-word character inside a string. 
+Note that a lit and string are treated the same, however special characters must be put in a string to be treated as
+literal character. Technically all other special characters are treated as literals, but to make your script compatible
+with future versions, you must put any non-word character inside a string.
 
 Note that string concatenation happens automatically (known as autoconcatenation). Let's take the following example:
 %%CODE|
@@ -364,14 +364,156 @@ if(@i == 0){
 }
 %%
 
-In the first run function, we see that '/run', 'this', and 'command' are all technically separate arguments, but because 
+In the first run function, we see that '/run', 'this', and 'command' are all technically separate arguments, but because
 they are not separated by commas, operators, or other symbols, they are automatically concatenated together, using the
-{{function|sconcat}} function, essentially yeilding: '/run this command', as you would expect. This is also the 
-behavior exhibited by a simple alias that uses non-strict formatting: <code>/cmd = /real command</code>. 
+{{function|sconcat}} function, essentially yeilding: '/run this command', as you would expect. This is also the
+behavior exhibited by a simple alias that uses non-strict formatting: <code>/cmd = /real command</code>.
 '/real' and 'command' are automatically sconcatenated together, and then run.
 
+=== Smart Comments and Aliases ===
+
+A smart comment applied to an alias can be used both by the alias engine, and by your scripts. In general, you can
+obtain the information in the currently running alias with the {{function|get_alias_comment}} function, and you can
+use this however you like, but there are additional annotations, which the alias engine uses to provide additional
+functionality.
+
+@command - When this annotation is present, this alias is instead treated as a command. This registers the alias as
+if you had used the {{function|register_command}} function. This comes with one drawback, which is that the name of the
+command, that is, for instance "/cmd" must be unique within other @commands defined in CommandHelper. Additional
+aliases can still provide additional functionality, but will not be used as part of the command system. One drawback
+of using commands is that commands registered in this way cannot be fully removed from the server without a server
+reboot, though functionality can generally be changed with a simple recompile anyways.
+
+When an alias is part of the command system, there are a few things that are done automatically, and a few things that
+can be further unlocked with additional annotations. First of all, the command is registered as part of the overall
+command system. This means that it will appear in default /help and autocomplete lists. Secondly, the command help text
+is automatically generated as part of the command, using the body of the smart comment. The usage parameter of the
+command is simply the left hand side of the alias, though additional usage can be provided in another annotation.
+
+Commands may have additional annotations, which correspond to the values in register_command:
+
+@usage - Overrides the default usage example
+@permission - The permission the user must have to run this command. Note that this permission is in *addition* to the
+normal alias permission system, and so it's recommended to continue using the * label on the alias itself.
+@noPermMsg - Overrides the no permission error message
+@alias - Alias for this command. A command can have multiple aliases, and you can repeat this annotation to provide
+more.
+
+@tabcompleter - Provides the name of a proc that is called, which should return the tab complete closure for this
+command. If the annotation is provided with no proc name, there are a set of default completions that will be provided
+on a best-effort basis, first based on variable names in the alias and superceded by information provided in the @param
+annotations in this comment. Variable names with "player" in them will autocomplete player names. Other variables will
+simply disable autocompletion. (The automatic tab completion is not yet implemented.)
+
+@param - This documents the variables in the alias, and generally follows the format
+"@param $variableName type description". Description is optional, and is only used as a code comment. The $variableName
+should match the parameter in the alias, and the type can be any valid MethodScript type, or a few special types,
+"$Player" and "$OfflinePlayer", or an ad-hoc enum, which is a comma separated list contained within square brackets.
+Depending on the MethodScript type, there will be different default autocomplete result, with special handling for
+enums, which autocomplete to the list of enums, boolean, which autocompletes to the strings "true" and "false". All
+other types disable auto completes for this variable.
+
+Note that these annotations will not be used if placed on an alias that isn't also a @command.
+The executor of the command is simply the code in the alias itself. Actually, it's worth noting that nothing
+about this changes the execution, it still uses the normal alias engine in the same way as every other alias,
+it simply provides additional integrations on top of the alias system.
+
+A full complex example, which provides a custom tabcompleter and overrides some existing parameters, might look
+like this:
+
+auto_include.ms:
+<%CODE|
+// Simulate some DB of users
+export('list', associative_array());
+
+proc _usersInList() {
+	return(import('list'));
+}
+
+proc _addUser(@user, @msg) {
+	import('list')[@user] = @msg; // push on the new user
+}
+
+proc _removeUser(@user) {
+	array_remove(import('list'), @user);
+}
+
+// NOTE! The procedure should take no arguments, and should return a closure. The closure may accept the
+// @alias, @sender, @args arguments, just as in the tabcompleter value for register_command.
+proc _myCommandTabComplete() {
+	return(get_tabcomplete_prototype(
+		array('add', 'remove'),
+		array(
+			'<add': closure(@alias, @sender, @args) { return(array_subtract(all_players(), array_keys(_usersInList()))); },
+			'<remove': closure(@alias, @sender, @args) { return(_usersInList()); },
+		),
+		'None'
+	));
+}
+%>
+
+commands.msa:
+<%CODE|
+/**
+ * This command adds or removes a user from a list, with a given message.
+ * @command
+ * @usage /myCommand add player [message], /myCommand remove player
+ * @tabcompleter _myCommandTabComplete
+ * @permission ch.testing
+ * @noPermMsg You don't have access to this command.
+ */
+*:/myCommand $enum $player [$] = >>>
+	// Error checking. Note that permission handling is already managed with the annotations. HOWEVER,
+	// it may be prudent to check again anyways, in case this code is used in older versions of CommandHelper.
+	if(!has_permission('ch.testing'), die());
+
+	if(!array_contains(array('add', 'remove'), $enum)) {
+		die(color('RED').'Enum must be add or remove. See /help /myCommand');
+	}
+	if($enum == 'remove' && $ != null) {
+		die(color('RED').'No message should be provided when removing a player');
+	}
+	if(!array_contains(all_players(), $player)) {
+		die(color('RED').'Player offline or unknown. See /help /myCommand');
+	}
+
+	switch($enum) {
+		case 'add':
+			_addUser($player, $);
+		case 'remove':
+			_removeUser($player);
+	}
+
+	msg(color('GREEN').'Action completed.');
+<<<
+%>
+
+We can make a slightly less accurate version of this code, which uses the defaults, which, while less correct,
+provides a decent compromise between functionality and code terseness.
+
+<%CODE|
+/**
+ * This command does things.
+ * @command
+ * @tabcompleter
+ * @param $enum [add, remove]
+ * @param $player $Player
+ * @param $ string
+ */
+*:/myCommand $enum $player [$] = ...
+%>
+
+This example will still provide tab completions for the enum and player arguments, but the list of players will not
+be filtered based on the value of the enum. The usage example will be less meaningful as well, but may be good enough
+in most cases.
+
+<%NOTE|Note the drawbacks of using the @command system: Using /recompile is not good enough to change all the settings,
+and requires a server reboot. It is recommended that during development, you use plain aliases, and then add the command
+system on top once you have a stable API. Code changes to the aliases can be done easily, but changing the documentation
+and permissions cannot.%>
+
 === Source File Encoding ===
-MethodScript files, both ms and msa files should have UTF-8 encoding. A byte order mark (BOM) may or may not be present. 
+MethodScript files, both ms and msa files should have UTF-8 encoding. A byte order mark (BOM) may or may not be present.
 While other encodings may work, particularly ASCII and others, the source files will be parsed using UTF-8. In the future,
 other encodings may be supported, but there is currently no plans to add this support in the near term.
 

--- a/src/main/resources/docs/SmartComments
+++ b/src/main/resources/docs/SmartComments
@@ -1,0 +1,125 @@
+A Smart Comment is a comment field that contains somewhat structured data that can be used
+both by your code and by the compiler, as well as being in an easy to read format, so that
+readers of your code can get additional context.
+
+In general, MethodScript supports four comment types, though two do the same thing.
+Both # and // are line comments, and are completely removed from the source code during
+compilation. The comment begins with one of those symbols, and ends with the start of a new line.
+Comments that start with /* and end with */ are block comments, and can contain newlines within
+them, though not currently other nested comment blocks. Like line comments, these are also
+removed during compilation. Both of these comments are meant solely as context for the future
+reader of the code, and have no functional purpose as far as the compiler is concerned, and
+are thus discarded as part of the compilation process, and so the runtime has no knowledge that
+these types of comments ever existed in the source code.
+
+Comment blocks that start with /** however, are smart comments, and the subject of this article.
+These comments are not lost with compilation, and are able to be used in later stages of compilation,
+to provide additional functionality to code.
+
+<%NOTE|Note that this page outlines some expected functionality, rather than functionality that currently exists.
+Where this is true, it is noted, but the format of comments can go ahead and begin using these conventions,
+and as they become implemented, they will suddenly start working in your code. Thus, the standard is set in stone
+now, and can go ahead and be counted on.%>
+
+Given the following example, we can see the general format.
+
+== General Format ==
+
+<%CODE|
+/**
+ * This is the body.
+ * This is part of the body, and contains an {@embedded annotation}.
+ * @standaloneAnnotation with comments
+ * @standaloneAnnotation can repeat
+ * @standaloneAnnotationWithNoComment
+ */
+%>
+
+There are a few things to point out. The general rule is that the comment block must start with /** and end with */.
+On each line within the comment, the line may start with 0 or more spaces, a star, and then a space. This text is
+stripped from the comment. The body text is the first part of the comment. Within the body, newlines and spaces are
+preserved, other that the initial alignment spacing, as described above. Both body text and standalone annotation
+comments may contain embedded annotations, which are the annnotations that begin with {@ and end with }. Embedded
+annotations may also have additional text following the annotation name.
+
+Standalone annotations are those that start with @. These are ended by a newline, and cannot contain newlines within
+them. Standalone annotations may repeat, or they may contain no additional text.
+
+== Usage in the compiler ==
+
+The primary use of these smart comments is for providing formal documentation for the various commented elements.
+By and large, the compiler itself ignores these values, though that's not always the case, depending on which
+annotations are used. For instance, the @deprecated annotation will trigger a compiler warning when references to
+the element are used elsewhere in code (not implemented yet). The primary use case is for generating automatic
+documentation in various places, including the IDE (also not implemented yet).
+
+Depending on where the comment is placed, the rules may be slightly different as well, and particularly which
+annotations will be active, so check the documentation below for specific details, as well as documentation about
+the various elements that support smart comments.
+
+Smart comments that are placed on elements which do not directly support smart comments will not break - however
+these will simply function as ordinary block comments, with the exception that the compiler may or may not retain
+the comment in the runtime, unused.
+
+== Usage in code ==
+
+The larger advantage is being able to dynamically access these comment blocks within your code. This can be used
+to power an automatically generating documentation system for instance, along with easily generated help text to
+be provided to users upon incorrect usage. Currently, support for obtaining these comments is rather limited, with
+support only existing for aliases. Additional usage will appear over time.
+
+
+== Embedded Annotations ==
+
+Embedded annotations are generally speaking meant to function almost like visual text modifiers, such as adding links,
+emphasis, and other formatting such as this. This isn't enforced however, and custom code can use these however they
+like. However, there are a few predefined annotations.
+
+=== {@link} ===
+
+The link annotation provides a link to another element in the code.
+
+This is currently unimplemented and undefined.
+
+=== {@url} ===
+
+The url annotation provides an inline link to a web address. In general, the annotation should
+follow the format {@url https://url.com replacementText} where the replacement text is the text that
+is displayed, and the url is where the link goes. If replacementText is empty, the url is used as the
+text.
+
+This is currently unimplemented.
+
+=== {@code} ===
+
+This is meant for references to literal code elements, for instance variable names, etc. The common use case
+is to simply format the text with a monospace font, but could be used for syntax highlighting, etc.
+
+This is currently unimplemented.
+
+== Annotations ==
+
+Depending on the context, annotations can be ignored, or have different functionality. Ignored annotations are not
+an error, they simply won't have any programmatic effects within MethodScript itself. You are free to use these
+annotations in your custom systems in any way you see fit, though it is highly encouraged to ensure you are not
+trying to fight the built in systems. Additional contexts may define additional annotations, with either server to
+further document the element, or can even provide some functionality.
+
+=== @seeAlso ===
+
+The general format is:
+
+@seeAlso https://url.com Description
+or
+@seeAlso element Description
+
+This provides a link to either another element in the codebase, or an external web url. Note that the element variety
+of this is not implemented or defined yet, but will have the same semantics as the embedded {@link} annotation.
+
+This is not implemented yet, though most text editors provide url clicking anyways.
+
+=== @param ===
+
+Documents a parameter. This is used for inputs to the element.
+
+

--- a/src/main/resources/functionDocs/get_tabcomplete_prototype
+++ b/src/main/resources/functionDocs/get_tabcomplete_prototype
@@ -6,10 +6,10 @@ it's best to write the closure yourself.
 In general, the prototypes can be one of five values, a string, a ClassType of an enum type, an array, a closure,
 or an associative array. Strings represent "prebaked" classes, and are listed below:
 
-- Player - Online players ({function|all_players} equivalent, but more efficient)
-- OfflinePlayer - All known players ({function|get_offline_players} equivalent)
-- Boolean - Equivalent to array("true", "false")
-- None - Returns an empty array, disabling tab complete for this value. This is useful for open fields, such as \
+* Player - Online players ({{function|all_players}} equivalent, but more efficient)
+* OfflinePlayer - All known players ({function|get_offline_players} equivalent)
+* Boolean - Equivalent to array("true", "false")
+* None - Returns an empty array, disabling tab complete for this value. This is useful for open fields, such as \
 random strings, or a number.
 
 ClassTypes must be enum values, and will autocomplete with the list of values in that enum.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,21 +1,21 @@
 name: CommandHelper
 main: com.laytonsmith.commandhelper.CommandHelperPlugin
-api-version: 1.13
+api-version: 1.16
 version: "${project.version}"
 commands:
     reloadaliases:
         description: Reloads aliases
         usage: /<command>
         aliases: [reloadalias, recompile]
+        permission: [commandhelper.reloadaliases, ch.reloadaliases]
     interpreter:
         description: Puts your chat into interpreter mode
         usage: /<command>
-    commandhelper:
-        description: Used to gain meta information about CommandHelper
-        usage: /<command> <arguments>
+        permission: commandhelper.interpreter
     runalias:
         description: If another plugin wants to run a CommandHelper command, it isn't always straightforward to do that, because of the way bukkit works. To get around this, you may use this command. "/runalias /command to run" will fire off the alias "/command to run"
         usage: /<command> <otherCommand>
     interpreter-on:
         description: Turns on the interpreter for however long is specified in the preferences option "interpreter-timeout". This only does something if run from console.
         usage: /<command>
+        permission: this.command.can.only.be.run.from.console

--- a/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
+++ b/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
@@ -1247,4 +1247,27 @@ public class MethodScriptCompilerTest {
 		assertEquals("null", StaticTest.SRun("ArraySortType @s = null;", null));
 		assertEquals("null", StaticTest.SRun("ms.lang.ArraySortType @s = null;", null));
 	}
+
+	@Test
+	public void testSmartCommentsAreProperlyAddedToAliases() throws Exception {
+		String config = "/**\n"
+				+ " * Smart comment!\n"
+				+ " * @annotation test_annotation"
+				+ " */\n"
+				+ "/test = /cmd\n";
+		Script s = MethodScriptCompiler.preprocess(MethodScriptCompiler.lex(config, null, null, false), envs).get(0);
+		assertEquals("Smart comment!", s.getSmartComment().getBody());
+		assertEquals("test_annotation", s.getSmartComment().getAnnotations("annotation").get(0));
+	}
+
+	@Test
+	public void testSmartCommentsCanBeRetrieved() throws Exception {
+		String config = "/**\n"
+				+ " * Smart comment!\n"
+				+ " * @annotation test_annotation"
+				+ " */\n"
+				+ "/test = msg(get_alias_comment())\n";
+		RunCommand(config, fakePlayer, "/test");
+		verify(fakePlayer).sendMessage("{annotations: {@annotation: {test_annotation}}, body: Smart comment!}");
+	}
 }


### PR DESCRIPTION
This commit finishes tying SmartComments to aliases, which then further unlocks several new features. Particularly, the ability to add meta information to aliases allows implementation of the command system, which is a system built on top of the regular alias engine, that better integrates aliases into bukkit, making them look and feel more like real commands. This includes things like having first class support for bukkit permissions, built in help documents (including proper usage reminders) and tab completers. Additionally a basic facility for getting the smart comment has been provided directly to user code, through the get_alias_comment() function.

There are a few unfinished features, namely the automatic generation of tabcompleters based on type hints in the documentation, though providing a custom tab completer through a proc reference is supported, and is a good first step, thus this feature is being wrapped up as an MVP.

Various documentation has been updated in addition, to explain the new system.