### PR TITLE
Throw compile errors in strict mode when encountering illegal statements

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Meta.java
+++ b/src/main/java/com/laytonsmith/core/functions/Meta.java
@@ -25,6 +25,7 @@ import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Prefs;
 import com.laytonsmith.core.Script;
 import com.laytonsmith.core.Static;
+import com.laytonsmith.core.compiler.BranchStatement;
 import com.laytonsmith.core.compiler.FileOptions;
 import com.laytonsmith.core.compiler.VariableScope;
 import com.laytonsmith.core.constructs.CArray;
@@ -606,7 +607,7 @@ public class Meta {
 	}
 
 	@api(environments = {CommandHelperEnvironment.class, GlobalEnv.class})
-	public static class scriptas extends AbstractFunction implements VariableScope {
+	public static class scriptas extends AbstractFunction implements VariableScope, BranchStatement {
 
 		@Override
 		public String getName() {
@@ -690,6 +691,16 @@ public class Meta {
 			List<Boolean> ret = new ArrayList<>(children.size());
 			ret.add(false);
 			if(children.size() == 3) {
+				ret.add(false);
+			}
+			ret.add(true);
+			return ret;
+		}
+
+		@Override
+		public List<Boolean> isBranch(List<ParseTree> children) {
+			List<Boolean> ret = new ArrayList<>(children.size());
+			for(int i = 0; i < children.size() - 1; i++) {
 				ret.add(false);
 			}
 			ret.add(true);

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -12,6 +12,7 @@ import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Script;
+import com.laytonsmith.core.compiler.BranchStatement;
 import com.laytonsmith.core.compiler.VariableScope;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CBoolean;
@@ -348,7 +349,7 @@ public class Threading {
 	@api
 	@noboilerplate
 	@seealso({x_new_thread.class})
-	public static class _synchronized extends AbstractFunction implements VariableScope {
+	public static class _synchronized extends AbstractFunction implements VariableScope, BranchStatement {
 
 		private static final Map<Object, Integer> SYNC_OBJECT_MAP = new HashMap<Object, Integer>();
 
@@ -522,6 +523,14 @@ public class Threading {
 
 		@Override
 		public List<Boolean> isScope(List<ParseTree> children) {
+			List<Boolean> ret = new ArrayList<>(2);
+			ret.add(false);
+			ret.add(true);
+			return ret;
+		}
+
+		@Override
+		public List<Boolean> isBranch(List<ParseTree> children) {
 			List<Boolean> ret = new ArrayList<>(2);
 			ret.add(false);
 			ret.add(true);

--- a/src/main/resources/docs/Strict_Mode
+++ b/src/main/resources/docs/Strict_Mode
@@ -40,8 +40,6 @@ mode, bare strings are not allowed, you must quote all strings.
 
 == Auto Concatenation ==
 
-(not yet implemented)
-
 Auto concatenation is when two objects with no operator between them are taken to be concatenated, with a space added
 between.
 
@@ -70,9 +68,11 @@ foreach(int @i : 1..10) {
 } // No semicolon required
 %>
 
-While this seems arbitrary, separating statements is required in two cases. Using the ++ or -- operators, it is
-ambiguous whether the operator is meant to apply to the previous value (postfix) or following value (prefix). In the
-future, direct closure execution will be allowed with parenthesis:
+While this seems arbitrary, separating statements is required in rare cases. For example, when using the
+++ or -- operators, it is ambiguous whether the operator is meant to apply to the previous value (postfix) or
+following value (prefix).
+
+Direct closure execution is allowed with parenthesis:
 
 <%CODE|
 closure @c = closure(string @value){};
@@ -119,8 +119,6 @@ auto @x = 'string';
 Please see the page on [[Cross_Casting|cross casting]] for a further discussion on the auto keyword.
 
 == Compiler Warnings ==
-
-(not yet implemented)
 
 Compiler warnings, such as deprecations and others are normally warned about, but compilation continues. In strict mode,
 these warnings instead trigger a compile error, and must be fixed immediately. However, in combination with the 


### PR DESCRIPTION
Due to removing auto concat from strict mode, users will get runtime exceptions in some cases where there were no errors before. So, this creates an exception at compile time instead. 

I'm aware the plan is to create return types for functions, so this is ultimately a temporary solution. It's helped me find a few in my own code. Just make sure I'm not doing something stupid with this solution.

I also updated the Strict Mode page to be up-to-date before we move to 3.3.5.