### PR TITLE
Support texture property for player head item meta on Paper

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCPlayerProfile.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCPlayerProfile.java
@@ -1,0 +1,19 @@
+package com.laytonsmith.abstraction;
+
+import java.util.UUID;
+
+public interface MCPlayerProfile extends AbstractionObject {
+
+	String getName();
+
+	String setName(String name);
+
+	UUID getId();
+
+	UUID setId(UUID id);
+
+	MCProfileProperty getProperty(String key);
+
+	void setProperty(MCProfileProperty property);
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCProfileProperty.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCProfileProperty.java
@@ -1,0 +1,27 @@
+package com.laytonsmith.abstraction;
+
+public class MCProfileProperty {
+
+	private final String name;
+	private final String value;
+	private final String signature;
+
+	public MCProfileProperty(String name, String value, String signature) {
+		this.name = name;
+		this.value = value;
+		this.signature = signature;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	public String getSignature() {
+		return this.signature;
+	}
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCServer.java
@@ -66,6 +66,17 @@ public interface MCServer extends AbstractionObject {
 	MCInventory createInventory(MCInventoryHolder owner, int size, String title);
 
 	/**
+	 * Gets a player profile with the specified UUID or name. If id is null, name will be used.
+	 * A profile provides MC account information including name, UUID, and properties like skin texture data.
+	 * Returns null if player doesn't exist (or server implementation does not support this feature).
+	 *
+	 * @param id The user UUID
+	 * @param name The player name
+	 * @return The player profile for this user
+	 */
+	MCPlayerProfile getPlayerProfile(UUID id, String name);
+
+	/**
 	 * Provides access to local user data associated with a name. Depending on the implementation, a web lookup with the
 	 * official API may or may not be performed.
 	 *

--- a/src/main/java/com/laytonsmith/abstraction/MCSkullMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCSkullMeta.java
@@ -11,4 +11,9 @@ public interface MCSkullMeta extends MCItemMeta {
 	boolean setOwner(String owner);
 
 	void setOwningPlayer(MCOfflinePlayer player);
+
+	MCPlayerProfile getProfile();
+
+	void setProfile(MCPlayerProfile profile);
+
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPlayerProfile.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCPlayerProfile.java
@@ -1,0 +1,84 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
+import com.laytonsmith.abstraction.MCPlayerProfile;
+import com.laytonsmith.abstraction.MCProfileProperty;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class BukkitMCPlayerProfile implements MCPlayerProfile {
+
+	Object pp;
+
+	public BukkitMCPlayerProfile(Object pp) {
+		this.pp = pp;
+	}
+
+	@Override
+	public String getName() {
+		return (String) ReflectionUtils.invokeMethod(this.pp, "getName");
+	}
+
+	@Override
+	public String setName(String name) {
+		return (String) ReflectionUtils.invokeMethod(this.pp, "setName", name);
+	}
+
+	@Override
+	public UUID getId() {
+		return (UUID) ReflectionUtils.invokeMethod(this.pp, "getId");
+	}
+
+	@Override
+	public UUID setId(UUID id) {
+		return (UUID) ReflectionUtils.invokeMethod(this.pp, "setId", id);
+	}
+
+	@Override
+	public MCProfileProperty getProperty(String key) {
+		Set<?> properties = (Set<?>) ReflectionUtils.invokeMethod(this.pp, "getProperties");
+		for(Object property : properties) {
+			if(ReflectionUtils.invokeMethod(property, "getName").equals(key)) {
+				String name = (String) ReflectionUtils.invokeMethod(property, "getName");
+				String value = (String) ReflectionUtils.invokeMethod(property, "getValue");
+				String signature = (String) ReflectionUtils.invokeMethod(property, "getSignature");
+				return new MCProfileProperty(name, value, signature);
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void setProperty(MCProfileProperty property) {
+		Class clz;
+		try {
+			clz = Class.forName("com.destroystokyo.paper.profile.ProfileProperty");
+		} catch (ClassNotFoundException e) {
+			return;
+		}
+		Object profileProperty = ReflectionUtils.newInstance(clz, new Class[]{String.class, String.class, String.class},
+				new Object[]{property.getName(), property.getValue(), property.getSignature()});
+		ReflectionUtils.invokeMethod(this.pp, "setProperty", profileProperty);
+	}
+
+	@Override
+	public Object getHandle() {
+		return this.pp;
+	}
+
+	@Override
+	public String toString() {
+		return this.pp.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof BukkitMCPlayerProfile && this.pp.equals(((BukkitMCPlayerProfile) obj).pp);
+	}
+
+	@Override
+	public int hashCode() {
+		return this.pp.hashCode();
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCServer.java
@@ -13,6 +13,7 @@ import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCMerchant;
 import com.laytonsmith.abstraction.MCOfflinePlayer;
 import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.MCPlayerProfile;
 import com.laytonsmith.abstraction.MCPluginManager;
 import com.laytonsmith.abstraction.MCRecipe;
 import com.laytonsmith.abstraction.MCScoreboard;
@@ -60,9 +61,14 @@ public class BukkitMCServer implements MCServer {
 
 	Server s;
 	MCVersion version;
+	boolean isPaper = false;
 
 	public BukkitMCServer() {
 		this.s = Bukkit.getServer();
+		try {
+			Class.forName("com.destroystokyo.paper.PaperConfig");
+			this.isPaper = true;
+		} catch (ClassNotFoundException e) {}
 	}
 
 	public BukkitMCServer(Server server) {
@@ -76,6 +82,10 @@ public class BukkitMCServer implements MCServer {
 
 	public Server __Server() {
 		return s;
+	}
+
+	public boolean isPaper() {
+		return this.isPaper;
 	}
 
 	@Override
@@ -314,6 +324,14 @@ public class BukkitMCServer implements MCServer {
 	@Override
 	public MCCommandMap getCommandMap() {
 		return new BukkitMCCommandMap((SimpleCommandMap) ReflectionUtils.invokeMethod(s.getClass(), s, "getCommandMap"));
+	}
+
+	@Override
+	public MCPlayerProfile getPlayerProfile(UUID id, String name) {
+		if(isPaper()) {
+			return new BukkitMCPlayerProfile(ReflectionUtils.invokeMethod(s, "createProfile", id, name));
+		}
+		return null;
 	}
 
 	@Override

--- a/src/main/resources/functionDocs/get_itemmeta
+++ b/src/main/resources/functionDocs/get_itemmeta
@@ -38,7 +38,9 @@ Below are the available fields in the item meta array. Fields can be null when t
 |-
 | Player Heads
 |
-* '''owner''' : (string) The player name.
+* '''owner''' : (string) The player name, or null if there's no owner.
+* '''owneruuid''' : (string) The player UUID, or null if there's no owner.
+* '''texture''' : (string) The texture property value. This is a base64 encoded JSON object that contains the skin texture URL among other things. (Paper only)
 |-
 | Potions
 |


### PR DESCRIPTION
Currently Spigot does not yet support this feature (outside of item meta serialization), but this ensures Paper servers can still retain the texture url data. (something not possible with the CHPaper extension) This means users can spawn items from custom head sites and existing heads will retain their initial texture even if the owner changes it later.

You might notice I'm using reflection to access the Paper API instead of building against Paper. I might change this later, but Paper changes some interfaces, and we've implemented at least two of them. So we'd have to have separate implementations for Spigot and Paper for these interfaces. So for now I stuck with reflection. The other benefit is that we won't accidentally use a Paper method when it doesn't exist on Spigot.

There are some oddities here in edge cases because you can theoretically run into incomplete profiles where the name or uuid doesn't exist yet. (I never ran into this) Also, if there's a mismatched user name and UUID, it can try to rectify this with the user cache when completing the profile, with sometimes unexpected results. I think the old name would have to be cached, which makes this unlikely with normal usage.

Mojang stores this data like this:

````
SkullOwner: {
    Id: [0, 0, 0, 0], // int array representation of UUID
    Name: 'PseudoKnight',
    Properties: {
        textures: [
            {
                Value: { // base64 encoded
                    isPublic: true,
                    profileId: '617a67e5-7988-4645-af56-42c770a6dda5',
                    profileName: 'PseudoKnight',
                    textures: {
                        CAPE: {
                            url: 'http://...'
                        }
                        SKIN: {
                            url: 'http://...'
                        }
                    },
                    timestamp: '' // unix timestamp
                }
                Signature: '' // not needed for player heads
            }
        ]
    }
}
````

So, it's quite bulky and doesn't make a lot of sense in some places. Here is how Paper essentially represents the data:

````
PlayerProfile: {
    name: 'PseudoKnight',
    id: '617a67e5-7988-4645-af56-42c770a6dda5',
    Properties: [
        {
            name: 'textures',
            value: '', // the base64 encoded "Value" above
            signature: ''
        }
    ]
}
````

There are no other properties, but it's open to adding more. However, since we don't care about anything else with player heads, I could flatten it. We don't even need a signature.

````
owner: 'PseudoKnight',
owneruuid:  '617a67e5-7988-4645-af56-42c770a6dda5',
texture: '', // base64 encoded "Value" above
````

I thought of other formats, like changing 'owner' value to UUID or an array, but that might break scripts. 

So how does one use this? Custom head websites often provide /give commands that spawn the custom heads, like this: 

`/give @p minecraft:player_head{display:{Name:"{\"text\":\"Candy Straws Bowl\"}"},SkullOwner:{Id:[I;637468406,-1905965987,-1265093003,-159306716],Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzAyNmQ1NTBhNDAyNDc5ZjVmODM5M2Q2M2RmY2M5MGEyYmNlYjBlZDVlMzBhNGRjOGM0MjNjNGVjMzIxMjVkYyJ9fX0="}]}}} 1`

All the user would need to do is copy the "Value" there and paste it under the "texture" key in the item meta array. Obviously the UUID is a pain to use in the new 1.16 provided format (int array), but it turns out any player UUID will work because it's getting the texture from an encoded URL anyway. But it should be noted that a uuid (or name) is not optional for the texture to work.