### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,6 +483,8 @@
 					</compilerArgs>
 					<fork>true</fork>
 					<optimize>true</optimize>
+							<useIncrementalCompilation>true</useIncrementalCompilation>
+
 				</configuration>
 			</plugin>
 
@@ -1140,6 +1142,8 @@
 						<version>3.8.1</version>
 						<configuration>
 							<showDeprecation>false</showDeprecation>
+							<useIncrementalCompilation>true</useIncrementalCompilation>
+
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
