### PR TITLE
Allow command execution from RCON

### DIFF
--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperPlugin.java
@@ -71,6 +71,7 @@ import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
@@ -587,7 +588,7 @@ public class CommandHelperPlugin extends JavaPlugin {
 			if(sender instanceof Player) {
 				PlayerCommandPreprocessEvent pcpe = new PlayerCommandPreprocessEvent((Player) sender, command);
 				playerListener.onPlayerCommandPreprocess(pcpe);
-			} else if(sender instanceof ConsoleCommandSender
+			} else if(sender instanceof ConsoleCommandSender || sender instanceof RemoteConsoleCommandSender
 					|| sender instanceof BlockCommandSender || sender instanceof CommandMinecart) {
 				// Console commands and command blocks/minecarts all fire the same event, so pass them to the
 				// event handler that would get them if they would not have started with "/runalias".


### PR DESCRIPTION
This fixes an issue where CommandHelper aliases cannot be executed via RCON. Attempting to run a command results in nothing happen, there is no response and the command doesn't execute.

With this change commands are properly executed and command output is sent to the RCON client as expected. I have used this extensively for a few weeks and I've experienced no issues.