### PR TITLE
ls: fix Core exception in certain conditions.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Cmdline.java
+++ b/src/main/java/com/laytonsmith/core/functions/Cmdline.java
@@ -1677,7 +1677,7 @@ public class Cmdline {
 
 		@Override
 		public Class<? extends CREThrowable>[] thrown() {
-			return new Class[]{CREInsufficientPermissionException.class};
+			return new Class[]{CREInsufficientPermissionException.class, CREIOException.class};
 		}
 
 		@Override
@@ -1695,12 +1695,17 @@ public class Cmdline {
 			requireCmdlineMode(environment, this, t);
 			CArray ca = new CArray(t);
 			File cwd = Static.GetFileFromArgument(args.length > 0 ? args[0].val() : null, environment, t, environment.getEnv(GlobalEnv.class).GetRootFolder());
-			if(cwd.exists()) {
-				for(File f : cwd.listFiles()) {
+			if(cwd.isDirectory()) {
+				File[] fs = cwd.listFiles();
+				if(fs == null) {
+					throw new CREIOException("Directory could not be read in.", t);
+				}
+
+				for(File f : fs) {
 					ca.push(new CString(f.getName(), t), t);
 				}
 			} else {
-				throw new CREIOException("No such file or directory: " + cwd.getPath(), t);
+				throw new CREIOException("No such directory: " + cwd.getPath(), t);
 			}
 			return ca;
 		}


### PR DESCRIPTION
Sometimes, an exception would occur whenever `File#listFiles()` returned null.
The most obvious cases here were a lack of read/execute permissions and providing `ls` a file.

```
:ls('testinghi');
Uh oh! You've found an error in Core.
This happened while running your code, so you may be able to find a workaround, but is ultimately an issue in Core.
The following code caused the error:
ls('testinghi')
on or around Interpreter:1.
Please report this to the developers, and be sure to include the version numbers:
Server version: SHELL;
MethodScript version: 3.3.5;
Loaded extensions and versions:
SKCompat (3.1.2)
CHFiles (2.2.5)
MSImage (1.1.0)
Core (3.3.5)
CHSocket (1.1.0)
Here's the stacktrace:
java.lang.NullPointerException: Cannot read the array length because "<local6>" is null
	at com.laytonsmith.core.functions.Cmdline$ls.exec(Cmdline.java:1699)
	at com.laytonsmith.core.Script.eval(Script.java:462)
	at com.laytonsmith.core.MethodScriptCompiler.execute(MethodScriptCompiler.java:2828)
	at com.laytonsmith.tools.Interpreter$4.run(Interpreter.java:832)
	at java.base/java.lang.Thread.run(Thread.java:833)


```