### PR TITLE
Dramatically reduce extension initialization time

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/Common/ClassUtils.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/Common/ClassUtils.java
@@ -259,7 +259,7 @@ public class ClassUtils {
 		} else if("V".equals(classname)) {
 			return "void"; //special case
 		} else {
-			classname = classname.substring(1, classname.length() - 1).replace('/', '.').replace('$', '.');
+			classname = classname.substring(1, classname.length() - 1).replace('/', '.');
 		}
 		return classname + StringUtils.stringMultiply(arrayCount, "[]");
 	}


### PR DESCRIPTION
This fixes class name misses for inner classes, where previously this would cause an enormous number of ClassNotFoundExceptions in ClassUtils.forCanonicalName() before it re-attempts them by re-adding the '$'.

It's possible you desire to fix this in another way, but this is the smallest change that fixes it.