### PR TITLE
Autoconcat optimization

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -2168,8 +2168,7 @@ public final class MethodScriptCompiler {
 			boolean returnSConcat = !root.getFileOptions().isStrict();
 
 			try {
-				ParseTree ret = ((Compiler.__autoconcat__) ((CFunction) root.getData()).getFunction())
-						.rewrite(root.getChildren(), returnSConcat, envs);
+				ParseTree ret = __autoconcat__.rewrite(root.getChildren(), returnSConcat, envs);
 				root.setData(ret.getData());
 				root.setChildren(ret.getChildren());
 				root.getNodeModifiers().merge(ret.getNodeModifiers());
@@ -2177,9 +2176,6 @@ public final class MethodScriptCompiler {
 				compilerExceptions.add(ex);
 				return;
 			}
-
-			// __autoconcat__'s AST rewrite can include new __autoconcat__'s, so handle them again.
-			rewriteAutoconcats(root, env, envs, compilerExceptions);
 		}
 	}
 

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -113,22 +113,6 @@ public class Compiler {
 
 		public static final String NAME = "__autoconcat__";
 
-		public static ParseTree getParseTree(List<ParseTree> children, FileOptions fo, Target t) {
-			CFunction ac = new CFunction(__autoconcat__.NAME, t);
-			ParseTree tree = new ParseTree(ac, fo);
-			tree.setChildren(children);
-			return tree;
-		}
-
-		public static ParseTree getParseTree(ParseTree child, FileOptions fo, Target t) {
-			CFunction ac = new CFunction(__autoconcat__.NAME, t);
-			ParseTree tree = new ParseTree(ac, fo);
-			List<ParseTree> children = new ArrayList<>();
-			children.add(child);
-			tree.setChildren(children);
-			return tree;
-		}
-
 		@Override
 		public Mixed exec(Target t, Environment env, Mixed... args) throws CancelCommandException, ConfigRuntimeException {
 			throw new Error("Should not have gotten here, " + __autoconcat__.NAME + " was not removed before runtime.");

--- a/src/main/java/com/laytonsmith/core/functions/Compiler.java
+++ b/src/main/java/com/laytonsmith/core/functions/Compiler.java
@@ -78,14 +78,7 @@ public class Compiler {
 
 		@Override
 		public Mixed execs(Target t, Environment env, Script parent, ParseTree... nodes) {
-			switch(nodes.length) {
-				case 0:
-					return CVoid.VOID;
-				case 1:
-					return parent.eval(nodes[0], env);
-				default:
-					return new __autoconcat__().execs(t, env, parent, nodes);
-			}
+			return (nodes.length == 1 ? parent.eval(nodes[0], env) : CVoid.VOID);
 		}
 
 		@Override


### PR DESCRIPTION
- Make `__autoconcat__` rewrites no longer able to return `__autoconcat__` in their rewritten AST, and use this property to do only a single AST traversal for rewriting autoconcats.
- Make `__autoconcat__.rewrite(...)` static. This could eventually be moved to MethodScriptCompiler instead.
- Remove unused autoconcat construction methods.
- Simplify `p()` execs (no functional changes).