### PR TITLE
Move execution of autoincludes to later.

### DIFF
--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperInterpreterListener.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperInterpreterListener.java
@@ -151,7 +151,7 @@ public class CommandHelperInterpreterListener implements Listener {
 		ParseTree tree = MethodScriptCompiler.compile(stream, env, env.getEnvClasses());
 		final boolean isInterpeterMode = interpreterMode.remove(p.getName());
 		try {
-			env.getEnv(StaticRuntimeEnv.class).getIncludeCache().registerAutoIncludes(env, null);
+			env.getEnv(StaticRuntimeEnv.class).getIncludeCache().executeAutoIncludes(env, null);
 			MethodScriptCompiler.execute(tree, env, output -> {
 				output = output.trim();
 				if(output.isEmpty()) {

--- a/src/main/java/com/laytonsmith/core/AliasCore.java
+++ b/src/main/java/com/laytonsmith/core/AliasCore.java
@@ -387,9 +387,6 @@ public class AliasCore {
 			}
 
 			try {
-				// If auto_includes have no dynamic content, we could register them before caching the
-				// environment for aliases. But for now, register them after we clone the new environment (newEnv).
-				includeCache.registerAutoIncludes(env, null);
 				localPackages.compileMS(player, env);
 			} finally {
 				compilerMS.stop();
@@ -524,6 +521,12 @@ public class AliasCore {
 
 		// Everything else should be reloaded now, so execute successfully compiled scripts and register commands
 		if(options.reloadScripts() && env != null) {
+			ProfilePoint executeAutoIncludes = profiler.start("Execution of auto includes", LogLevel.VERBOSE);
+			try {
+				includeCache.executeAutoIncludes(env, null);
+			} finally {
+				executeAutoIncludes.stop();
+			}
 			ProfilePoint executeMS = profiler.start("Execution of MS files in Local Packages", LogLevel.VERBOSE);
 			try {
 				env.getEnv(GlobalEnv.class).SetLabel(Static.GLOBAL_PERMISSION);

--- a/src/main/java/com/laytonsmith/core/Script.java
+++ b/src/main/java/com/laytonsmith/core/Script.java
@@ -249,7 +249,7 @@ public class Script {
 					}
 				}
 
-				currentEnv.getEnv(StaticRuntimeEnv.class).getIncludeCache().registerAutoIncludes(currentEnv, this);
+				currentEnv.getEnv(StaticRuntimeEnv.class).getIncludeCache().executeAutoIncludes(currentEnv, this);
 				MethodScriptCompiler.execute(rootNode, currentEnv, done, this);
 			}
 		} catch (ConfigRuntimeException ex) {

--- a/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
+++ b/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
@@ -182,6 +182,16 @@ public class IncludeCache {
 	}
 
 	/**
+	 * @param env
+	 * @param s
+	 * @deprecated The method was renamed to properly reflect what it does, which is to {@link #executeAutoIncludes}.
+	 */
+	@Deprecated
+	public void registerAutoIncludes(Environment env, Script s) {
+		executeAutoIncludes(env, s);
+	}
+
+	/**
 	 * Compiles and executes all the auto_include.ms files added to this object.
 	 * This will use a cached {@link ParseTree} for each {@link File} when available.
 	 * This effectively stores all the defined procedures within the given {@link Environment}.

--- a/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
+++ b/src/main/java/com/laytonsmith/core/functions/IncludeCache.java
@@ -189,7 +189,7 @@ public class IncludeCache {
 	 * @param env The {@link Environment} to execute with
 	 * @param s The {@link Script} to execute with (can be null)
 	 */
-	public void registerAutoIncludes(Environment env, Script s) {
+	public void executeAutoIncludes(Environment env, Script s) {
 		for(File f : this.autoIncludes) {
 			try {
 				MethodScriptCompiler.execute(


### PR DESCRIPTION
This prevents auto_includes which write to Globals from being cleared on
second and on runs. The poorly named "registerAutoIncludes" has been
renamed to state what it actually does, which is execute them.