### PR TITLE
Add framework for late binding keywords.

### DIFF
--- a/src/main/java/com/laytonsmith/core/compiler/BothAssociativeLateBindingKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/BothAssociativeLateBindingKeyword.java
@@ -1,0 +1,31 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
+
+/**
+ *
+ */
+public abstract class BothAssociativeLateBindingKeyword extends LateBindingKeyword {
+	@Override
+	public final LateBindingKeyword.Associativity getAssociativity() {
+		return LateBindingKeyword.Associativity.BOTH;
+	}
+
+	protected abstract ParseTree process(ParseTree leftHandNode, ParseTree rightHandNode) throws ConfigCompileException;
+
+	@Override
+	public final ParseTree processLeftAssociative(ParseTree leftHandNode) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final ParseTree processRightAssociative(ParseTree rightHandNode) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final ParseTree processBothAssociative(ParseTree leftHandNode, ParseTree rightHandNode) throws ConfigCompileException {
+		return process(leftHandNode, rightHandNode);
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/EarlyBindingKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/EarlyBindingKeyword.java
@@ -1,0 +1,31 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscovery;
+import com.laytonsmith.core.Documentation;
+import java.net.URL;
+
+/**
+ *
+ */
+public abstract class EarlyBindingKeyword implements KeywordDocumentation {
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Class<? extends Documentation>[] seeAlso() {
+		return new Class[]{};
+	}
+
+	@Override
+	public URL getSourceJar() {
+		return ClassDiscovery.GetClassContainer(this.getClass());
+	}
+
+	@Override
+	public String getName() {
+		return this.getClass().getAnnotation(Keyword.keyword.class).value();
+	}
+
+	public String getKeywordName() {
+		return getName();
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
+++ b/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
@@ -240,7 +240,7 @@ public final class FileOptions {
 		for(Field f : ClassDiscovery.getDefaultInstance().loadFieldsWithAnnotation(Option.class)) {
 			String desc = f.getAnnotation(Option.class).value();
 			try {
-				b.append(desc).append(": ").append(f.get(this));
+				b.append(desc).append(": ").append(f.get(this)).append("; ");
 			} catch (IllegalArgumentException | IllegalAccessException ex) {
 				// uh
 			}

--- a/src/main/java/com/laytonsmith/core/compiler/Keyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/Keyword.java
@@ -22,7 +22,7 @@ import java.util.List;
  * passed to the keyword handler for processing. In order for keywords to be dynamically introduced, the keyword
  * implementation must be tagged with the keyword annotation.
  */
-public abstract class Keyword implements Documentation {
+public abstract class Keyword implements KeywordDocumentation {
 
 	protected Keyword() {
 	}

--- a/src/main/java/com/laytonsmith/core/compiler/KeywordDocumentation.java
+++ b/src/main/java/com/laytonsmith/core/compiler/KeywordDocumentation.java
@@ -1,0 +1,15 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.core.Documentation;
+
+/**
+ * A wrapper interface for reflective access among all keywords, normal, late, and early binding.
+ */
+public interface KeywordDocumentation extends Documentation {
+
+	/**
+	 * Returns the name of the keyword as used in code.
+	 * @return
+	 */
+	public String getKeywordName();
+}

--- a/src/main/java/com/laytonsmith/core/compiler/KeywordList.java
+++ b/src/main/java/com/laytonsmith/core/compiler/KeywordList.java
@@ -14,6 +14,8 @@ import java.util.logging.Logger;
 public class KeywordList {
 
 	private static Map<String, Keyword> keywordList;
+	private static Map<String, EarlyBindingKeyword> earlyKeywordList;
+	private static Map<String, LateBindingKeyword> lateKeywordList;
 
 	static {
 		refreshKeywordList();
@@ -37,33 +39,106 @@ public class KeywordList {
 				Logger.getLogger(KeywordList.class.getName()).log(Level.SEVERE, null, ex);
 			}
 		}
+		Set<Class<? extends EarlyBindingKeyword>> earlyKeywords = ClassDiscovery.getDefaultInstance().loadClassesWithAnnotationThatExtend(Keyword.keyword.class, EarlyBindingKeyword.class);
+		earlyKeywordList = new HashMap<>();
+		for(Class<? extends EarlyBindingKeyword> k : earlyKeywords) {
+			if(k == EarlyBindingKeyword.class) {
+				// Skip this one
+				continue;
+			}
+			try {
+				EarlyBindingKeyword kk = k.newInstance();
+				earlyKeywordList.put(kk.getKeywordName(), kk);
+			} catch (InstantiationException | IllegalAccessException ex) {
+				Logger.getLogger(KeywordList.class.getName()).log(Level.SEVERE, null, ex);
+			}
+		}
+		Set<Class<? extends LateBindingKeyword>> lateKeywords = ClassDiscovery.getDefaultInstance().loadClassesWithAnnotationThatExtend(Keyword.keyword.class, LateBindingKeyword.class);
+		lateKeywordList = new HashMap<>();
+		for(Class<? extends LateBindingKeyword> k : lateKeywords) {
+			if(k == LateBindingKeyword.class) {
+				// Skip this one
+				continue;
+			}
+			try {
+				LateBindingKeyword kk = k.newInstance();
+				lateKeywordList.put(kk.getKeywordName(), kk);
+			} catch (InstantiationException | IllegalAccessException ex) {
+				Logger.getLogger(KeywordList.class.getName()).log(Level.SEVERE, null, ex);
+			}
+		}
 	}
 
 	/**
-	 * Returns a set of known keywords
-	 *
-	 * @return
-	 */
-	public static Set<Keyword> getKeywordList() {
-		return new HashSet<>(keywordList.values());
-	}
-
-	/**
-	 * Returns a set of keyword names
+	 * Returns a set of all keyword names, including early and late binding ones.
 	 *
 	 * @return
 	 */
 	public static Set<String> getKeywordNames() {
-		return new HashSet<>(keywordList.keySet());
+		Set<String> ret = new HashSet<>(keywordList.keySet());
+		ret.addAll(earlyKeywordList.keySet());
+		ret.addAll(lateKeywordList.keySet());
+		return ret;
 	}
 
 	/**
-	 * Returns a keyword object given the keyword name, or null, if it doesn't exist.
+	 * Returns a set of known keywords (including normal, early, and late binding) that can be used for documentation
+	 * purposes.
+	 *
+	 * @return
+	 */
+	public static Set<KeywordDocumentation> getKeywordList() {
+		Set<KeywordDocumentation> ret = new HashSet<>(keywordList.values());
+		ret.addAll(earlyKeywordList.values());
+		ret.addAll(lateKeywordList.values());
+		return ret;
+	}
+
+	/**
+	 * Returns a normal binding keyword object given the keyword name, or null, if it doesn't exist.
 	 *
 	 * @param name
 	 * @return
 	 */
 	public static Keyword getKeywordByName(String name) {
 		return keywordList.get(name);
+	}
+
+	/**
+	 * Returns a set of known early binding keywords
+	 *
+	 * @return
+	 */
+	public static Set<EarlyBindingKeyword> getEarlyBindingKeywordList() {
+		return new HashSet<>(earlyKeywordList.values());
+	}
+
+	/**
+	 * Returns a set of known late binding keywords
+	 *
+	 * @return
+	 */
+	public static Set<LateBindingKeyword> getLateBindingKeywordList() {
+		return new HashSet<>(lateKeywordList.values());
+	}
+
+	/**
+	 * Returns a early binding keyword object given the keyword name, or null, if it doesn't exist.
+	 *
+	 * @param name
+	 * @return
+	 */
+	public static EarlyBindingKeyword getEarlyBindingKeywordByName(String name) {
+		return earlyKeywordList.get(name);
+	}
+
+	/**
+	 * Returns a late binding keyword object given the keyword name, or null, if it doesn't exist.
+	 *
+	 * @param name
+	 * @return
+	 */
+	public static LateBindingKeyword getLateBindingKeywordByName(String name) {
+		return lateKeywordList.get(name);
 	}
 }

--- a/src/main/java/com/laytonsmith/core/compiler/LateBindingKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/LateBindingKeyword.java
@@ -1,0 +1,63 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscovery;
+import com.laytonsmith.core.Documentation;
+import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
+import java.net.URL;
+
+/**
+ * A late binding keyword is one that is bound after other parts of the parse tree have been formed. They are
+ * then processed afterwards as their own nodes. Late Binding Keywords can have left, right, or both associativity.
+ * This is meant for keywords that don't work with low level contexts, such as ones that care about brackets or
+ * other individual symbols, but instead work with the logical concept of a high level ParseTree node, which
+ * has already been resolved into a single ParseTree (which may itself have other keywords).
+ */
+public abstract class LateBindingKeyword implements KeywordDocumentation {
+	public static enum Associativity {
+		/**
+		 * A left associative keyword attaches to the node to its left. That is, {@code node1 keyword node2}, then
+		 * node1 is associated with this keyword.
+		 */
+		LEFT,
+		/**
+		 * A left associative keyword attaches to the node to its right. That is, {@code node1 keyword node2}, then
+		 * node2 is associated with this keyword.
+		 */
+		RIGHT,
+		/**
+		 * A both associative keyword attaches to the node to its left and right. That is, {@code node1 keyword node2},
+		 * then node1 and node2 is associated with this keyword.
+		 */
+		BOTH;
+	}
+
+	public abstract ParseTree processLeftAssociative(ParseTree leftHandNode) throws ConfigCompileException;
+
+	public abstract ParseTree processRightAssociative(ParseTree rightHandNode) throws ConfigCompileException;
+
+	public abstract ParseTree processBothAssociative(ParseTree leftHandNode, ParseTree rightHandNode) throws ConfigCompileException;
+
+	public abstract Associativity getAssociativity();
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Class<? extends Documentation>[] seeAlso() {
+		return new Class[]{};
+	}
+
+	@Override
+	public URL getSourceJar() {
+		return ClassDiscovery.GetClassContainer(this.getClass());
+	}
+
+	@Override
+	public String getName() {
+		return this.getClass().getAnnotation(Keyword.keyword.class).value();
+	}
+
+	public String getKeywordName() {
+		return getName();
+	}
+
+}

--- a/src/main/java/com/laytonsmith/core/compiler/LeftAssociativeLateBindingKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/LeftAssociativeLateBindingKeyword.java
@@ -1,0 +1,33 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
+
+/**
+ *
+ */
+public abstract class LeftAssociativeLateBindingKeyword extends LateBindingKeyword {
+
+	@Override
+	public final Associativity getAssociativity() {
+		return Associativity.LEFT;
+	}
+
+	protected abstract ParseTree process(ParseTree leftHandNode) throws ConfigCompileException;
+
+	@Override
+	public final ParseTree processLeftAssociative(ParseTree leftHandNode) throws ConfigCompileException {
+		return process(leftHandNode);
+	}
+
+	@Override
+	public final ParseTree processRightAssociative(ParseTree rightHandNode) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final ParseTree processBothAssociative(ParseTree leftHandNode, ParseTree rightHandNode) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/src/main/java/com/laytonsmith/core/compiler/RightAssociativeLateBindingKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/RightAssociativeLateBindingKeyword.java
@@ -1,0 +1,32 @@
+package com.laytonsmith.core.compiler;
+
+import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.exceptions.ConfigCompileException;
+
+/**
+ *
+ */
+public abstract class RightAssociativeLateBindingKeyword extends LateBindingKeyword {
+
+	@Override
+	public final LateBindingKeyword.Associativity getAssociativity() {
+		return LateBindingKeyword.Associativity.RIGHT;
+	}
+
+	protected abstract ParseTree process(ParseTree leftHandNode) throws ConfigCompileException;
+
+	@Override
+	public final ParseTree processLeftAssociative(ParseTree leftHandNode) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final ParseTree processRightAssociative(ParseTree rightHandNode) throws ConfigCompileException {
+		return process(rightHandNode);
+	}
+
+	@Override
+	public final ParseTree processBothAssociative(ParseTree leftHandNode, ParseTree rightHandNode) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/main/java/com/laytonsmith/core/compiler/keywords/ReturnKeyword.java
+++ b/src/main/java/com/laytonsmith/core/compiler/keywords/ReturnKeyword.java
@@ -1,0 +1,39 @@
+package com.laytonsmith.core.compiler.keywords;
+
+import com.laytonsmith.PureUtilities.Version;
+import com.laytonsmith.core.MSVersion;
+import com.laytonsmith.core.ParseTree;
+import com.laytonsmith.core.compiler.FileOptions;
+import com.laytonsmith.core.compiler.Keyword;
+import com.laytonsmith.core.compiler.RightAssociativeLateBindingKeyword;
+import com.laytonsmith.core.constructs.CFunction;
+import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.functions.ControlFlow;
+
+/**
+ *
+ */
+@Keyword.keyword("return")
+public class ReturnKeyword extends RightAssociativeLateBindingKeyword {
+
+	@Override
+	protected ParseTree process(ParseTree leftHandNode) {
+		Target t = leftHandNode.getTarget();
+		FileOptions fileOptions = leftHandNode.getFileOptions();
+		ParseTree ret = new ParseTree(new CFunction(ControlFlow._return.NAME, t), fileOptions);
+		ret.addChild(leftHandNode);
+		return ret;
+	}
+
+	@Override
+	public String docs() {
+		return "Returns the specified value from the Callable.";
+	}
+
+	@Override
+	public Version since() {
+		return MSVersion.V3_3_5;
+	}
+
+
+}

--- a/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
+++ b/src/main/java/com/laytonsmith/core/functions/ControlFlow.java
@@ -2377,9 +2377,11 @@ public class ControlFlow {
 	@api
 	public static class _return extends AbstractFunction implements Optimizable {
 
+		public static final String NAME = "return";
+
 		@Override
 		public String getName() {
-			return "return";
+			return NAME;
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Reflection.java
+++ b/src/main/java/com/laytonsmith/core/functions/Reflection.java
@@ -62,7 +62,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -293,12 +292,9 @@ public class Reflection {
 			} else if("keywords".equalsIgnoreCase(param)) {
 				if(args.length == 1) {
 					CArray a = new CArray(t);
-					List<Keyword> l = new ArrayList<>(KeywordList.getKeywordList());
-					l.forEach(new Consumer<Keyword>() {
-						@Override
-						public void accept(Keyword t) {
-							a.push(new CString(t.getKeywordName(), Target.UNKNOWN), Target.UNKNOWN);
-						}
+					List<String> l = new ArrayList<>(KeywordList.getKeywordNames());
+					l.forEach((String t1) -> {
+						a.push(new CString(t1, Target.UNKNOWN), Target.UNKNOWN);
 					});
 					return new ArrayHandling.array_sort().exec(t, env, a);
 				} else if(args.length == 2) {

--- a/src/main/java/com/laytonsmith/tools/docgen/sitedeploy/APIBuilder.java
+++ b/src/main/java/com/laytonsmith/tools/docgen/sitedeploy/APIBuilder.java
@@ -11,7 +11,7 @@ import com.laytonsmith.annotations.typeof;
 import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.MethodScriptFileLocations;
 import com.laytonsmith.core.Optimizable;
-import com.laytonsmith.core.compiler.Keyword;
+import com.laytonsmith.core.compiler.KeywordDocumentation;
 import com.laytonsmith.core.compiler.KeywordList;
 import com.laytonsmith.core.constructs.CClassType;
 import com.laytonsmith.core.constructs.NativeTypeList;
@@ -180,7 +180,7 @@ public class APIBuilder {
 		{
 			// keywords
 			Map<String, Map<String, String>> keywords = new TreeMap<>();
-			for(Keyword keyword : KeywordList.getKeywordList()) {
+			for(KeywordDocumentation keyword : KeywordList.getKeywordList()) {
 				Map<String, String> keyw = new TreeMap<>();
 				keyw.put("name", keyword.getKeywordName());
 				keyw.put("docs", keyword.docs());

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -483,4 +483,17 @@ public class OptimizationTest {
 		assertEquals("not(@value)", optimize("!@value"));
 		// !!!!@value (or more than 2 !!) is broken in the compiler -.-
 	}
+
+	@Test
+	public void testReturnAsKeyword() throws Exception {
+		// It shouldn't have string(), but whatever, it's the weird sconcat behavior.
+		assertEquals("proc('_name',string(return('value')))", optimize("proc _name() { return 'value'; }"));
+		assertEquals("proc('_name',string(return(rand(1,10))))", optimize("proc _name() { return rand(1, 10); }"));
+
+		assertEquals("proc('_name',__statements__(return('value')))", optimize("<! strict > proc _name() { return 'value'; }"));
+		assertEquals("proc('_name',__statements__(return(rand(1,10))))", optimize("<! strict > proc _name() { return rand(1, 10); }"));
+
+		assertEquals("proc('_name',string(return(add(dyn(1),dyn(2)))))", optimize("proc _name() { return dyn(1) + dyn(2); }"));
+		assertEquals("proc('_name',__statements__(return(add(dyn(1),dyn(2)))))", optimize("<! strict > proc _name() { return dyn(1) + dyn(2); }"));
+	}
 }


### PR DESCRIPTION
There is also a start for early binding ones as well, but that is unused
for now. A LateBindingKeyword is one that is either left, right, or
both associative, but works at a very high level, where it expects one
or two parse tree nodes to surround it, and it take the whole node,
whatever that is, which may be made up of other complex items. These
binding works more or less the same as other keywords, but it runs after
autoconcats are resolved, meaning that normal binding keywords will all
have already run.

EarlyBindingKeywords are meant to operate at an extremely early stage,
operating instead of on nodes, directly on the TokenStream, so that
syntax such as commas and other extremly low level components can be
subsumed into the keyword. This is intended to be used with class
definitions and perhaps others, down the road.

The first keyword to use this framework is the return framework, working as one would expect so that `return statement;` works now.