### PR TITLE
Add support for custom tags in item meta

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/Convertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/Convertor.java
@@ -269,4 +269,16 @@ public interface Convertor {
 	 * @return The username
 	 */
 	String GetUser(Environment env);
+
+	/**
+	 * Returns a Minecraft namespaced key object from a string.
+	 * The key can only alphanumeric characters, dots, underscores, and dashes.
+	 * A preceding namespace can be delimited with a single colon, which can also have forward slashes.
+	 * Example: "path/commandhelper:my_tag".
+	 * If no namespace is given, it will default to "commandhelper".
+	 *
+	 * @param key a string formatted key
+	 * @return a key object
+	 */
+	MCNamespacedKey GetNamespacedKey(String key);
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCItemMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCItemMeta.java
@@ -128,4 +128,8 @@ public interface MCItemMeta extends AbstractionObject {
 	List<MCAttributeModifier> getAttributeModifiers();
 
 	void setAttributeModifiers(List<MCAttributeModifier> modifiers);
+
+	boolean hasCustomTags();
+
+	MCTagContainer getCustomTags();
 }

--- a/src/main/java/com/laytonsmith/abstraction/MCNamespacedKey.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCNamespacedKey.java
@@ -1,0 +1,4 @@
+package com.laytonsmith.abstraction;
+
+public interface MCNamespacedKey extends AbstractionObject {
+}

--- a/src/main/java/com/laytonsmith/abstraction/MCTagContainer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCTagContainer.java
@@ -2,7 +2,7 @@ package com.laytonsmith.abstraction;
 
 import com.laytonsmith.abstraction.enums.MCTagType;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * Minecraft NBT containers that can be used to read and modify tags in supported game objects.
@@ -17,12 +17,10 @@ public interface MCTagContainer extends AbstractionObject {
 	boolean isEmpty();
 
 	/**
-	 * Gets a set of key objects for each tag that exists in this container.
-	 * These are minecraft formatted namespaced keys. (e.g. "namespace:key")
-	 * These key objects can be passed to other methods in this class.
+	 * Gets a set of namespaced keys for each tag that exists in this container. (e.g. "namespace:key")
 	 * @return a set of keys
 	 */
-	Collection getKeys();
+	Set<MCNamespacedKey> getKeys();
 
 	/**
 	 * Returns the tag type with the given key.
@@ -31,7 +29,7 @@ public interface MCTagContainer extends AbstractionObject {
 	 * @param key the tag key
 	 * @return the type for the tag
 	 */
-	MCTagType getType(Object key);
+	MCTagType getType(MCNamespacedKey key);
 
 	/**
 	 * Returns the tag value with the given key and tag type.
@@ -40,7 +38,7 @@ public interface MCTagContainer extends AbstractionObject {
 	 * @param type the tag type
 	 * @return the value for the tag
 	 */
-	Object get(Object key, MCTagType type);
+	Object get(MCNamespacedKey key, MCTagType type);
 
 	/**
 	 * Sets the tag value with the given key and tag type.
@@ -49,13 +47,13 @@ public interface MCTagContainer extends AbstractionObject {
 	 * @param type the tag type
 	 * @param value the tag value
 	 */
-	void set(Object key, MCTagType type, Object value);
+	void set(MCNamespacedKey key, MCTagType type, Object value);
 
 	/**
 	 * Deletes the tag with the given key from this container.
 	 * @param key the tag key
 	 */
-	void remove(Object key);
+	void remove(MCNamespacedKey key);
 
 	/**
 	 * Creates a new tag container from this container context.

--- a/src/main/java/com/laytonsmith/abstraction/MCTagContainer.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCTagContainer.java
@@ -1,0 +1,67 @@
+package com.laytonsmith.abstraction;
+
+import com.laytonsmith.abstraction.enums.MCTagType;
+
+import java.util.Collection;
+
+/**
+ * Minecraft NBT containers that can be used to read and modify tags in supported game objects.
+ * This includes item meta, entities, block entities, chunks, worlds, etc.
+ */
+public interface MCTagContainer extends AbstractionObject {
+
+	/**
+	 * Returns whether the tag container does not contain any tags.
+	 * @return whether container is empty
+	 */
+	boolean isEmpty();
+
+	/**
+	 * Gets a set of key objects for each tag that exists in this container.
+	 * These are minecraft formatted namespaced keys. (e.g. "namespace:key")
+	 * These key objects can be passed to other methods in this class.
+	 * @return a set of keys
+	 */
+	Collection getKeys();
+
+	/**
+	 * Returns the tag type with the given key.
+	 * MCTagType can be used to convert tags to and from MethodScript constructs.
+	 * Returns null if a tag with that key does not exist.
+	 * @param key the tag key
+	 * @return the type for the tag
+	 */
+	MCTagType getType(Object key);
+
+	/**
+	 * Returns the tag value with the given key and tag type.
+	 * Returns null if a tag with that key and type does not exist.
+	 * @param key the tag key
+	 * @param type the tag type
+	 * @return the value for the tag
+	 */
+	Object get(Object key, MCTagType type);
+
+	/**
+	 * Sets the tag value with the given key and tag type.
+	 * Throws an IllegalArgumentException if the type and value do not match.
+	 * @param key the tag key
+	 * @param type the tag type
+	 * @param value the tag value
+	 */
+	void set(Object key, MCTagType type, Object value);
+
+	/**
+	 * Deletes the tag with the given key from this container.
+	 * @param key the tag key
+	 */
+	void remove(Object key);
+
+	/**
+	 * Creates a new tag container from this container context.
+	 * This can then be used to nest a tag container with the {@link #set} method.
+	 * @return a new tag container
+	 */
+	MCTagContainer newContainer();
+
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -18,6 +18,7 @@ import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCMetadataValue;
+import com.laytonsmith.abstraction.MCNamespacedKey;
 import com.laytonsmith.abstraction.MCNote;
 import com.laytonsmith.abstraction.MCPattern;
 import com.laytonsmith.abstraction.MCPlugin;
@@ -870,5 +871,10 @@ public class BukkitConvertor extends AbstractConvertor {
 			}
 			return name;
 		}
+	}
+
+	@Override
+	public MCNamespacedKey GetNamespacedKey(String key) {
+		return new BukkitMCNamespacedKey(NamespacedKey.fromString(key, CommandHelperPlugin.self));
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCItemMeta.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCItemMeta.java
@@ -6,6 +6,7 @@ import com.laytonsmith.abstraction.AbstractionObject;
 import com.laytonsmith.abstraction.MCAttributeModifier;
 import com.laytonsmith.abstraction.MCEnchantment;
 import com.laytonsmith.abstraction.MCItemMeta;
+import com.laytonsmith.abstraction.MCTagContainer;
 import com.laytonsmith.abstraction.blocks.MCBlockData;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlockData;
@@ -224,5 +225,14 @@ public class BukkitMCItemMeta implements MCItemMeta {
 					(AttributeModifier) m.getHandle());
 		}
 		im.setAttributeModifiers(map);
+	}
+
+	@Override
+	public boolean hasCustomTags() {
+		return !im.getPersistentDataContainer().isEmpty();
+	}
+
+	public MCTagContainer getCustomTags() {
+		return new BukkitMCTagContainer(im.getPersistentDataContainer());
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCNamespacedKey.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCNamespacedKey.java
@@ -1,0 +1,33 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCNamespacedKey;
+import org.bukkit.NamespacedKey;
+
+public class BukkitMCNamespacedKey implements MCNamespacedKey {
+
+	NamespacedKey nsk;
+
+	public BukkitMCNamespacedKey(NamespacedKey nsk) {
+		this.nsk = nsk;
+	}
+
+	@Override
+	public Object getHandle() {
+		return this.nsk;
+	}
+
+	@Override
+	public String toString() {
+		return this.nsk.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof MCNamespacedKey && this.nsk.equals(((MCNamespacedKey) obj).getHandle());
+	}
+
+	@Override
+	public int hashCode() {
+		return this.nsk.hashCode();
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTagContainer.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCTagContainer.java
@@ -1,0 +1,164 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCTagContainer;
+import com.laytonsmith.abstraction.enums.MCTagType;
+import com.laytonsmith.commandhelper.CommandHelperPlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Collection;
+
+public class BukkitMCTagContainer implements MCTagContainer {
+
+	PersistentDataContainer pdc;
+
+	public BukkitMCTagContainer(PersistentDataContainer pdc) {
+		this.pdc = pdc;
+	}
+
+	@Override
+	public MCTagContainer newContainer() {
+		return new BukkitMCTagContainer(pdc.getAdapterContext().newPersistentDataContainer());
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.pdc.isEmpty();
+	}
+
+	@Override
+	public Collection getKeys() {
+		return pdc.getKeys();
+	}
+
+	@Override
+	public MCTagType getType(Object key) {
+		NamespacedKey namespacedKey = NamespacedKey(key);
+		// Check tag types in order of most frequently used
+		if(pdc.has(namespacedKey, PersistentDataType.STRING)) {
+			return MCTagType.STRING;
+		} else if(pdc.has(namespacedKey, PersistentDataType.INTEGER)) {
+			return MCTagType.INTEGER;
+		} else if(pdc.has(namespacedKey, PersistentDataType.BYTE)) {
+			return MCTagType.BYTE;
+		} else if(pdc.has(namespacedKey, PersistentDataType.DOUBLE)) {
+			return MCTagType.DOUBLE;
+		} else if(pdc.has(namespacedKey, PersistentDataType.LONG)) {
+			return MCTagType.LONG;
+		} else if(pdc.has(namespacedKey, PersistentDataType.FLOAT)) {
+			return MCTagType.FLOAT;
+		} else if(pdc.has(namespacedKey, PersistentDataType.TAG_CONTAINER)) {
+			return MCTagType.TAG_CONTAINER;
+		} else if(pdc.has(namespacedKey, PersistentDataType.BYTE_ARRAY)) {
+			return MCTagType.BYTE_ARRAY;
+		} else if(pdc.has(namespacedKey, PersistentDataType.SHORT)) {
+			return MCTagType.SHORT;
+		} else if(pdc.has(namespacedKey, PersistentDataType.INTEGER_ARRAY)) {
+			return MCTagType.INTEGER_ARRAY;
+		} else if(pdc.has(namespacedKey, PersistentDataType.LONG_ARRAY)) {
+			return MCTagType.LONG_ARRAY;
+		} else if(pdc.has(namespacedKey, PersistentDataType.TAG_CONTAINER_ARRAY)) {
+			return MCTagType.TAG_CONTAINER_ARRAY;
+		}
+		return null;
+	}
+
+	@Override
+	public Object get(Object key, MCTagType type) {
+		PersistentDataType bukkitType = GetPersistentDataType(type);
+		Object value = pdc.get(NamespacedKey(key), bukkitType);
+		if(value instanceof PersistentDataContainer) {
+			return new BukkitMCTagContainer((PersistentDataContainer) value);
+		} else if(value instanceof PersistentDataContainer[] concreteContainers) {
+			MCTagContainer[] abstractContainers = new MCTagContainer[concreteContainers.length];
+			for(int i = 0; i < concreteContainers.length; i++) {
+				abstractContainers[i] = new BukkitMCTagContainer(concreteContainers[i]);
+			}
+			return abstractContainers;
+		}
+		return value;
+	}
+
+	@Override
+	public void set(Object key, MCTagType type, Object value) {
+		PersistentDataType bukkitType = GetPersistentDataType(type);
+		if(value instanceof MCTagContainer) {
+			value = ((MCTagContainer) value).getHandle();
+		} else if(value instanceof MCTagContainer[] abstractContainers) {
+			PersistentDataContainer[] concreteContainers = new PersistentDataContainer[abstractContainers.length];
+			for(int i = 0; i < abstractContainers.length; i++) {
+				concreteContainers[i] = (PersistentDataContainer) abstractContainers[i].getHandle();
+			}
+			value = concreteContainers;
+		}
+		pdc.set(NamespacedKey(key), bukkitType, value);
+	}
+
+	@Override
+	public void remove(Object key) {
+		pdc.remove(NamespacedKey(key));
+	}
+
+	private static NamespacedKey NamespacedKey(Object key) {
+		if(key instanceof NamespacedKey) {
+			return (NamespacedKey) key;
+		} else if(key instanceof String) {
+			NamespacedKey namespacedKey = NamespacedKey.fromString((String) key, CommandHelperPlugin.self);
+			if(namespacedKey != null) {
+				return namespacedKey;
+			}
+		}
+		throw new IllegalArgumentException("Invalid namespaced key.");
+	}
+
+	private static PersistentDataType GetPersistentDataType(MCTagType type) {
+		switch(type) {
+			case BYTE:
+				return PersistentDataType.BYTE;
+			case BYTE_ARRAY:
+				return PersistentDataType.BYTE_ARRAY;
+			case DOUBLE:
+				return PersistentDataType.DOUBLE;
+			case FLOAT:
+				return PersistentDataType.FLOAT;
+			case INTEGER:
+				return PersistentDataType.INTEGER;
+			case INTEGER_ARRAY:
+				return PersistentDataType.INTEGER_ARRAY;
+			case LONG:
+				return PersistentDataType.LONG;
+			case LONG_ARRAY:
+				return PersistentDataType.LONG_ARRAY;
+			case SHORT:
+				return PersistentDataType.SHORT;
+			case STRING:
+				return PersistentDataType.STRING;
+			case TAG_CONTAINER:
+				return PersistentDataType.TAG_CONTAINER;
+			case TAG_CONTAINER_ARRAY:
+				return PersistentDataType.TAG_CONTAINER_ARRAY;
+		}
+		throw new IllegalArgumentException("Invalid persistent data type: " + type.name());
+	}
+
+	@Override
+	public Object getHandle() {
+		return pdc;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof MCTagContainer && this.pdc.equals(((MCTagContainer) o).getHandle());
+	}
+
+	@Override
+	public int hashCode() {
+		return pdc.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return pdc.toString();
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCTagType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCTagType.java
@@ -1,0 +1,220 @@
+package com.laytonsmith.abstraction.enums;
+
+import com.laytonsmith.abstraction.MCTagContainer;
+import com.laytonsmith.core.ArgumentValidation;
+import com.laytonsmith.core.constructs.CArray;
+import com.laytonsmith.core.constructs.CDouble;
+import com.laytonsmith.core.constructs.CInt;
+import com.laytonsmith.core.constructs.CString;
+import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.core.exceptions.CRE.CREFormatException;
+import com.laytonsmith.core.natives.interfaces.Mixed;
+
+import java.util.function.Function;
+
+/**
+ * Minecraft NBT types, with functions to convert to and from MethodScript constructs.
+ */
+public enum MCTagType {
+	BYTE(
+			(Mixed v) -> ArgumentValidation.getInt8(v, v.getTarget()),
+			(Byte v) -> new CInt(((Number) v).longValue(), Target.UNKNOWN)),
+	BYTE_ARRAY(
+			(Mixed v) -> {
+				CArray array = ArgumentValidation.getArray(v, v.getTarget());
+				if(array.isAssociative()) {
+					throw new CRECastException("Expected byte array to not be associative.", v.getTarget());
+				}
+				byte[] bytes = new byte[(int) array.size()];
+				int i = 0;
+				for(Mixed m : array) {
+					bytes[i++] = ArgumentValidation.getInt8(m, m.getTarget());
+				}
+				return bytes;
+			},
+			(byte[] array) -> {
+				CArray r = new CArray(Target.UNKNOWN);
+				for(int i : array) {
+					r.push(new CInt(i, Target.UNKNOWN), Target.UNKNOWN);
+				}
+				return r;
+			}),
+	DOUBLE(
+			(Mixed v) -> ArgumentValidation.getDouble(v, v.getTarget()),
+			(Double v) -> new CDouble(v, Target.UNKNOWN)),
+	FLOAT(
+			(Mixed v) -> ArgumentValidation.getDouble32(v, v.getTarget()),
+			(Float v) -> new CDouble(v.doubleValue(), Target.UNKNOWN)),
+	INTEGER(
+			(Mixed v) -> ArgumentValidation.getInt32(v, v.getTarget()),
+			(Integer v) -> new CInt(((Number) v).longValue(), Target.UNKNOWN)),
+	INTEGER_ARRAY(
+			(Mixed v) -> {
+				CArray array = ArgumentValidation.getArray(v, v.getTarget());
+				if(array.isAssociative()) {
+					throw new CRECastException("Expected integer array to not be associative.", v.getTarget());
+				}
+				int[] ints = new int[(int) array.size()];
+				int i = 0;
+				for(Mixed m : array) {
+					ints[i++] = ArgumentValidation.getInt32(m, m.getTarget());
+				}
+				return ints;
+			},
+			(int[] array) -> {
+				CArray r = new CArray(Target.UNKNOWN);
+				for(int i : array) {
+					r.push(new CInt(i, Target.UNKNOWN), Target.UNKNOWN);
+				}
+				return r;
+			}),
+	LONG(
+			(Mixed v) -> ArgumentValidation.getInt(v, v.getTarget()),
+			(Long v) -> new CInt(((Number) v).longValue(), Target.UNKNOWN)),
+	LONG_ARRAY(
+			(Mixed v) -> {
+				CArray array = ArgumentValidation.getArray(v, v.getTarget());
+				if(array.isAssociative()) {
+					throw new CRECastException("Expected long array to not be associative.", v.getTarget());
+				}
+				long[] longs = new long[(int) array.size()];
+				int i = 0;
+				for(Mixed m : array) {
+					longs[i++] = ArgumentValidation.getInt(m, m.getTarget());
+				}
+				return longs;
+			},
+			(long[] array) -> {
+				CArray ret = new CArray(Target.UNKNOWN);
+				for(long i : array) {
+					ret.push(new CInt(i, Target.UNKNOWN), Target.UNKNOWN);
+				}
+				return ret;
+			}),
+	SHORT(
+			(Mixed v) -> ArgumentValidation.getInt16(v, v.getTarget()),
+			(Short v) -> new CInt(((Number) v).longValue(), Target.UNKNOWN)),
+	STRING(
+			(Mixed v) -> v.val(),
+			(String v) -> new CString(v, Target.UNKNOWN)),
+	TAG_CONTAINER(
+			(Mixed v) -> {
+				throw new UnsupportedOperationException();
+			},
+			(MCTagContainer v) -> {
+				throw new UnsupportedOperationException();
+			}),
+	TAG_CONTAINER_ARRAY(
+			(Mixed v) -> {
+				throw new UnsupportedOperationException();
+			},
+			(MCTagContainer[] v) -> {
+				throw new UnsupportedOperationException();
+			});
+
+	private final Function conversion;
+	private final Function construction;
+
+	<T extends Mixed, Z> MCTagType(Function<T, Z> conversion, Function<Z, T> construction) {
+		this.conversion = conversion;
+		this.construction = construction;
+	}
+
+	/**
+	 * Returns a Java object from a MethodScript construct.
+	 * Throws a ConfigRuntimeException if the value is not valid for this tag type.
+	 * @param container the tag container context
+	 * @param value MethodScript construct
+	 * @return a Java object
+	 */
+	public Object convert(MCTagContainer container, Mixed value) {
+		if(this == TAG_CONTAINER) {
+			if(!value.isInstanceOf(CArray.TYPE)) {
+				throw new CREFormatException("Expected tag container to be an array.", value.getTarget());
+			}
+			CArray containerArray = (CArray) value;
+			if(!containerArray.isAssociative()) {
+				throw new CREFormatException("Expected tag container array to be associative.", value.getTarget());
+			}
+			for(String key : containerArray.stringKeySet()) {
+				Mixed possibleArray = containerArray.get(key, value.getTarget());
+				if(!possibleArray.isInstanceOf(CArray.TYPE)) {
+					throw new CREFormatException("Expected tag entry to be an array.", possibleArray.getTarget());
+				}
+				CArray entryArray = (CArray) possibleArray;
+				if(!entryArray.isAssociative()) {
+					throw new CREFormatException("Expected tag array to be associative.", entryArray.getTarget());
+				}
+				Mixed entryType = entryArray.get("type", entryArray.getTarget());
+				Mixed entryValue = entryArray.get("value", entryArray.getTarget());
+				MCTagType tagType;
+				try {
+					tagType = MCTagType.valueOf(entryType.val());
+				} catch (IllegalArgumentException ex) {
+					throw new CREFormatException("Tag type is not valid: " + entryType.val(), entryType.getTarget());
+				}
+				Object tagValue;
+				if(tagType == MCTagType.TAG_CONTAINER) {
+					tagValue = tagType.convert(container.newContainer(), entryValue);
+				} else if(tagType == TAG_CONTAINER_ARRAY) {
+					tagValue = tagType.convert(container, entryValue);
+				} else {
+					tagValue = tagType.convert(container, entryValue);
+				}
+				try {
+					container.set(key, tagType, tagValue);
+				} catch (ClassCastException ex) {
+					throw new CREFormatException("Tag value does not match expected type.", entryValue.getTarget());
+				} catch (IllegalArgumentException ex) {
+					throw new CREFormatException(ex.getMessage(), entryValue.getTarget());
+				}
+			}
+			return container;
+		} else if(this == TAG_CONTAINER_ARRAY) {
+			if(!value.isInstanceOf(CArray.TYPE)) {
+				throw new CREFormatException("Expected tag container to be an array.", value.getTarget());
+			}
+			CArray array = (CArray) value;
+			if(array.isAssociative()) {
+				throw new CREFormatException("Expected tag container array to not be associative.", array.getTarget());
+			}
+			MCTagContainer[] containers = new MCTagContainer[(int) array.size()];
+			int i = 0;
+			for(Mixed possibleContainer : array) {
+				containers[i++] = (MCTagContainer) TAG_CONTAINER.convert(container.newContainer(), possibleContainer);
+			}
+			return containers;
+		}
+		return conversion.apply(value);
+	}
+
+	/**
+	 * Returns a MethodScript construct from a Java object.
+	 * Throws a ClassCastException if the value does not match this tag type.
+	 * @param value a valid Java object
+	 * @return a MethodScript construct
+	 */
+	public Mixed construct(Object value) throws ClassCastException {
+		if(this == TAG_CONTAINER) {
+			MCTagContainer container = (MCTagContainer) value;
+			CArray containerArray = CArray.GetAssociativeArray(Target.UNKNOWN);
+			for(Object key : container.getKeys()) {
+				CArray entry = CArray.GetAssociativeArray(Target.UNKNOWN);
+				MCTagType type = container.getType(key);
+				entry.set("type", type.name(), Target.UNKNOWN);
+				entry.set("value", type.construct(container.get(key, type)), Target.UNKNOWN);
+				containerArray.set(key.toString(), entry, Target.UNKNOWN);
+			}
+			return containerArray;
+		} else if(this == TAG_CONTAINER_ARRAY) {
+			MCTagContainer[] containers = (MCTagContainer[]) value;
+			CArray array = new CArray(Target.UNKNOWN, containers.length);
+			for(MCTagContainer container : containers) {
+				array.push(TAG_CONTAINER.construct(container), Target.UNKNOWN);
+			}
+			return array;
+		}
+		return (Mixed) construction.apply(value);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/enums/MCTagType.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCTagType.java
@@ -1,6 +1,8 @@
 package com.laytonsmith.abstraction.enums;
 
+import com.laytonsmith.abstraction.MCNamespacedKey;
 import com.laytonsmith.abstraction.MCTagContainer;
+import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CDouble;
@@ -163,7 +165,7 @@ public enum MCTagType {
 					tagValue = tagType.convert(container, entryValue);
 				}
 				try {
-					container.set(key, tagType, tagValue);
+					container.set(StaticLayer.GetConvertor().GetNamespacedKey(key), tagType, tagValue);
 				} catch (ClassCastException ex) {
 					throw new CREFormatException("Tag value does not match expected type.", entryValue.getTarget());
 				} catch (IllegalArgumentException ex) {
@@ -199,7 +201,7 @@ public enum MCTagType {
 		if(this == TAG_CONTAINER) {
 			MCTagContainer container = (MCTagContainer) value;
 			CArray containerArray = CArray.GetAssociativeArray(Target.UNKNOWN);
-			for(Object key : container.getKeys()) {
+			for(MCNamespacedKey key : container.getKeys()) {
 				CArray entry = CArray.GetAssociativeArray(Target.UNKNOWN);
 				MCTagType type = container.getType(key);
 				entry.set("type", type.name(), Target.UNKNOWN);

--- a/src/main/java/com/laytonsmith/core/ObjectGenerator.java
+++ b/src/main/java/com/laytonsmith/core/ObjectGenerator.java
@@ -71,6 +71,7 @@ import com.laytonsmith.abstraction.enums.MCPatternShape;
 import com.laytonsmith.abstraction.enums.MCPotionEffectType;
 import com.laytonsmith.abstraction.enums.MCPotionType;
 import com.laytonsmith.abstraction.enums.MCRecipeType;
+import com.laytonsmith.abstraction.enums.MCTagType;
 import com.laytonsmith.abstraction.enums.MCTrimMaterial;
 import com.laytonsmith.abstraction.enums.MCTrimPattern;
 import com.laytonsmith.core.constructs.CArray;
@@ -463,6 +464,12 @@ public class ObjectGenerator {
 					modifiers.push(attributeModifier(m, t), t);
 				}
 				ma.set("modifiers", modifiers, t);
+			}
+
+			if(meta.hasCustomTags()) {
+				ma.set("tags", MCTagType.TAG_CONTAINER.construct(meta.getCustomTags()), t);
+			} else {
+				ma.set("tags", CNull.NULL, t);
 			}
 
 			MCMaterial material = is.getType();
@@ -876,6 +883,15 @@ public class ObjectGenerator {
 						meta.setAttributeModifiers(modifierList);
 					} else {
 						throw new CREFormatException("Attribute modifiers were expected to be an array.", t);
+					}
+				}
+
+				if(ma.containsKey("tags")) {
+					Mixed tagArray = ma.get("tags", t);
+					if(tagArray instanceof CNull) {
+						// no custom tags
+					} else {
+						MCTagType.TAG_CONTAINER.convert(meta.getCustomTags(), tagArray);
 					}
 				}
 

--- a/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
+++ b/src/main/java/com/laytonsmith/core/functions/ItemMeta.java
@@ -20,6 +20,7 @@ import com.laytonsmith.abstraction.enums.MCFireworkType;
 import com.laytonsmith.abstraction.enums.MCItemFlag;
 import com.laytonsmith.abstraction.enums.MCPatternShape;
 import com.laytonsmith.abstraction.enums.MCPotionType;
+import com.laytonsmith.abstraction.enums.MCTagType;
 import com.laytonsmith.abstraction.enums.MCTrimMaterial;
 import com.laytonsmith.abstraction.enums.MCTrimPattern;
 import com.laytonsmith.annotations.api;
@@ -128,6 +129,7 @@ public class ItemMeta {
 			docs = docs.replace("%AXOLOTL_TYPES%", StringUtils.Join(MCAxolotlType.values(), ", ", ", or ", " or "));
 			docs = docs.replace("%TRIM_PATTERNS%", StringUtils.Join(MCTrimPattern.values(), ", ", ", or ", " or "));
 			docs = docs.replace("%TRIM_MATERIALS%", StringUtils.Join(MCTrimMaterial.values(), ", ", ", or ", " or "));
+			docs = docs.replace("%TAG_TYPES%", StringUtils.Join(MCTagType.values(), ", ", ", or ", " or "));
 			return docs;
 		}
 

--- a/src/main/java/com/laytonsmith/tools/Interpreter.java
+++ b/src/main/java/com/laytonsmith/tools/Interpreter.java
@@ -30,6 +30,7 @@ import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCMetadataValue;
+import com.laytonsmith.abstraction.MCNamespacedKey;
 import com.laytonsmith.abstraction.MCNote;
 import com.laytonsmith.abstraction.MCPattern;
 import com.laytonsmith.abstraction.MCPlugin;
@@ -1290,6 +1291,11 @@ public final class Interpreter {
 		@Override
 		public String GetUser(Environment env) {
 			return System.getProperty("user.name");
+		}
+
+		@Override
+		public MCNamespacedKey GetNamespacedKey(String key) {
+			throw new UnsupportedOperationException("This method is not supported from a shell.");
 		}
 	}
 

--- a/src/main/resources/functionDocs/get_itemmeta
+++ b/src/main/resources/functionDocs/get_itemmeta
@@ -16,6 +16,7 @@ Below are the available fields in the item meta array. Fields can be null when t
 * '''flags''' : (array) Possible flags: ''%ITEM_FLAGS%''.
 * '''repair''' : (int) The cost to repair or combine this item in an anvil.
 * '''modifiers''' : (array) An array of attribute modifier arrays, each with keys: '''"attribute"''', '''"operation"''', '''"amount"''' (double), '''"uuid"''' (optional), '''"name"''' (optional), and '''"slot"''' (optional). Possible attributes: ''%ATTRIBUTES%''. Possible operations: ''%OPERATIONS%''. Possible slots: ''%SLOTS%''.
+* '''tags''' : (array) An associative array of custom tags. A tag's key is namespaced (e.g. "commandhelper:mytag") and the value is an associative array containing the '''"type"''' and '''"value"''' of the tag. Possible types: ''%TAG_TYPES%''.
 |-
 | All Damageable Items
 |

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -21,6 +21,7 @@ import com.laytonsmith.abstraction.MCItemMeta;
 import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCMetadataValue;
+import com.laytonsmith.abstraction.MCNamespacedKey;
 import com.laytonsmith.abstraction.MCNote;
 import com.laytonsmith.abstraction.MCPattern;
 import com.laytonsmith.abstraction.MCPlayer;
@@ -889,6 +890,11 @@ public class StaticTest {
 		@Override
 		public String GetUser(Environment env) {
 			return "testUser";
+		}
+
+		@Override
+		public MCNamespacedKey GetNamespacedKey(String key) {
+			throw new UnsupportedOperationException("Not supported yet.");
 		}
 	}
 


### PR DESCRIPTION
This is a proposal solution for adding custom tags from Bukkit's PersistentDataContainers in item meta. This is for preserving tags added by other plugins as well as allowing scripters more control over their own custom data stored in items. 

I'm using array objects to store NBT types along with the values. Due to API limitations we're not able to tell what type of data is under each key, so all types are checked, ordered by an estimation of frequency of use. This can be optimized later, but performance actually seemed adequate and doesn't rely on reflection.

API naming worth discussing is "type", "value", and "tags". We could also go for something like "custom" instead of "tags", "data" instead of "value"

Item array example:
```
{
	"name": "IRON_PICKAXE",
	"meta": {
		"tags": {
			"commandhelper:mytag": {
				"type": "STRING",
				"value": "something or other",
			},
			"mcmmo:super_ability_boosted": {
				"type": "INTEGER",
				"value": 0,
			}
		}
	}
}
```
Explosive pick example:
```
bind('block_break', null, null, @event) {
	@item = pinv(player(), null);
	if(@item 
	&& string_ends_with(@item['name'], 'PICKAXE')
	&& @item['meta'] 
	&& @item['meta']['tags'] 
	&& array_index_exists(@item['meta']['tags'], 'commandhelper:explosive_pick')) {
		@size = @item['meta']['tags']['commandhelper:explosive_pick']['value'];
		explosion(@event['location'], @size, false, false, puuid());
	}
}
```
Creating explosive pick:
```
pgive_item(array(
	name: 'DIAMOND_PICKAXE',
	meta: array(
		tags: array(
			'explosive_pick': array( // commandhelper namespace is added by default
				type: 'BYTE', 
				value: 1
			)
		)
	)
))
```