### PR TITLE
Add file option for pausing cmdline on script exception

### DIFF
--- a/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
+++ b/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
@@ -68,7 +68,7 @@ public final class FileOptions {
 		compilerOptions = parseEnumSet(getDefault(parsedOptions, "compileroptions", ""), CompilerOption.class);
 		copyright = getDefault(parsedOptions, "copyright", "").trim();
 		license = getDefault(parsedOptions, "license", "").trim();
-		allDynamicProcs = parseBoolean(getDefault(parsedOptions, "allDynamicProcs", "false"));
+		allDynamicProcs = parseBoolean(getDefault(parsedOptions, "alldynamicprocs", "false"));
 	}
 
 	private String getDefault(Map<String, String> map, String key, String defaultIfNone) {

--- a/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
+++ b/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
@@ -50,6 +50,8 @@ public final class FileOptions {
 	private final String license;
 	@Option("Disables undefined proc errors in the typechecker")
 	private final Boolean allDynamicProcs;
+	@Option("Do not close terminal when an exception occurs in a cmdline mode script")
+	private final Boolean cmdlinePauseOnException;
 
 	private final Map<String, String> rawOptions;
 	//TODO: Make this non-public once this is all finished.
@@ -69,6 +71,7 @@ public final class FileOptions {
 		copyright = getDefault(parsedOptions, "copyright", "").trim();
 		license = getDefault(parsedOptions, "license", "").trim();
 		allDynamicProcs = parseBoolean(getDefault(parsedOptions, "alldynamicprocs", "false"));
+		cmdlinePauseOnException = parseBoolean(getDefault(parsedOptions, "cmdlinepauseonexception", "false"));
 	}
 
 	private String getDefault(Map<String, String> map, String key, String defaultIfNone) {
@@ -220,6 +223,14 @@ public final class FileOptions {
 	 */
 	public boolean isAllDynamicProcs() {
 		return allDynamicProcs;
+	}
+
+	/**
+	 * Get whether the terminal should be held open when an exception occurs in a cmdline script.
+	 * @return
+	 */
+	public boolean isCmdlinePauseOnException() {
+		return cmdlinePauseOnException;
 	}
 
 	/**

--- a/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
+++ b/src/main/java/com/laytonsmith/core/compiler/FileOptions.java
@@ -68,7 +68,7 @@ public final class FileOptions {
 		compilerOptions = parseEnumSet(getDefault(parsedOptions, "compileroptions", ""), CompilerOption.class);
 		copyright = getDefault(parsedOptions, "copyright", "").trim();
 		license = getDefault(parsedOptions, "license", "").trim();
-		allDynamicProcs = parseBoolean(getDefault(parsedOptions, "allDynamicProcs", null));
+		allDynamicProcs = parseBoolean(getDefault(parsedOptions, "allDynamicProcs", "false"));
 	}
 
 	private String getDefault(Map<String, String> map, String key, String defaultIfNone) {

--- a/src/main/java/com/laytonsmith/tools/Interpreter.java
+++ b/src/main/java/com/laytonsmith/tools/Interpreter.java
@@ -85,11 +85,13 @@ import com.laytonsmith.core.events.drivers.CmdlineEvents;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CREThrowable;
+import com.laytonsmith.core.exceptions.AbstractCompileException;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Cmdline;
+import com.laytonsmith.core.functions.Cmdline.prompt_char;
 import com.laytonsmith.core.functions.Echoes;
 import com.laytonsmith.core.functions.ExampleScript;
 import com.laytonsmith.core.functions.Function;
@@ -785,7 +787,29 @@ public final class Interpreter {
 		final ParseTree tree;
 		try {
 			TokenStream stream = MethodScriptCompiler.lex(script, env, fromFile, true);
-			tree = MethodScriptCompiler.compile(stream, env, env.getEnvClasses(), staticAnalysis);
+			try {
+				tree = MethodScriptCompiler.compile(stream, env, env.getEnvClasses(), staticAnalysis);
+			} catch (AbstractCompileException e) {
+
+				// Pause on script exception in cmdline mode if set in the file options.
+				if(env.getEnv(GlobalEnv.class).inCmdlineMode()
+						&& System.console() != null && stream.getFileOptions().isCmdlinePauseOnException()) {
+					compile.stop();
+					if(e instanceof ConfigCompileException ex) {
+						ConfigRuntimeException.HandleUncaughtException(ex, null, null);
+					} else if(e instanceof ConfigCompileGroupException ex) {
+						ConfigRuntimeException.HandleUncaughtException(ex, null);
+					} else {
+						throw e;
+					}
+					StreamUtils.GetSystemOut().println(TermColors.reset());
+					prompt_char.promptChar("Press any key to continue...");
+					return;
+				}
+
+				// Pass exception to caller.
+				throw e;
+			}
 			staticAnalysis = new StaticAnalysis(staticAnalysis.getEndScope(), true); // Continue analysis in end scope.
 		} finally {
 			compile.stop();
@@ -854,9 +878,20 @@ public final class Interpreter {
 							}
 						} catch (ConfigRuntimeException e) {
 							ConfigRuntimeException.HandleUncaughtException(e, env);
-							//No need for the full stack trace
+
+							// No need for the full stack trace.
 							if(System.console() == null) {
 								System.exit(1);
+							}
+
+							// Pause on script exception in cmdline mode if set in the file options.
+							if(env.getEnv(GlobalEnv.class).inCmdlineMode()
+									&& tree.getFileOptions().isCmdlinePauseOnException()) {
+								try {
+									prompt_char.promptChar("Press any key to continue...");
+								} catch (IOException e1) {
+									// Ignore.
+								}
 							}
 						} catch (NoClassDefFoundError e) {
 							StreamUtils.GetSystemErr().println(RED + Static.getNoClassDefFoundErrorMessage(e) + reset());


### PR DESCRIPTION
Allows users to see exceptions from scripts that were executed through an extension associated with `mscript.exe`.

Points of interest:
- File option defaults to false, maintaining current behavior.
- Compile errors during lexing happen too early for this file option to apply. It is possible to get the file options that are parsed in the lexer for early usage, but there's no obvious way to expose those.
- When `System.console() == null`, the file option is ignored (there's no console anyways, so pausing would not make sense).
- The implementation uses `Cmdline.prompt_char`. This could be moved to some utils class if accessing that is not desired.