### PR TITLE
Support passing byte_array into crypto functions

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Crypto.java
+++ b/src/main/java/com/laytonsmith/core/functions/Crypto.java
@@ -46,7 +46,13 @@ public class Crypto {
 
 	private static CString getHMAC(String algorithm, Target t, Mixed[] args) {
 		try {
-			SecretKeySpec signingKey = new SecretKeySpec(args[0].val().getBytes(), algorithm);
+			byte[] key;
+			if(args[0] instanceof CByteArray) {
+				key = ((CByteArray) args[0]).asByteArrayCopy();
+			} else {
+				key = args[0].val().getBytes();
+			}
+			SecretKeySpec signingKey = new SecretKeySpec(key, algorithm);
 			Mac mac = Mac.getInstance(algorithm);
 			mac.init(signingKey);
 			byte[] hmac = mac.doFinal(getByteArrayFromArg(args[1]));
@@ -61,6 +67,8 @@ public class Crypto {
 		byte[] val;
 		if(c.isInstanceOf(CSecureString.TYPE)) {
 			val = ArrayUtils.charToBytes(((CSecureString) c).getDecryptedCharArray());
+		} else if(c instanceof CByteArray) {
+			val = ((CByteArray) c).asByteArrayCopy();
 		} else {
 			val = c.val().getBytes();
 		}
@@ -157,9 +165,11 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {val} Returns the md5 hash of the specified string. The md5 hash is no longer considered secure, so you should"
-					+ " not use it for storage of sensitive data, however for general hashing, it is a quick and easy solution. md5 is"
-					+ " a one way hashing algorithm. This function is aware of and compatible with secure_string.";
+			return "string {val} Returns the md5 hash of the specified string or byte array."
+					+ " The md5 hash is no longer considered secure, so you should not use it for storage of"
+					+ " sensitive data, however for general hashing, it is a quick and easy solution."
+					+ " md5 is a one way hashing algorithm."
+					+ " This function is aware of and compatible with secure_string.";
 		}
 
 		@Override
@@ -226,10 +236,11 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {val} Returns the sha1 hash of the specified string. Note that sha1 is considered no more secure than md5,"
-					+ " and should not be used in a security context. sha-256 should be used instead for storing sensitive"
-					+ " data. It is a one way hashing algorithm. This function is aware of and compatible with"
-					+ " secure_string.";
+			return "string {val} Returns the sha1 hash of the specified string or byte array."
+					+ " Note that sha1 is considered no more secure than md5,"
+					+ " and should not be used in a security context."
+					+ " sha-256 should be used instead for storing sensitive data. It is a one way hashing algorithm."
+					+ " This function is aware of and compatible with secure_string.";
 		}
 
 		@Override
@@ -296,9 +307,10 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {val} Returns the sha256 hash of the specified string. Note that sha256 is considered more secure than sha1 and md5, and is"
-					+ " typically used when storing sensitive data. It is a one way hashing algorithm. This function"
-					+ " is aware of and compatible with secure_string.";
+			return "string {val} Returns the sha256 hash of the specified string or byte array."
+					+ " Note that sha256 is considered more secure than sha1 and md5,"
+					+ " and is typically used when storing sensitive data. It is a one way hashing algorithm."
+					+ " This function is aware of and compatible with secure_string.";
 		}
 
 		@Override
@@ -366,7 +378,7 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {val} Returns the sha512 hash of the specified string. Note that sha512"
+			return "string {val} Returns the sha512 hash of the specified string or byte array. Note that sha512"
 					+ " is considered more secure than sha1 and md5 (and sha256, because it takes longer to calculate),"
 					+ " and is typically used when storing sensitive data. It is a one way hashing algorithm. This"
 					+ " function is aware of and compatible with secure_string.";
@@ -684,8 +696,9 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {key, val} Returns the md5 HMAC of the specified string using the provided key. This function"
-					+ " is aware of and compatible with secure_string.";
+			return "string {key, val} Returns the md5 HMAC of the specified value using the provided key."
+					+ " If the key or value is not a byte array, it will be converted to a byte array through its"
+					+ " UTF-8 string representation. This function is aware of and compatible with secure_string.";
 		}
 
 		@Override
@@ -743,8 +756,9 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {key, val} Returns the sha1 HMAC of the specified string using the provided key. This function"
-					+ " is aware of and compatible with secure_string.";
+			return "string {key, val} Returns the sha1 HMAC of the specified value using the provided key."
+					+ " If the key or value is not a byte array, it will be converted to a byte array through its"
+					+ " UTF-8 string representation. This function is aware of and compatible with secure_string.";
 		}
 
 		@Override
@@ -802,8 +816,9 @@ public class Crypto {
 
 		@Override
 		public String docs() {
-			return "string {key, val} Returns the sha256 HMAC of the specified string using the provided key. This"
-					+ " function is aware of and compatible with secure_string.";
+			return "string {key, val} Returns the sha256 HMAC of the specified value using the provided key."
+					+ " If the key or value is not a byte array, it will be converted to a byte array through its"
+					+ " UTF-8 string representation. This function is aware of and compatible with secure_string.";
 		}
 
 		@Override


### PR DESCRIPTION
This adds a way to perform the existing crypto functions using both `byte_array` keys and values. I needed this for signing a HTTP request to access an AWS S3 bucket, which works with this modification.

Note that I also needed the following code to convert the returned hex string to a byte array:
```java
proc _hex_to_ba(string @hex) {
	byte_array @ret = byte_array();
	for(int @i = 0, @i < length(@hex), @i += 2) {
		int @val = parse_int(substr(@hex, @i, @i + 2), 16);
		ba_put_byte(@ret, if(@val < 128, @val, @val - 256));
	}
	return(@ret);
}
```
It could be helpful to add some `hex_string_to_ba()` function to provide this functionality out of the box, or add some option to make the hmac functions return a byte array instead of a hex string. If this is the case, issues should be created for those feature requests.