### PR TITLE
Stacktrace manager optimization

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CClosure.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CClosure.java
@@ -207,13 +207,18 @@ public class CClosure extends Construct implements Callable, Booleanish {
 		if(node == null) {
 			return;
 		}
-		StackTraceManager stManager = env.getEnv(GlobalEnv.class).GetStackTraceManager();
-		stManager.addStackTraceElement(new ConfigRuntimeException.StackTraceElement("<<closure>>", getTarget()));
+		Environment environment;
 		try {
-			Environment environment;
 			synchronized(this) {
 				environment = env.clone();
 			}
+		} catch (CloneNotSupportedException ex) {
+			Logger.getLogger(CClosure.class.getName()).log(Level.SEVERE, null, ex);
+			return;
+		}
+		StackTraceManager stManager = environment.getEnv(GlobalEnv.class).GetStackTraceManager();
+		stManager.addStackTraceElement(new ConfigRuntimeException.StackTraceElement("<<closure>>", getTarget()));
+		try {
 			CArray arguments = new CArray(node.getData().getTarget());
 			CArray vararg = null;
 			CClassType varargType = null;


### PR DESCRIPTION
Store `StacktTraceManager` directly in `GlobalEnv` to prevent a synchronized hashmap lookup on every `eval()` and `seval()` call. Move `StackTraceManager` getter in `CClosure` to post-environment-clone to ensure that it does not overwrite the `StackTraceManager` of the original thread when called from a new thread(by for example `x_new_thread()`).

In the 5 seconds profile below, we can see that a couple of `GlobalEnv.GetStackTraceManager()` calls take up about 18% CPU time for my specific MethodScript program.
![afbeelding](https://github.com/EngineHub/CommandHelper/assets/9693840/8ea52d91-cadf-42e3-9ba6-735397a37fdd)
