### PR TITLE
Add x_get_lock, synchronized changes

### DIFF
--- a/src/main/java/com/laytonsmith/PureUtilities/Quadruplet.java
+++ b/src/main/java/com/laytonsmith/PureUtilities/Quadruplet.java
@@ -1,0 +1,94 @@
+package com.laytonsmith.PureUtilities;
+
+import java.util.Objects;
+
+/**
+ * Creates an object quadruplet. The hashcode and equals functions have been overridden to use the underlying object's hash
+ * code and equals combined. The underlying objects may be null.
+ *
+ * @param <A> The first object's type.
+ * @param <B> The second object's type.
+ * @param <C> The third object's type.
+ * @param <D> The fourth object's type.
+ */
+public class Quadruplet<A, B, C, D> {
+
+	private final A fst;
+	private final B snd;
+	private final C trd;
+	private final D frth;
+
+	/**
+	 * Creates a new Quadruplet with the specified values.
+	 *
+	 * @param a
+	 * @param b
+	 * @param c
+	 * @param d
+	 */
+	public Quadruplet(A a, B b, C c, D d) {
+		fst = a;
+		snd = b;
+		trd = c;
+		frth = d;
+	}
+
+	@Override
+	public String toString() {
+		return "<"
+				+ Objects.toString(fst) + ", "
+				+ Objects.toString(snd) + ", "
+				+ Objects.toString(trd) + ", "
+				+ Objects.toString(frth) + ">";
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 7;
+		hash = 47 * hash + Objects.hashCode(this.fst);
+		hash = 47 * hash + Objects.hashCode(this.snd);
+		hash = 47 * hash + Objects.hashCode(this.trd);
+		hash = 47 * hash + Objects.hashCode(this.frth);
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null) {
+			return false;
+		}
+		if(getClass() != obj.getClass()) {
+			return false;
+		}
+		final Quadruplet<?, ?, ?, ?> other = (Quadruplet<?, ?, ?, ?>) obj;
+		if(!Objects.equals(this.fst, other.fst)) {
+			return false;
+		}
+		if(!Objects.equals(this.snd, other.snd)) {
+			return false;
+		}
+		if(!Objects.equals(this.trd, other.trd)) {
+			return false;
+		}
+		if(!Objects.equals(this.frth, other.frth)) {
+			return false;
+		}
+		return true;
+	}
+
+	public A getFirst() {
+		return fst;
+	}
+
+	public B getSecond() {
+		return snd;
+	}
+
+	public C getThird() {
+		return trd;
+	}
+
+	public D getFourth() {
+		return frth;
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/Convertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/Convertor.java
@@ -131,13 +131,25 @@ public interface Convertor {
 	MCInventoryHolder CreateInventoryHolder(String id, String title);
 
 	/**
-	 * Run whenever the server is shutting down (or restarting). There is no guarantee provided as to what thread the
+	 * Runs whenever the server is shutting down (or reloading). There is no guarantee provided as to what thread the
 	 * runnables actually run on, so you should ensure that the runnable executes it's actions on the appropriate thread
-	 * yourself.
+	 * yourself. Note that this shutdown hook will only run once, so if multiple reload events occur, this will not
+	 * be registered for the second run, unless you specifically add it yourself. If you need a shutdown hook to run
+	 * every time, and only want to register it once, see {@link #addPersistentShutdownHook}.
 	 *
 	 * @param r
 	 */
 	void addShutdownHook(Runnable r);
+
+	/**
+	 * Runs whenever the server is shutting down (or reloading). There is no guarantee provided as to what thread the
+	 * runnables actually run on, so you should ensure that the runnable executes it's actions on the appropriate thread
+	 * yourself. Note that this shutdown hook will never dequeue, so if multiple reload events occur, this will run
+	 * every time, and so you should only call this once (i.e. from a static context). If you need a shutdown hook to
+	 * dequeue after run, see {@link #addShutdownHook}.
+	 * @param r
+	 */
+	void addPersistentShutdownHook(Runnable r);
 
 	/**
 	 * Runs all the registered shutdown hooks. This should only be called by the shutdown mechanism. After running, each

--- a/src/main/java/com/laytonsmith/abstraction/Convertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/Convertor.java
@@ -294,4 +294,13 @@ public interface Convertor {
 	 * @return
 	 */
 	public MCTransformation GetTransformation(Quaternionf leftRotation, Quaternionf rightRotation, Vector3f scale, Vector3f translation);
+
+	/**
+	 * Returns true if this is the main thread of the application. This is only applicable in some managed environments,
+	 * in other environments where this doesn't matter, this will always return false (i.e. all threads are considered
+	 * equally important/unimportant). If this returns true, this means that the current thread is for instance the
+	 * UI thread, and thus should not be blocked on.
+	 * @return
+	 */
+	public boolean IsMainThread();
 }

--- a/src/main/java/com/laytonsmith/abstraction/StaticLayer.java
+++ b/src/main/java/com/laytonsmith/abstraction/StaticLayer.java
@@ -166,6 +166,10 @@ public final class StaticLayer {
 		return convertor.GetPlugin();
 	}
 
+	public static boolean IsMainThread() {
+		return convertor.IsMainThread();
+	}
+
 	public static synchronized Convertor GetConvertor() {
 		return convertor;
 	}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitConvertor.java
@@ -910,4 +910,10 @@ public class BukkitConvertor extends AbstractConvertor {
 	public MCTransformation GetTransformation(Quaternionf leftRotation, Quaternionf rightRotation, Vector3f scale, Vector3f translation) {
 		return new BukkitMCTransformation(new Transformation(translation, leftRotation, scale, rightRotation));
 	}
+
+	@Override
+	public boolean IsMainThread() {
+		return Bukkit.isPrimaryThread();
+	}
+
 }

--- a/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
+++ b/src/main/java/com/laytonsmith/core/functions/ResourceManager.java
@@ -62,7 +62,7 @@ public class ResourceManager {
 	private static final Map<Long, CResource<?>> RESOURCES = new HashMap<>();
 
 	static {
-		StaticLayer.GetConvertor().addShutdownHook(new Runnable() {
+		StaticLayer.GetConvertor().addPersistentShutdownHook(new Runnable() {
 
 			@Override
 			public void run() {

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -639,9 +639,7 @@ public final class Threading {
 				SYNC_OBJECT_QUEUE.computeIfAbsent(syncObject, k -> new LinkedList<>())
 						.add(triplet);
 			}
-			StaticLayer.SetFutureRunnable(dm, 0, () -> {
-				PumpQueue(syncObject, dm);
-			});
+			StaticLayer.SetFutureRunnable(dm, 0, () -> PumpQueue(syncObject, dm));
 			return CVoid.VOID;
 		}
 

--- a/src/main/java/com/laytonsmith/core/functions/Threading.java
+++ b/src/main/java/com/laytonsmith/core/functions/Threading.java
@@ -657,7 +657,7 @@ public final class Threading {
 
 		@Override
 		public String docs() {
-			return "void {mixed lock, Callable action} Runs the specified action on the main thread once the lock is obtained. Note that"
+			return "void {mixed lock, Callable action} Runs the specified action on the main thread (or a timer thread in cmdline) once the lock is obtained. Note that"
 					+ " this lock is the same object as used in synchronized(). ---- "
 					+ " The primary difference being that this"
 					+ " function always returns immediately, scheduling the task for later (as soon as possible, but"

--- a/src/main/java/com/laytonsmith/core/functions/XGUI.java
+++ b/src/main/java/com/laytonsmith/core/functions/XGUI.java
@@ -45,7 +45,7 @@ public class XGUI {
 	private static final AtomicInteger WINDOW_IDS = new AtomicInteger(0);
 
 	static {
-		StaticLayer.GetConvertor().addShutdownHook(new Runnable() {
+		StaticLayer.GetConvertor().addPersistentShutdownHook(new Runnable() {
 
 			@Override
 			public void run() {

--- a/src/main/java/com/laytonsmith/tools/Interpreter.java
+++ b/src/main/java/com/laytonsmith/tools/Interpreter.java
@@ -1306,6 +1306,12 @@ public final class Interpreter {
 		public MCTransformation GetTransformation(Quaternionf leftRotation, Quaternionf rightRotation, Vector3f scale, Vector3f translation) {
 			throw new UnsupportedOperationException("This method is not supported from a shell.");
 		}
+
+		@Override
+		public boolean IsMainThread() {
+			return false;
+		}
+
 	}
 
 }

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -902,6 +902,12 @@ public class StaticTest {
 		public MCTransformation GetTransformation(Quaternionf leftRotation, Quaternionf rightRotation, Vector3f scale, Vector3f translation) {
 			throw new UnsupportedOperationException("Not supported yet.");
 		}
+
+		@Override
+		public boolean IsMainThread() {
+			return false;
+		}
+
 	}
 
 	public static class FakeServerMixin implements EventMixinInterface {


### PR DESCRIPTION
Provide a new function, x_get_lock, which provides an asynchronous lock waiting mechanism. This uses the same underlying lock structure as synchronized(). Additionally, the lock object has now been restricted to non-value types, except strings. This is a breaking change, but is unlikely to affect anyone.