### PR TITLE
Add item_in_hand and hand fields to block_place event.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
@@ -16,6 +16,7 @@ import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlock;
 import com.laytonsmith.abstraction.bukkit.blocks.BukkitMCBlockState;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCEntity;
 import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
+import com.laytonsmith.abstraction.enums.MCEquipmentSlot;
 import com.laytonsmith.abstraction.enums.MCIgniteCause;
 import com.laytonsmith.abstraction.enums.MCInstrument;
 import com.laytonsmith.abstraction.enums.MCVersion;
@@ -60,6 +61,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.NotePlayEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
@@ -236,6 +238,14 @@ public class BukkitBlockEvents {
 		@Override
 		public MCItemStack getItemInHand() {
 			return new BukkitMCItemStack(event.getItemInHand());
+		}
+
+		@Override
+		public MCEquipmentSlot getHand() {
+			if(event.getHand() == EquipmentSlot.HAND) {
+				return MCEquipmentSlot.WEAPON;
+			}
+			return MCEquipmentSlot.OFF_HAND;
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/abstraction/events/MCBlockPlaceEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCBlockPlaceEvent.java
@@ -4,6 +4,7 @@ import com.laytonsmith.abstraction.MCItemStack;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCBlockState;
+import com.laytonsmith.abstraction.enums.MCEquipmentSlot;
 import com.laytonsmith.core.events.BindableEvent;
 
 public interface MCBlockPlaceEvent extends BindableEvent {
@@ -17,6 +18,8 @@ public interface MCBlockPlaceEvent extends BindableEvent {
 	MCBlockState getBlockReplacedState();
 
 	MCItemStack getItemInHand();
+
+	MCEquipmentSlot getHand();
 
 	boolean canBuild();
 }

--- a/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/BlockEvents.java
@@ -7,6 +7,7 @@ import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.blocks.MCMaterial;
+import com.laytonsmith.abstraction.enums.MCEquipmentSlot;
 import com.laytonsmith.abstraction.enums.MCIgniteCause;
 import com.laytonsmith.abstraction.enums.MCInstrument;
 import com.laytonsmith.abstraction.events.MCBlockBreakEvent;
@@ -326,7 +327,9 @@ public class BlockEvents {
 					+ "{player: The player's name | block: the block type that was placed"
 					+ " | against: a block array of the block being placed against"
 					+ " | oldblock: the old block type that was replaced"
-					+ " | location: A locationArray for this block} "
+					+ " | location: A locationArray for this block "
+					+ " | item: the item used to the place the block "
+					+ " | hand: hand used to place the block} "
 					+ "{block} "
 					+ "{}";
 		}
@@ -411,6 +414,12 @@ public class BlockEvents {
 			map.put("player", new CString(event.getPlayer().getName(), t));
 			map.put("block", new CString(mat.getName(), t));
 			map.put("location", ObjectGenerator.GetGenerator().location(block.getLocation(), false));
+			map.put("item", ObjectGenerator.GetGenerator().item(event.getItemInHand(), Target.UNKNOWN));
+			if(event.getHand() == MCEquipmentSlot.WEAPON) {
+				map.put("hand", new CString("main_hand", Target.UNKNOWN));
+			} else {
+				map.put("hand", new CString("off_hand", Target.UNKNOWN));
+			}
 
 			MCBlock agstblock = event.getBlockAgainst();
 			MCMaterial agstmat = agstblock.getType();


### PR DESCRIPTION
Adds those two keys to the event array. `item_in_hand` is a full item stack, whereas `hand` is just `main_hand`/`off_hand`.