### PR TITLE
add item_pre_anvil event

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/MCAnvilInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/MCAnvilInventory.java
@@ -1,0 +1,18 @@
+package com.laytonsmith.abstraction;
+
+public interface MCAnvilInventory extends MCInventory {
+	MCItemStack getFirstItem();
+	MCItemStack getSecondItem();
+	MCItemStack getResult();
+	int getMaximumRepairCost();
+	int getRepairCost();
+	int getRepairCostAmount();
+	String getRenameText();
+
+	void setFirstItem(MCItemStack stack);
+	void setSecondItem(MCItemStack stack);
+	void setResult(MCItemStack stack);
+	void setMaximumRepairCost(int levels);
+	void setRepairCost(int levels);
+	void setRepairCostAmount(int levels);
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCAnvilInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCAnvilInventory.java
@@ -40,7 +40,7 @@ public class BukkitMCAnvilInventory extends BukkitMCInventory implements MCAnvil
 
 	@Override
 	public int getRepairCostAmount() {
-		return ai.getRepairCost();
+		return ai.getRepairCostAmount();
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCAnvilInventory.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCAnvilInventory.java
@@ -1,0 +1,80 @@
+package com.laytonsmith.abstraction.bukkit;
+
+import com.laytonsmith.abstraction.MCAnvilInventory;
+import com.laytonsmith.abstraction.MCItemStack;
+import org.bukkit.inventory.AnvilInventory;
+
+public class BukkitMCAnvilInventory extends BukkitMCInventory implements MCAnvilInventory {
+
+	AnvilInventory ai;
+
+	public BukkitMCAnvilInventory(AnvilInventory inventory) {
+		super(inventory);
+		ai = inventory;
+	}
+
+	@Override
+	public MCItemStack getFirstItem() {
+		return new BukkitMCItemStack(ai.getItem(0));
+	}
+
+	@Override
+	public MCItemStack getSecondItem() {
+		return new BukkitMCItemStack(ai.getItem(1));
+	}
+
+	@Override
+	public MCItemStack getResult() {
+		return new BukkitMCItemStack(ai.getItem(2));
+	}
+
+	@Override
+	public int getMaximumRepairCost() {
+		return ai.getMaximumRepairCost();
+	}
+
+	@Override
+	public int getRepairCost() {
+		return ai.getRepairCost();
+	}
+
+	@Override
+	public int getRepairCostAmount() {
+		return ai.getRepairCost();
+	}
+
+	@Override
+	public String getRenameText() {
+		return ai.getRenameText();
+	}
+
+	@Override
+	public void setFirstItem(MCItemStack stack) {
+		ai.setItem(0, ((BukkitMCItemStack) stack).asItemStack());
+	}
+
+	@Override
+	public void setSecondItem(MCItemStack stack) {
+		ai.setItem(1, ((BukkitMCItemStack) stack).asItemStack());
+	}
+
+	@Override
+	public void setResult(MCItemStack stack) {
+		ai.setItem(2, ((BukkitMCItemStack) stack).asItemStack());
+	}
+
+	@Override
+	public void setMaximumRepairCost(int levels) {
+		ai.setMaximumRepairCost(levels);
+	}
+
+	@Override
+	public void setRepairCost(int levels) {
+		ai.setRepairCost(levels);
+	}
+
+	@Override
+	public void setRepairCostAmount(int levels) {
+		ai.setRepairCostAmount(levels);
+	}
+}

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
@@ -1,5 +1,6 @@
 package com.laytonsmith.abstraction.bukkit.events;
 
+import com.laytonsmith.abstraction.MCAnvilInventory;
 import com.laytonsmith.abstraction.MCCraftingInventory;
 import com.laytonsmith.abstraction.MCEnchantmentOffer;
 import com.laytonsmith.abstraction.MCHumanEntity;
@@ -10,6 +11,7 @@ import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCRecipe;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.BukkitConvertor;
+import com.laytonsmith.abstraction.bukkit.BukkitMCAnvilInventory;
 import com.laytonsmith.abstraction.bukkit.BukkitMCCraftingInventory;
 import com.laytonsmith.abstraction.bukkit.BukkitMCEnchantmentOffer;
 import com.laytonsmith.abstraction.bukkit.BukkitMCInventory;
@@ -37,6 +39,7 @@ import com.laytonsmith.abstraction.events.MCInventoryInteractEvent;
 import com.laytonsmith.abstraction.events.MCInventoryOpenEvent;
 import com.laytonsmith.abstraction.events.MCItemHeldEvent;
 import com.laytonsmith.abstraction.events.MCItemSwapEvent;
+import com.laytonsmith.abstraction.events.MCPrepareAnvilEvent;
 import com.laytonsmith.abstraction.events.MCPrepareItemCraftEvent;
 import com.laytonsmith.abstraction.events.MCPrepareItemEnchantEvent;
 import org.bukkit.enchantments.Enchantment;
@@ -52,6 +55,7 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryEvent;
 import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
@@ -542,6 +546,34 @@ public class BukkitInventoryEvents {
 		@Override
 		public MCCraftingInventory getInventory() {
 			return new BukkitMCCraftingInventory(e.getInventory());
+		}
+	}
+
+	public static class BukkitMCPrepareAnvilEvent extends BukkitMCInventoryEvent implements MCPrepareAnvilEvent {
+		PrepareAnvilEvent e;
+
+		public BukkitMCPrepareAnvilEvent(PrepareAnvilEvent event) {
+			super(event);
+			e = event;
+		}
+
+		@Override
+		public void setResult(MCItemStack i) {
+			e.setResult(((BukkitMCItemStack) i).asItemStack());
+		}
+
+		@Override
+		public List<MCHumanEntity> getViewers() {
+			List<MCHumanEntity> viewers = new ArrayList<>();
+			for(HumanEntity viewer : e.getViewers()) {
+				viewers.add(new BukkitMCHumanEntity(viewer));
+			}
+			return viewers;
+		}
+
+		@Override
+		public MCAnvilInventory getInventory() {
+			return new BukkitMCAnvilInventory(e.getInventory());
 		}
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitInventoryEvents.java
@@ -563,12 +563,8 @@ public class BukkitInventoryEvents {
 		}
 
 		@Override
-		public List<MCHumanEntity> getViewers() {
-			List<MCHumanEntity> viewers = new ArrayList<>();
-			for(HumanEntity viewer : e.getViewers()) {
-				viewers.add(new BukkitMCHumanEntity(viewer));
-			}
-			return viewers;
+		public MCPlayer getPlayer() {
+			return new BukkitMCPlayer(e.getViewers().get(0));
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCI
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCInventoryOpenEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCItemHeldEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCItemSwapEvent;
+import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCPrepareAnvilEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCPrepareItemCraftEvent;
 import com.laytonsmith.abstraction.bukkit.events.BukkitInventoryEvents.BukkitMCPrepareItemEnchantEvent;
 import com.laytonsmith.core.events.Driver;
@@ -21,6 +22,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
@@ -79,5 +81,11 @@ public class BukkitInventoryListener implements Listener {
 	public void onPreCraft(PrepareItemCraftEvent event) {
 		BukkitMCPrepareItemCraftEvent pc = new BukkitInventoryEvents.BukkitMCPrepareItemCraftEvent(event);
 		EventUtils.TriggerListener(Driver.ITEM_PRE_CRAFT, "item_pre_craft", pc);
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPreAnvil(PrepareAnvilEvent event) {
+		BukkitMCPrepareAnvilEvent pa = new BukkitInventoryEvents.BukkitMCPrepareAnvilEvent(event);
+		EventUtils.TriggerListener(Driver.ITEM_PRE_ANVIL, "item_pre_anvil", pa);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
@@ -1,12 +1,10 @@
 package com.laytonsmith.abstraction.events;
 
-import com.laytonsmith.abstraction.MCHumanEntity;
+import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCItemStack;
 
-import java.util.List;
-
 public interface MCPrepareAnvilEvent extends MCInventoryEvent {
-	List<MCHumanEntity> getViewers();
+	MCPlayer getPlayer();
 
 	void setResult(MCItemStack i);
 }

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
@@ -1,0 +1,16 @@
+package com.laytonsmith.abstraction.events;
+
+import com.laytonsmith.abstraction.MCHumanEntity;
+import com.laytonsmith.abstraction.MCInventory;
+import com.laytonsmith.abstraction.MCItemStack;
+
+import java.util.List;
+
+public interface MCPrepareAnvilEvent extends MCInventoryEvent {
+	@Override
+	MCInventory getInventory();
+
+	List<MCHumanEntity> getViewers();
+
+	void setResult(MCItemStack i);
+}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPrepareAnvilEvent.java
@@ -1,15 +1,11 @@
 package com.laytonsmith.abstraction.events;
 
 import com.laytonsmith.abstraction.MCHumanEntity;
-import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCItemStack;
 
 import java.util.List;
 
 public interface MCPrepareAnvilEvent extends MCInventoryEvent {
-	@Override
-	MCInventory getInventory();
-
 	List<MCHumanEntity> getViewers();
 
 	void setResult(MCItemStack i);

--- a/src/main/java/com/laytonsmith/core/events/Driver.java
+++ b/src/main/java/com/laytonsmith/core/events/Driver.java
@@ -67,6 +67,7 @@ public enum Driver {
 	ITEM_SWAP,
 	ITEM_PRE_CRAFT,
 	ITEM_PRE_ENCHANT,
+	ITEM_PRE_ANVIL,
 	/**
 	 * Player events
 	 */

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -1007,8 +1007,8 @@ public class InventoryEvents {
 					+ " | second_item: the second item being used in the recipe."
 					+ " | result: the result of the recipe."
 					+ " | max_repair_cost: the maximum possible cost of this repair."
-					+ " | level_repair_cost: how many levels are needed to perform this repair?"
-					+ " | item_repair_cost: how many items are needed to perform this repair? }"
+					+ " | level_repair_cost: how many levels are needed to perform this repair."
+					+ " | item_repair_cost: how many items are needed to perform this repair. }"
 					+ " { result: the result of the anvil }"
 					+ " {}";
 		}

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -1002,10 +1002,10 @@ public class InventoryEvents {
 		public String docs() {
 			return "{}"
 					+ " Fires when a recipe is formed in an anvil, but the result has not yet been clicked."
-					+ " { viewers: all human entities looking at this anvil "
-					+ " | first_item: the first item in the anvil"
-					+ "	| second_item: the second item in the anvil"
-					+ " | result: the result of the anvil"
+					+ " { viewers: all players viewing this anvil's interface."
+					+ " | first_item: the first item being used in the recipe."
+					+ " | second_item: the second item being used in the recipe."
+					+ " | result: the result of the recipe."
 					+ " | max_repair_cost: the maximum possible cost of this repair."
 					+ " | level_repair_cost: how many levels are needed to perform this repair?"
 					+ " | item_repair_cost: how many items are needed to perform this repair? }"
@@ -1028,8 +1028,7 @@ public class InventoryEvents {
 
 		@Override
 		public Map<String, Mixed> evaluate(BindableEvent event) throws EventException {
-			if(event instanceof MCPrepareAnvilEvent) {
-				MCPrepareAnvilEvent e = (MCPrepareAnvilEvent) event;
+			if(event instanceof MCPrepareAnvilEvent e) {
 				MCAnvilInventory anvil = (MCAnvilInventory) e.getInventory();
 				Map<String, Mixed> ret = evaluate_helper(e);
 
@@ -1059,9 +1058,8 @@ public class InventoryEvents {
 
 		@Override
 		public boolean modifyEvent(String key, Mixed value, BindableEvent event) {
-			if(event instanceof MCPrepareAnvilEvent) {
+			if(event instanceof MCPrepareAnvilEvent e) {
 				Target t = value.getTarget();
-				MCPrepareAnvilEvent e = (MCPrepareAnvilEvent) event;
 				if(key.equalsIgnoreCase("result")) {
 					e.setResult(ObjectGenerator.GetGenerator().item(value, t));
 					return true;

--- a/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/InventoryEvents.java
@@ -1002,7 +1002,7 @@ public class InventoryEvents {
 		public String docs() {
 			return "{}"
 					+ " Fires when a recipe is formed in an anvil, but the result has not yet been clicked."
-					+ " { viewers: all players viewing this anvil's interface."
+					+ " { player: the player using the anvil."
 					+ " | first_item: the first item being used in the recipe."
 					+ " | second_item: the second item being used in the recipe."
 					+ " | result: the result of the recipe."
@@ -1032,12 +1032,7 @@ public class InventoryEvents {
 				MCAnvilInventory anvil = (MCAnvilInventory) e.getInventory();
 				Map<String, Mixed> ret = evaluate_helper(e);
 
-				CArray viewers = new CArray(Target.UNKNOWN);
-				for(MCHumanEntity viewer : e.getViewers()) {
-					viewers.push(new CString(viewer.getName(), Target.UNKNOWN), Target.UNKNOWN);
-				}
-
-				ret.put("viewers", viewers);
+				ret.put("player", new CString(e.getPlayer().getName(), Target.UNKNOWN));
 				ret.put("first_item", ObjectGenerator.GetGenerator().item(anvil.getFirstItem(), Target.UNKNOWN));
 				ret.put("second_item", ObjectGenerator.GetGenerator().item(anvil.getSecondItem(), Target.UNKNOWN));
 				ret.put("result", ObjectGenerator.GetGenerator().item(anvil.getResult(), Target.UNKNOWN));


### PR DESCRIPTION
Kind of flying blind with creating a new event. It's been many years since I've written one, in an extension. :joy:
Let me know if there's any validation you'd like for me to do on my end.

Example payload (pretty printed):
```
event_type: item_pre_anvil
first_item: {meta: {damage: 0, display: null, enchants: {silk_touch: {elevel: 1}, unbreaking: {elevel: 3}}, flags: {}, lore: null, model: null, modifiers: null, repair: 0, tags: null, unbreakable: false}, name: DIAMOND_PICKAXE, qty: 1}
item_repair_cost: 10
level_repair_cost: 10
macrotype: inventory
max_repair_cost: 40
result: {meta: {damage: 0, display: null, enchants: {efficiency: {elevel: 4}, silk_touch: {elevel: 1}, unbreaking: {elevel: 3}}, flags: {}, lore: null, model: null, modifiers: null, repair: 1, tags: null, unbreakable: false}, name: DIAMOND_PICKAXE, qty: 1}
second_item: {meta: {damage: 0, display: null, enchants: {efficiency: {elevel: 4}, unbreaking: {elevel: 3}}, flags: {}, lore: null, model: null, modifiers: null, repair: 0, tags: null, unbreakable: false}, name: DIAMOND_PICKAXE, qty: 1}
viewers: {Lildirt}
```