### PR TITLE
Fix location shift in block_break so dropped items aren't placed into adjacent blocks.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
@@ -86,7 +86,6 @@ public class BukkitBlockListener implements Listener {
 				Block block = chevent.getBlock();
 				block.setType(Material.AIR);
 				Location loc = block.getLocation();
-				loc.add(0.5, 0.5, 0.5);
 				if(chevent.isDropItems()) {
 					for(MCItemStack item : bbe.getDrops()) {
 						block.getWorld().dropItemNaturally(loc, (ItemStack) item.getHandle());

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
@@ -86,6 +86,7 @@ public class BukkitBlockListener implements Listener {
 				Block block = chevent.getBlock();
 				block.setType(Material.AIR);
 				Location loc = block.getLocation();
+				loc.subtract(0.0, 0.125, 0.0);
 				if(chevent.isDropItems()) {
 					for(MCItemStack item : bbe.getDrops()) {
 						block.getWorld().dropItemNaturally(loc, (ItemStack) item.getHandle());


### PR DESCRIPTION
If you call `modify_event('drops', <any item array>)` for `block_break`, there's a bit of a 'hack' in place to emulate this since [`BlockBreakEvent`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/block/BlockBreakEvent.html) doesn't support rewriting drops natively.

Since we offset the location then do a `dropItemNaturally` call, it can sometimes send the item *into* another block, which causes it to shoot to the surface if they're underground. Not ideal.

I've attached links to two gifs. They're a bit large (and might play slow until they download fully). Hopefully it visualizes what happens.

Before: (~13MB) https://dirt.wtf/1ebnnKc8Pne20dm0.gif

After: (~8MB) https://dirt.wtf/VFB66bDgc6zGsRFa.gif