### PR TITLE
Optimize array_contains functions

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -814,7 +814,7 @@ public class CArray extends Construct implements Iterable<Mixed>, Booleanish,
 	@Override
 	public Iterator<Mixed> iterator() {
 		if(associativeMode) {
-			throw new RuntimeException("iterator() cannot be called on an associative array");
+			return associativeArray.values().iterator();
 		} else {
 			return array.iterator();
 		}

--- a/src/main/java/com/laytonsmith/core/constructs/CByteArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CByteArray.java
@@ -583,7 +583,20 @@ public class CByteArray extends CArray implements Sizeable, ArrayAccess {
 
 	@Override
 	public Iterator<Mixed> iterator() {
-		throw new CREUnsupportedOperationException("Iterating a byte array is not supported.", getTarget());
+		return new Iterator<Mixed>() {
+
+			private int index = 0;
+
+			@Override
+			public boolean hasNext() {
+				return this.index <= maxValue;
+			}
+
+			@Override
+			public Mixed next() {
+				return new CInt(data.get(this.index++), Target.UNKNOWN);
+			}
+		};
 	}
 
 	@Override
@@ -694,6 +707,24 @@ public class CByteArray extends CArray implements Sizeable, ArrayAccess {
 		protected SortedMap<String, Mixed> getAssociativeArray() {
 			//This is even more serious, because it shouldn't ever happen.
 			throw new Error("This error should not happen. Please report this bug to the developers");
+		}
+
+		@Override
+		public Iterator<Mixed> iterator() {
+			return new Iterator<Mixed>() {
+
+				private int index = 0;
+
+				@Override
+				public boolean hasNext() {
+					return this.index <= backing.length;
+				}
+
+				@Override
+				public Mixed next() {
+					return new CInt(backing[this.index++], Target.UNKNOWN);
+				}
+			};
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/constructs/CSlice.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CSlice.java
@@ -166,6 +166,43 @@ public class CSlice extends CArray {
 	}
 
 	@Override
+	public Iterator<Mixed> iterator() {
+		if(start <= finish) {
+			return new Iterator<Mixed>() {
+
+				private long current = start;
+				private long last = finish;
+
+				@Override
+				public boolean hasNext() {
+					return this.current <= this.last;
+				}
+
+				@Override
+				public Mixed next() {
+					return new CInt(this.current++, Target.UNKNOWN);
+				}
+			};
+		} else {
+			return new Iterator<Mixed>() {
+
+				private long current = start;
+				private long last = finish;
+
+				@Override
+				public boolean hasNext() {
+					return this.current >= this.last;
+				}
+
+				@Override
+				public Mixed next() {
+					return new CInt(this.current--, Target.UNKNOWN);
+				}
+			};
+		}
+	}
+
+	@Override
 	public long size() {
 		return size;
 	}

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -712,9 +712,17 @@ public class ArrayHandling {
 				CArray ca = ArgumentValidation.getArray(args[0], t);
 				aa = ca;
 			}
-			for(Mixed key : aa.keySet()) {
-				if(new equals().exec(t, env, aa.get(key, t), args[1]).getBoolean()) {
-					return CBoolean.TRUE;
+			if(aa instanceof CArray ca) {
+				for(Mixed val : ca) {
+					if(new equals().exec(t, env, val, args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
+				}
+			} else {
+				for(Mixed key : aa.keySet()) {
+					if(new equals().exec(t, env, aa.get(key, t), args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
 				}
 			}
 			return CBoolean.FALSE;
@@ -822,9 +830,17 @@ public class ArrayHandling {
 			} else {
 				aa = ArgumentValidation.getArray(args[0], t);
 			}
-			for(Mixed key : aa.keySet()) {
-				if(new equals_ic().exec(t, environment, aa.get(key, t), args[1]).getBoolean()) {
-					return CBoolean.TRUE;
+			if(aa instanceof CArray ca) {
+				for(Mixed val : ca) {
+					if(new equals_ic().exec(t, environment, val, args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
+				}
+			} else {
+				for(Mixed key : aa.keySet()) {
+					if(new equals_ic().exec(t, environment, aa.get(key, t), args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
 				}
 			}
 			return CBoolean.FALSE;
@@ -876,9 +892,17 @@ public class ArrayHandling {
 			} else {
 				aa = ArgumentValidation.getArray(args[0], t);
 			}
-			for(Mixed key : aa.keySet()) {
-				if(new sequals().exec(t, env, aa.get(key, t), args[1]).getBoolean()) {
-					return CBoolean.TRUE;
+			if(aa instanceof CArray ca) {
+				for(Mixed val : ca) {
+					if(new sequals().exec(t, env, val, args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
+				}
+			} else {
+				for(Mixed key : aa.keySet()) {
+					if(new sequals().exec(t, env, aa.get(key, t), args[1]).getBoolean()) {
+						return CBoolean.TRUE;
+					}
 				}
 			}
 			return CBoolean.FALSE;


### PR DESCRIPTION
Improve runtime performance on `array_contains()`, `array_scontains()` and `array_contains_ic()` by iterating over the array values whenever possible, rather than creating a keyset to iterate over and calling the getter to get all values.

Running the same code, profiler results (where the profiler started at different points in time) do show a large difference in `array_contains()`.

Before:
![afbeelding](https://github.com/user-attachments/assets/253e127c-7100-4d1f-878b-9b25889e1635)

After:
![afbeelding](https://github.com/user-attachments/assets/dc1cd75c-618e-4466-bd49-de048284436b)
