### PR TITLE
Move impl init/deinit to implementation test base class

### DIFF
--- a/src/test/java/com/laytonsmith/PureUtilities/ReflectionUtilsTest.java
+++ b/src/test/java/com/laytonsmith/PureUtilities/ReflectionUtilsTest.java
@@ -2,23 +2,17 @@ package com.laytonsmith.PureUtilities;
 
 import com.laytonsmith.PureUtilities.ClassLoading.ClassDiscovery;
 import com.laytonsmith.PureUtilities.Common.ReflectionUtils;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import static org.junit.Assert.assertEquals;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  *
  *
  */
-public class ReflectionUtilsTest {
+public class ReflectionUtilsTest extends AbstractIntegrationTest {
 
 	public ReflectionUtilsTest() {
-	}
-
-	@Before
-	public void setUp() {
-		StaticTest.InstallFakeServerFrontend();
 	}
 
 	class A {

--- a/src/test/java/com/laytonsmith/core/CodeTargetTest.java
+++ b/src/test/java/com/laytonsmith/core/CodeTargetTest.java
@@ -5,7 +5,7 @@ import com.laytonsmith.core.constructs.CFunction;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.functions.StringHandling;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import java.io.File;
 import java.util.List;
 import static org.junit.Assert.fail;
@@ -14,12 +14,11 @@ import org.junit.Test;
 /**
  * This class tests various scripts that have historically been shown to have incorrect code targets.
  */
-public class CodeTargetTest {
+public class CodeTargetTest extends AbstractIntegrationTest {
 
 	private static final File TEST_FILE = new File("test.ms");
 
 	private List<ParseTree> compile(String script) throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		Environment env = Static.GenerateStandaloneEnvironment();
 		File file = TEST_FILE;
 		TokenStream stream = MethodScriptCompiler.lex(script, env, file, true);

--- a/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
+++ b/src/test/java/com/laytonsmith/core/MethodScriptCompilerTest.java
@@ -23,11 +23,11 @@ import com.laytonsmith.core.exceptions.AbstractCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.verify;
 //@RunWith(PowerMockRunner.class)
 //@PrepareForTest(CommandHelperPlugin.class)
 //@PowerMockIgnore({"javax.xml.parsers.*", "com.sun.org.apache.xerces.internal.jaxp.*"})
-public class MethodScriptCompilerTest {
+public class MethodScriptCompilerTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;
@@ -70,11 +70,6 @@ public class MethodScriptCompilerTest {
 
 	public MethodScriptCompilerTest() {
 		//StaticTest.InstallFakeServerFrontend();
-	}
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 	}
 
 	@AfterClass

--- a/src/test/java/com/laytonsmith/core/NewExceptionHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/NewExceptionHandlingTest.java
@@ -7,9 +7,9 @@ import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.AbstractCompileException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.functions.Exceptions;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -28,14 +28,9 @@ import static org.mockito.Mockito.verify;
 /**
  *
  */
-public class NewExceptionHandlingTest {
+public class NewExceptionHandlingTest extends AbstractIntegrationTest {
 
 	static Set<Class<? extends Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
-
-	@BeforeClass
-	public static void setUpClass() {
-		StaticTest.InstallFakeServerFrontend();
-	}
 
 	public String optimize(String script) throws Exception {
 		return OptimizationUtilities.optimize(script, null, envs, null, true, true);

--- a/src/test/java/com/laytonsmith/core/OptimizationTest.java
+++ b/src/test/java/com/laytonsmith/core/OptimizationTest.java
@@ -8,7 +8,7 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,7 +17,6 @@ import java.util.Set;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -25,15 +24,10 @@ import org.junit.Test;
  *
  * This is also used to test the lexer/compiler at a low level
  */
-public class OptimizationTest {
+public class OptimizationTest extends AbstractIntegrationTest {
 
 	static Set<Class<? extends Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
 	static Environment env;
-
-	@BeforeClass
-	public static void setUpClass() {
-		StaticTest.InstallFakeServerFrontend();
-	}
 
 	public static String optimize(String script, boolean pureMethodScript, Environment env) throws Exception {
 		try {

--- a/src/test/java/com/laytonsmith/core/StaticAnalysisTest.java
+++ b/src/test/java/com/laytonsmith/core/StaticAnalysisTest.java
@@ -9,24 +9,20 @@ import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.environments.RuntimeMode;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import static org.junit.Assert.*;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  *
  */
-public class StaticAnalysisTest {
-	@BeforeClass
-	public static void beforeClass() {
-		StaticTest.InstallFakeServerFrontend();
-	}
+public class StaticAnalysisTest extends AbstractIntegrationTest {
 
 	public void runScript(String script) throws Exception {
 		runScript(script, null);

--- a/src/test/java/com/laytonsmith/core/TestStatic.java
+++ b/src/test/java/com/laytonsmith/core/TestStatic.java
@@ -8,6 +8,7 @@ import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
@@ -23,7 +24,7 @@ import org.junit.Test;
  *
  *
  */
-public class TestStatic {
+public class TestStatic extends AbstractIntegrationTest {
 
 	Target t = Target.UNKNOWN;
 

--- a/src/test/java/com/laytonsmith/core/VarargTest.java
+++ b/src/test/java/com/laytonsmith/core/VarargTest.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import static com.laytonsmith.testing.StaticTest.*;
 import org.junit.Before;
@@ -12,14 +13,13 @@ import static org.mockito.Mockito.*;
 /**
  *
  */
-public class VarargTest {
+public class VarargTest extends AbstractIntegrationTest {
 
 	Environment env;
 	MCPlayer fakePlayer;
 
 	@Before
 	public void setup() throws Exception {
-		InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		fakePlayer = GetOnlinePlayer();
 	}

--- a/src/test/java/com/laytonsmith/core/asm/IRMetadataTest.java
+++ b/src/test/java/com/laytonsmith/core/asm/IRMetadataTest.java
@@ -4,7 +4,7 @@ import com.laytonsmith.core.asm.metadata.IRMetadata;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.asm.metadata.IRMetadata.PrototypeBuilder;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -14,12 +14,11 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Cailin
  */
-public class IRMetadataTest {
+public class IRMetadataTest extends AbstractIntegrationTest {
 
 	com.laytonsmith.core.environments.Environment env;
 
 	public IRMetadataTest() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment(), new LLVMEnvironment());
 	}

--- a/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
+++ b/src/test/java/com/laytonsmith/core/compiler/signatures/FunctionSignaturesTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.laytonsmith.core.Static;
@@ -27,16 +26,11 @@ import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.CRE.CREIndexOverflowException;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 
-public class FunctionSignaturesTest {
+public class FunctionSignaturesTest extends AbstractIntegrationTest {
 
 	private Environment env;
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
-	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/java/com/laytonsmith/core/constructs/ClassInfoTest.java
+++ b/src/test/java/com/laytonsmith/core/constructs/ClassInfoTest.java
@@ -5,27 +5,20 @@ import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.objects.ObjectModifier;
 import com.laytonsmith.core.objects.ObjectType;
-import com.laytonsmith.testing.StaticTest;
-
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  *
  * @author cailin
  */
-public class ClassInfoTest {
-
-	@Before
-	public void before() {
-		StaticTest.InstallFakeServerFrontend();
-	}
+public class ClassInfoTest extends AbstractIntegrationTest {
 
 	@Test
 	public void testAllInterfacesReturnNothingForGetInterfaces() throws Exception {

--- a/src/test/java/com/laytonsmith/core/constructs/EnumTest.java
+++ b/src/test/java/com/laytonsmith/core/constructs/EnumTest.java
@@ -8,39 +8,19 @@ package com.laytonsmith.core.constructs;
 import com.laytonsmith.core.FullyQualifiedClassName;
 import com.laytonsmith.core.natives.interfaces.MEnumType;
 import com.laytonsmith.core.natives.interfaces.MEnumTypeValue;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import com.laytonsmith.testing.AbstractIntegrationTest;
+
 import org.junit.Test;
 
-import static com.laytonsmith.testing.StaticTest.InstallFakeServerFrontend;
 import static org.junit.Assert.*;
 
 /**
  *
  * @author Cailin
  */
-public class EnumTest {
+public class EnumTest extends AbstractIntegrationTest {
 
 	public EnumTest() {
-	}
-
-	@BeforeClass
-	public static void setUpClass() {
-		InstallFakeServerFrontend();
-	}
-
-	@AfterClass
-	public static void tearDownClass() {
-	}
-
-	@Before
-	public void setUp() {
-	}
-
-	@After
-	public void tearDown() {
 	}
 
 	@Test(expected = ClassNotFoundException.class)

--- a/src/test/java/com/laytonsmith/core/constructs/InstanceofUtilTest.java
+++ b/src/test/java/com/laytonsmith/core/constructs/InstanceofUtilTest.java
@@ -4,23 +4,17 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.natives.interfaces.Booleanish;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 
-import static com.laytonsmith.testing.StaticTest.InstallFakeServerFrontend;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  *
  */
-public class InstanceofUtilTest {
-
-	@BeforeClass
-	public static void setUpClass() {
-		InstallFakeServerFrontend();
-	}
+public class InstanceofUtilTest extends AbstractIntegrationTest {
 
 	@Test
 	public void testInstanceofUtil() throws Exception {

--- a/src/test/java/com/laytonsmith/core/constructs/TestCClassType.java
+++ b/src/test/java/com/laytonsmith/core/constructs/TestCClassType.java
@@ -6,6 +6,7 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,13 +26,12 @@ import org.junit.Ignore;
  *
  * @author cailin
  */
-public class TestCClassType {
+public class TestCClassType extends AbstractIntegrationTest {
 
 	static Environment env;
 
 	@Before
 	public void load() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment(false);
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
 	}

--- a/src/test/java/com/laytonsmith/core/events/GeneralTest.java
+++ b/src/test/java/com/laytonsmith/core/events/GeneralTest.java
@@ -2,10 +2,10 @@ package com.laytonsmith.core.events;
 
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.core.Static;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 //import static org.powermock.api.mockito.PowerMockito.when;
 //import org.powermock.core.classloader.annotations.PrepareForTest;
 //import org.powermock.modules.junit4.PowerMockRunner;
@@ -16,16 +16,11 @@ import org.junit.BeforeClass;
  */
 //@RunWith(PowerMockRunner.class)
 //@PrepareForTest(Static.class)
-public class GeneralTest {
+public class GeneralTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 
 	public GeneralTest() {
-	}
-
-	@BeforeClass
-	public static void setUpClass() {
-
 	}
 
 	@Before

--- a/src/test/java/com/laytonsmith/core/events/PrefiltersTest.java
+++ b/src/test/java/com/laytonsmith/core/events/PrefiltersTest.java
@@ -4,6 +4,7 @@ import com.laytonsmith.core.events.Prefilters.PrefilterType;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.PrefilterNonMatchException;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -20,7 +21,7 @@ import static org.junit.Assert.fail;
  *
  *
  */
-public class PrefiltersTest {
+public class PrefiltersTest extends AbstractIntegrationTest {
 
 	public PrefiltersTest() {
 	}

--- a/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
@@ -12,6 +12,7 @@ import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.natives.interfaces.Mixed;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.Run;
@@ -33,14 +34,13 @@ import static org.hamcrest.core.Is.*;
  *
  *
  */
-public class ArrayHandlingTest {
+public class ArrayHandlingTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 	CArray commonArray;
 	com.laytonsmith.core.environments.Environment env;
 
 	public ArrayHandlingTest() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
 	}

--- a/src/test/java/com/laytonsmith/core/functions/BasicLogicTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/BasicLogicTest.java
@@ -10,8 +10,8 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
-import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.GetFakeServer;
 import static com.laytonsmith.testing.StaticTest.GetOnlinePlayer;
 import static com.laytonsmith.testing.StaticTest.SRun;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
  *
  *
  */
-public class BasicLogicTest {
+public class BasicLogicTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 	MCServer fakeServer;
@@ -53,7 +53,6 @@ public class BasicLogicTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 	}
 
 	@AfterClass

--- a/src/test/java/com/laytonsmith/core/functions/ControlFlowTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ControlFlowTest.java
@@ -9,9 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.laytonsmith.abstraction.MCPlayer;
@@ -19,9 +17,9 @@ import com.laytonsmith.abstraction.MCServer;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 
-public class ControlFlowTest {
+public class ControlFlowTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 	MCServer fakeServer;
@@ -30,15 +28,6 @@ public class ControlFlowTest {
 	public ControlFlowTest() throws Exception {
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
-	}
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
 	}
 
 	@Before

--- a/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/DataHandlingTest.java
@@ -8,6 +8,7 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.RunCommand;
 import static com.laytonsmith.testing.StaticTest.SRun;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.when;
  *
  *
  */
-public class DataHandlingTest {
+public class DataHandlingTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;
@@ -37,7 +38,6 @@ public class DataHandlingTest {
 	static Set<Class<? extends com.laytonsmith.core.environments.Environment.EnvironmentImpl>> envs = com.laytonsmith.core.environments.Environment.getDefaultEnvClasses();
 
 	public DataHandlingTest() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
 	}

--- a/src/test/java/com/laytonsmith/core/functions/DataTransformationsTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/DataTransformationsTest.java
@@ -7,6 +7,8 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import static com.laytonsmith.testing.CustomMatchers.regexMatch;
+
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.SRun;
 import static org.hamcrest.CoreMatchers.is;
@@ -20,14 +22,13 @@ import org.junit.Test;
 /**
  *
  */
-public class DataTransformationsTest {
+public class DataTransformationsTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;
 	com.laytonsmith.core.environments.Environment env;
 
 	public DataTransformationsTest() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
 	}

--- a/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/EchoesTest.java
@@ -10,6 +10,7 @@ import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.CancelCommandException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.functions.Echoes.color;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import static com.laytonsmith.testing.StaticTest.GetFakeServer;
 import static com.laytonsmith.testing.StaticTest.GetOnlinePlayer;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.when;
  *
  *
  */
-public class EchoesTest {
+public class EchoesTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;

--- a/src/test/java/com/laytonsmith/core/functions/MathTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/MathTest.java
@@ -13,6 +13,7 @@ import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.After;
@@ -33,7 +34,7 @@ import static org.mockito.Mockito.verify;
  *
  *
  */
-public class MathTest {
+public class MathTest extends AbstractIntegrationTest {
 
 	Target t = Target.UNKNOWN;
 	MCServer fakeServer;
@@ -54,7 +55,6 @@ public class MathTest {
 
 	@Before
 	public void setUp() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		fakePlayer = GetOnlinePlayer();
 		fakeServer = GetFakeServer();
 

--- a/src/test/java/com/laytonsmith/core/functions/MetaTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/MetaTest.java
@@ -6,6 +6,8 @@ import com.laytonsmith.commandhelper.CommandHelperPlugin;
 import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
+import com.laytonsmith.testing.AbstractIntegrationTest;
+
 import static com.laytonsmith.testing.StaticTest.GetFakeServer;
 import static com.laytonsmith.testing.StaticTest.GetOnlinePlayer;
 import static com.laytonsmith.testing.StaticTest.SRun;
@@ -23,7 +25,7 @@ import static org.mockito.Mockito.when;
  *
  *
  */
-public class MetaTest {
+public class MetaTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;

--- a/src/test/java/com/laytonsmith/core/functions/MinecraftTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/MinecraftTest.java
@@ -8,6 +8,7 @@ import com.laytonsmith.abstraction.enums.MCVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -19,7 +20,7 @@ import org.junit.Test;
  *
  *
  */
-public class MinecraftTest {
+public class MinecraftTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;

--- a/src/test/java/com/laytonsmith/core/functions/ObjectManagementTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ObjectManagementTest.java
@@ -14,7 +14,7 @@ import com.laytonsmith.core.environments.GlobalEnv;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.objects.ObjectDefinition;
 import com.laytonsmith.core.objects.ObjectType;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Set;
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 /**
  *
  */
-public class ObjectManagementTest {
+public class ObjectManagementTest extends AbstractIntegrationTest {
 
 	static Set<Class<? extends Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
 
@@ -40,7 +40,6 @@ public class ObjectManagementTest {
 	}
 
 	public ObjectManagementTest() {
-		StaticTest.InstallFakeServerFrontend();
 	}
 
 	@Test

--- a/src/test/java/com/laytonsmith/core/functions/PlayerManangementTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/PlayerManangementTest.java
@@ -10,6 +10,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.abstraction.blocks.MCBlock;
 import com.laytonsmith.abstraction.bukkit.BukkitMCWorld;
 import com.laytonsmith.commandhelper.CommandHelperPlugin;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.GetFakeConsoleCommandSender;
 import static com.laytonsmith.testing.StaticTest.GetFakeServer;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.when;
  *
  *
  */
-public class PlayerManangementTest {
+public class PlayerManangementTest extends AbstractIntegrationTest {
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;

--- a/src/test/java/com/laytonsmith/core/functions/RegexTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/RegexTest.java
@@ -4,6 +4,7 @@ import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 
 import static com.laytonsmith.testing.StaticTest.SRun;
 import java.util.Set;
@@ -21,7 +22,7 @@ import org.junit.Test;
  *
  *
  */
-public class RegexTest {
+public class RegexTest extends AbstractIntegrationTest {
 
 	static Set<Class<? extends com.laytonsmith.core.environments.Environment.EnvironmentImpl>> envs = com.laytonsmith.core.environments.Environment.getDefaultEnvClasses();
 

--- a/src/test/java/com/laytonsmith/core/functions/SchedulingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/SchedulingTest.java
@@ -3,6 +3,7 @@ package com.laytonsmith.core.functions;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.SRun;
 import org.junit.After;
@@ -16,7 +17,7 @@ import static org.mockito.Mockito.verify;
 /**
  *
  */
-public class SchedulingTest {
+public class SchedulingTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 	com.laytonsmith.core.environments.Environment env;
@@ -31,7 +32,6 @@ public class SchedulingTest {
 
 	@Before
 	public void setUp() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
 		env = Static.GenerateStandaloneEnvironment();
 		env = env.cloneAndAdd(new CommandHelperEnvironment());
 		fakePlayer = StaticTest.GetOnlinePlayer();

--- a/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
@@ -5,17 +5,16 @@ import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigCompileGroupException;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.C;
 import com.laytonsmith.testing.StaticTest;
 import static com.laytonsmith.testing.StaticTest.SRun;
 import static com.laytonsmith.testing.StaticTest.assertCEquals;
 import java.util.Locale;
 import org.junit.After;
-import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.mockito.Mockito.verify;
 
@@ -23,20 +22,11 @@ import static org.mockito.Mockito.verify;
  *
  *
  */
-public class StringHandlingTest {
+public class StringHandlingTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 
 	public StringHandlingTest() {
-	}
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
 	}
 
 	@Before

--- a/src/test/java/com/laytonsmith/core/functions/ThreadingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ThreadingTest.java
@@ -6,6 +6,7 @@ import com.laytonsmith.core.MethodScriptCompiler;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import com.laytonsmith.testing.StaticTest;
 import org.junit.*;
 
@@ -14,18 +15,13 @@ import java.util.Set;
 
 import static org.mockito.Mockito.verify;
 
-public class ThreadingTest {
+public class ThreadingTest extends AbstractIntegrationTest {
 
 
 	MCServer fakeServer;
 	MCPlayer fakePlayer;
 	com.laytonsmith.core.environments.Environment env;
 	static Set<Class<? extends com.laytonsmith.core.environments.Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
-	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {

--- a/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
+++ b/src/test/java/com/laytonsmith/core/objects/ObjectDefinitionTableTest.java
@@ -19,7 +19,7 @@ import com.laytonsmith.core.natives.interfaces.Mixed;
 import com.laytonsmith.core.profiler.Profiler;
 import com.laytonsmith.core.taskmanager.TaskManager;
 import com.laytonsmith.persistence.PersistenceNetwork;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +36,7 @@ import org.junit.Ignore;
 /**
  *
  */
-public class ObjectDefinitionTableTest {
+public class ObjectDefinitionTableTest extends AbstractIntegrationTest {
 
 	Environment env;
 	static Set<Class<? extends Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
@@ -57,8 +57,6 @@ public class ObjectDefinitionTableTest {
 
 	@Before
 	public void Before() {
-		StaticTest.InstallFakeServerFrontend();
-
 		ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class, (invocation) -> {
 			throw new AssertionError("Interaction with the execution queue is not supported in this test.");
 		});

--- a/src/test/java/com/laytonsmith/persistence/TestPersistence.java
+++ b/src/test/java/com/laytonsmith/persistence/TestPersistence.java
@@ -7,7 +7,7 @@ import com.laytonsmith.PureUtilities.DaemonManager;
 import com.laytonsmith.PureUtilities.ZipReader;
 import com.laytonsmith.persistence.io.ConnectionMixinFactory;
 import com.laytonsmith.persistence.io.ReadWriteFileConnection;
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import static com.laytonsmith.testing.StaticTest.GetPrivate;
 import java.io.File;
 import java.net.URI;
@@ -27,13 +27,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  *
  */
-public class TestPersistence {
+public class TestPersistence extends AbstractIntegrationTest {
 
 	/**
 	 * TODO: Need to test the following: Ensuring correct behavior with hidden keys that conflict
@@ -44,11 +43,6 @@ public class TestPersistence {
 	List<File> toDelete = new ArrayList<File>();
 	ConnectionMixinFactory.ConnectionMixinOptions options;
 	DaemonManager dm;
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		StaticTest.InstallFakeServerFrontend();
-	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/java/com/laytonsmith/testing/AbstractIntegrationTest.java
+++ b/src/test/java/com/laytonsmith/testing/AbstractIntegrationTest.java
@@ -1,0 +1,40 @@
+package com.laytonsmith.testing;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import com.laytonsmith.abstraction.Implementation;
+
+/**
+ * Integration base test class. Manages static setup and cleanup for child integration test classes.
+ */
+public abstract class AbstractIntegrationTest {
+
+	/**
+	 * Runs before a child test class. Runs before the {@link BeforeClass} annotated method in a child class,
+	 * unless that method shares the same name.
+	 * @throws Exception
+	 */
+	@BeforeClass
+	public static void setUpClassGlobal() throws Exception {
+
+		// Set server type.
+		Implementation.setServerType(Implementation.Type.TEST);
+
+		// Install fake server frontend.
+		// This is initialized only once and kept cross-test-class in StaticTest.
+		StaticTest.InstallFakeServerFrontend();
+	}
+
+	/**
+	 * Runs after a child test class. Runs after the {@link AfterClass} annotated method in a child class,
+	 * unless that method shares the same name.
+	 * @throws Exception
+	 */
+	@AfterClass
+	public static void tearDownClassGlobal() throws Exception {
+
+		// Reset server type.
+		Implementation.forceServerType(null);
+	}
+}

--- a/src/test/java/com/laytonsmith/testing/ProcedureTest.java
+++ b/src/test/java/com/laytonsmith/testing/ProcedureTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
  *
  *
  */
-public class ProcedureTest {
+public class ProcedureTest extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 

--- a/src/test/java/com/laytonsmith/testing/RandomTests.java
+++ b/src/test/java/com/laytonsmith/testing/RandomTests.java
@@ -77,7 +77,7 @@ import java.util.HashSet;
  */
 //@RunWith(PowerMockRunner.class)
 //@PrepareForTest(Static.class)
-public class RandomTests {
+public class RandomTests extends AbstractIntegrationTest {
 
 	MCPlayer fakePlayer;
 
@@ -100,7 +100,6 @@ public class RandomTests {
 		Map<String, Throwable> uhohs = new HashMap<>();
 		String[] requiredMethods = new String[]{"toString", "equals", "hashCode"};
 		//Ensure that all the abstraction objects overloaded
-		StaticTest.InstallFakeServerFrontend();
 		outer:
 		for(Class c : ClassDiscovery.getDefaultInstance().loadClassesThatExtend(AbstractionObject.class)) {
 			inner:

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -112,7 +112,7 @@ import static org.mockito.Mockito.when;
  *
  *
  */
-public class StaticTest {
+public class StaticTest extends AbstractIntegrationTest {
 
 	static com.laytonsmith.core.environments.Environment env;
 	static Set<Class<? extends Environment.EnvironmentImpl>> envs = Environment.getDefaultEnvClasses();
@@ -541,7 +541,6 @@ public class StaticTest {
 	}
 
 	public static void Run(String script, MCCommandSender player, MethodScriptComplete done, Environment env) throws Exception {
-		InstallFakeServerFrontend();
 		if(env == null) {
 			env = StaticTest.env;
 		}
@@ -558,7 +557,6 @@ public class StaticTest {
 	}
 
 	public static void RunCommand(String combinedScript, MCCommandSender player, String command, Environment env) throws Exception {
-		InstallFakeServerFrontend();
 		if(env == null) {
 			env = StaticTest.env;
 		}
@@ -573,7 +571,6 @@ public class StaticTest {
 	}
 
 	public static String SRun(String script, MCCommandSender player, Environment env) throws Exception {
-		InstallFakeServerFrontend();
 		final StringBuffer b = new StringBuffer();
 		Run(script, player, new MethodScriptComplete() {
 
@@ -667,7 +664,6 @@ public class StaticTest {
 	 * @throws java.lang.Exception
 	 */
 	public static void InstallFakeConvertor(MCPlayer fakePlayer) throws Exception {
-		InstallFakeServerFrontend();
 		try {
 			//We need to add the test directory to the ClassDiscovery path
 			//This should probably not be hard coded at some point.

--- a/src/test/java/com/laytonsmith/tools/SyntaxHighlightersTest.java
+++ b/src/test/java/com/laytonsmith/tools/SyntaxHighlightersTest.java
@@ -5,7 +5,7 @@
  */
 package com.laytonsmith.tools;
 
-import com.laytonsmith.testing.StaticTest;
+import com.laytonsmith.testing.AbstractIntegrationTest;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Ignore;
@@ -14,10 +14,9 @@ import org.junit.Ignore;
  *
  * @author Cailin
  */
-public class SyntaxHighlightersTest {
+public class SyntaxHighlightersTest extends AbstractIntegrationTest {
 
 	public SyntaxHighlightersTest() {
-		StaticTest.InstallFakeServerFrontend();
 	}
 
 	@Test


### PR DESCRIPTION
Move `Implementation.setServerType(Implementation.Type.TEST);` and `StaticTest.InstallFakeServerFrontend();` from many test classes to `AbstractImplementationTest` and use that as parent class of those classes.

Fixes individual tests failing in the IDE and occasional test failures in the automated Linux build.